### PR TITLE
feat(agents): per-agent tool visibility with scope filtering (#41)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "24"
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,7 +24,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "24"
 
@@ -66,7 +66,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "24"
 
@@ -100,7 +100,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "24"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,3 +142,54 @@ The lead (you) orchestrates all work by spawning specialized subagents via the A
 - Fix issues found by reviews (spawn the relevant implementing subagent to fix)
 - Re-run failed reviews after fixes
 - Only create PR when all reviews pass
+
+## Build & E2E Testing
+
+### SPA Embed Pipeline
+
+The Go binary embeds the frontend SPA from `pkg/gateway/spa/` via `go:embed`. This directory is **not** the Vite build output — `npm run build` outputs to `dist/spa/`. You must sync them before building the binary:
+
+```bash
+npm run build                    # builds to dist/spa/
+rm -rf pkg/gateway/spa/assets    # remove stale assets
+cp -r dist/spa/* pkg/gateway/spa/  # sync to embed dir
+CGO_ENABLED=0 go build -o /tmp/omnipus ./cmd/omnipus/  # rebuild binary
+```
+
+**If you skip the sync, the binary will serve a stale SPA that does not include your frontend changes.** Verify with: `grep -c "YOUR_NEW_STRING" pkg/gateway/spa/assets/index-*.js` — must be >0.
+
+### E2E Testing with the Embedded SPA
+
+Always test against the embedded SPA (the Go binary), not the Vite dev server. The Vite dev server proxies `/api` to `localhost:18790` which may not match the gateway port.
+
+**Start the gateway:**
+
+```bash
+export OMNIPUS_HOME=/tmp/omnipus-e2e-test
+rm -rf "$OMNIPUS_HOME" && mkdir -p "$OMNIPUS_HOME"
+OMNIPUS_BEARER_TOKEN="" ./omnipus gateway --allow-empty &
+```
+
+**Known blockers and workarounds:**
+
+1. **Port conflict with other apps** — Port 3000 is the default. If another app (e.g., Next.js) is running on 3000, the gateway silently fails to bind. Check with `lsof -i :3000 | grep LISTEN`. Fix: set a different port in `$OMNIPUS_HOME/config.json` under `gateway.port` (e.g., 5000) before starting.
+
+2. **Onboarding requires auth bypass** — The onboarding flow calls API endpoints that require bearer auth before an admin account exists. Set `"dev_mode_bypass": true` in `config.json` under `gateway` after the first run creates the config, then restart the gateway. This is a pre-existing bug (the onboarding endpoints should use `withOptionalAuth`).
+
+3. **Model must support tool use** — Omnipus sends tools with every LLM request. If the selected model doesn't support tool use (e.g., `google/gemma-2-9b-it` on OpenRouter), the LLM call returns a 404 with "No endpoints found that support tool use." Use a tool-capable model like `z-ai/glm-5-turbo`, `google/gemini-2.5-flash`, or `anthropic/claude-3.5-haiku`.
+
+4. **Gateway logs are in `$OMNIPUS_HOME/logs/`** — `gateway.log` for runtime logs, `gateway_panic.log` for startup errors. Always check `gateway_panic.log` if the gateway exits silently.
+
+### E2E Test Checklist
+
+After frontend+backend changes, verify these flows on the embedded SPA:
+
+1. **Onboarding** — Welcome → Provider → API Key → Model Select → Admin Account → Complete
+2. **Chat** — Send message → receive LLM response → multi-turn context retained → token/cost updates
+3. **Agents** — List (system + custom) → Create Agent (with Tools & Permissions) → Agent Profile (accordion, tools panel)
+4. **System Agent** — Profile shows read-only sections only (no Identity, no Tools & Permissions)
+5. **Settings** — Provider shows Connected, all tabs load
+6. **Command Center** — Gateway status, task board
+7. **Skills & Tools** — 4 tabs, empty states
+8. **Sidebar** — All nav items, active highlighting
+9. **Console errors** — Zero JS errors (WebSocket reconnect warnings are acceptable)

--- a/docs/regression/2026-04-12-per-agent-tool-visibility.md
+++ b/docs/regression/2026-04-12-per-agent-tool-visibility.md
@@ -1,0 +1,110 @@
+# End-to-End Regression Report: Per-Agent Tool Visibility
+
+**Date:** 2026-04-12
+**Branch:** `feature/next-wave`
+**Issues:** #15 (Agent CRUD), #41 (Per-Agent Tool Visibility)
+**Scope:** Validate that PR 2 (#41) — per-agent tool visibility with 3-layer scope filtering, Tools & Permissions UI, and accordion agent profile — works end-to-end on the correct embedded SPA with a real LLM provider.
+
+## Test environment
+
+- Host: Linux 6.8.0-107-generic, Go 1.26, Node 24
+- Clean home dir: `/tmp/omnipus-vqa-home`
+- Master key: auto-generated on first boot
+- Binary: `CGO_ENABLED=0 go build -o /tmp/omnipus-test/omnipus ./cmd/omnipus`
+- SPA: rebuilt via `npm run build`, synced to `pkg/gateway/spa/`, re-embedded in binary
+- Provider: OpenRouter (real API key)
+- Model: z-ai/glm-5-turbo (tool-use capable)
+- Gateway port: 5000 (default 3000 was occupied by another app)
+
+## Test gates
+
+- `CGO_ENABLED=0 go build ./...` — clean
+- `CGO_ENABLED=0 go vet ./...` — clean
+- `go test ./pkg/tools/ ./pkg/config/ ./pkg/gateway/ ./pkg/agent/ ./pkg/sysagent/...` — all 6 suites pass
+- `tsc --noEmit` — clean
+- `npm run build` — clean (only pre-existing chunk size warnings)
+- 7 review agents (code-reviewer, code-simplifier, comment-analyzer, pr-test-analyzer, silent-failure-hunter, type-design-analyzer, architect) — all findings resolved
+
+## New tests added (26 total)
+
+- `pkg/tools/compositor_test.go` — 8 tests: FilterToolsByVisibility (inherit/explicit modes, scope gates, empty visible, core agent, nil config)
+- `pkg/config/config_test.go` — 6 tests: ResolveType (explicit, system, core, custom, nil callback), AgentToolsCfg JSON round-trip
+- `pkg/gateway/rest_test.go` — 12 tests: HandleBuiltinTools (GET, POST rejection), HandleMCPTools (GET, POST rejection), getAgentTools (system, custom), updateAgentTools (system forbidden, not found, invalid mode, success), createAgent with tools_cfg, GuardedTool.Scope delegation
+
+## Scenarios
+
+### 1. Cold boot + onboarding — PASS
+
+- Fresh home dir, no config
+- Gateway starts with `--allow-empty`, auto-generates master key
+- Onboarding wizard: Welcome → Provider (OpenRouter) → API Key → Model (z-ai/glm-5-turbo) → Admin Account → Complete
+- All 4 steps render correctly, progress bar updates
+- "Connected successfully" after API key entry
+- Model search/filter works (350+ models, search "glm-5-turbo" finds it)
+
+### 2. Real LLM chat — PASS
+
+- Sent: "What is the square root of 144?"
+- Response: "The square root of 144 is **12**." (correct)
+- Token count: 3.8k, cost: $0.0125
+- Session bar shows model name, live token/cost updates
+- Message bubbles render with correct alignment (user right, agent left)
+- Markdown formatting (bold, numbered lists) renders correctly
+
+### 3. Create Agent with Tools & Permissions — PASS
+
+- Create Agent modal shows **two tabs**: "General" and "Tools & Permissions"
+- General tab: name, description, model selector, icon picker, color picker, Advanced toggle
+- Tools & Permissions tab:
+  - 5 preset buttons: Read-only Researcher, Developer, Task Manager, Unrestricted, Custom
+  - "Custom" selected by default with gold border
+  - Tool list grouped by category ("general 0/20")
+  - Clicking "Read-only Researcher" → count updates to 5/20, preset highlights
+  - MCP Servers section: "No MCP servers configured. Add servers in Settings."
+- Created "Research Bot" with Researcher preset → appears in agents list with "draft" badge
+
+### 4. Agent Profile — Accordion layout — PASS
+
+- 7 collapsible sections: Identity (default open), Model Configuration, Rate Limits, Behavior, Tools & Permissions, Sessions, Activity
+- All sections collapse/expand independently
+- Identity section: name, description, avatar color picker, icon selector
+
+### 5. Agent Profile — Tools & Permissions panel — PASS
+
+- Header shows "5 selected" count (from Researcher preset)
+- "Read-only Researcher" preset auto-detected with gold border (from saved config)
+- Tool checkboxes: `web_fetch` and `web_search` checked, others unchecked
+- Core-scope tools (`append_file`, `edit_file`, `exec`) show amber warning icon
+- "Save Tool Permissions" button with "Selected: 5 tools" label
+- MCP Servers empty state
+
+### 6. System Agent Profile — No Tools section — PASS
+
+- "Omnipus" with "system" type badge
+- Only 3 read-only sections: Model Configuration, Sessions, Activity
+- No Identity, Rate Limits, Behavior, or Tools & Permissions sections
+- No Save button
+
+### 7. All other screens — PASS
+
+- **Agents list**: System agent (active, green dot) + custom agent (draft badge, description)
+- **Command Center**: Gateway online, 2 agents, 1 channel, rate limits disabled, task board with tabs
+- **Skills & Tools**: 4 tabs (Installed Skills, MCP Servers, Channels, Built-in Tools), empty states
+- **Settings**: 8 tabs, OpenRouter "Connected" with Test/Edit
+- **Sidebar**: 5 nav items with icons, active route highlighted, Settings + Sign out at bottom
+- **Login**: Branded, mascot, username/password fields, "Login failed" on wrong credentials
+
+### 8. Console errors — PASS
+
+- Zero JS errors on port 5000 session
+- No uncaught exceptions, no missing modules, no 404s on assets
+
+## Known issues (pre-existing, not PR #41)
+
+1. **Onboarding 401**: Provider connection endpoint requires auth before admin account exists. Workaround: `dev_mode_bypass: true` in config. Should be fixed by using `withOptionalAuth` on onboarding endpoints.
+2. **SPA embed pipeline**: `npm run build` outputs to `dist/spa/` but `go:embed` reads from `pkg/gateway/spa/`. Must manually sync. Documented in CLAUDE.md.
+3. **Port 3000 conflict**: Default port may conflict with other local apps. Check `lsof -i :3000 | grep LISTEN` before starting.
+
+## Verdict
+
+**PASS** — All PR #41 features verified end-to-end on the correct embedded SPA with real OpenRouter LLM chat. No regressions detected.

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@fontsource/outfit": "^5.1.1",
         "@phosphor-icons/react": "^2.1.7",
         "@radix-ui/react-accordion": "^1.2.12",
+        "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.4",
         "@radix-ui/react-dropdown-menu": "^2.1.4",
         "@radix-ui/react-label": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@fontsource/outfit": "^5.1.1",
     "@phosphor-icons/react": "^2.1.7",
     "@radix-ui/react-accordion": "^1.2.12",
+    "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.4",
     "@radix-ui/react-dropdown-menu": "^2.1.4",
     "@radix-ui/react-label": "^2.1.1",

--- a/pkg/agent/eventbus_test.go
+++ b/pkg/agent/eventbus_test.go
@@ -660,6 +660,8 @@ func (t *asyncFollowUpTool) Parameters() map[string]any {
 	}
 }
 
+func (t *asyncFollowUpTool) Scope() tools.ToolScope { return tools.ScopeGeneral }
+
 func (t *asyncFollowUpTool) Execute(ctx context.Context, args map[string]any) *tools.ToolResult {
 	return tools.AsyncResult("async follow-up scheduled")
 }

--- a/pkg/agent/hooks_test.go
+++ b/pkg/agent/hooks_test.go
@@ -240,6 +240,8 @@ func (t *echoTextTool) Parameters() map[string]any {
 	}
 }
 
+func (t *echoTextTool) Scope() tools.ToolScope { return tools.ScopeGeneral }
+
 func (t *echoTextTool) Execute(ctx context.Context, args map[string]any) *tools.ToolResult {
 	text, _ := args["text"].(string)
 	return tools.SilentResult(text)

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -1096,6 +1096,8 @@ func (m *mockCustomTool) Parameters() map[string]any {
 	}
 }
 
+func (m *mockCustomTool) Scope() tools.ToolScope { return tools.ScopeGeneral }
+
 func (m *mockCustomTool) Execute(ctx context.Context, args map[string]any) *tools.ToolResult {
 	return tools.SilentResult("Custom tool executed")
 }
@@ -1105,7 +1107,8 @@ type handledMediaTool struct {
 	path  string
 }
 
-func (m *handledMediaTool) Name() string { return "handled_media_tool" }
+func (m *handledMediaTool) Name() string           { return "handled_media_tool" }
+func (m *handledMediaTool) Scope() tools.ToolScope { return tools.ScopeGeneral }
 func (m *handledMediaTool) Description() string {
 	return "Returns a media attachment and fully handles the user response"
 }
@@ -1172,7 +1175,8 @@ type handledMediaWithSteeringTool struct {
 	loop  *AgentLoop
 }
 
-func (m *handledMediaWithSteeringTool) Name() string { return "handled_media_with_steering_tool" }
+func (m *handledMediaWithSteeringTool) Name() string           { return "handled_media_with_steering_tool" }
+func (m *handledMediaWithSteeringTool) Scope() tools.ToolScope { return tools.ScopeGeneral }
 func (m *handledMediaWithSteeringTool) Description() string {
 	return "Returns handled media and enqueues a steering message during execution"
 }
@@ -1205,7 +1209,8 @@ type mediaArtifactTool struct {
 	path  string
 }
 
-func (m *mediaArtifactTool) Name() string { return "media_artifact_tool" }
+func (m *mediaArtifactTool) Name() string           { return "media_artifact_tool" }
+func (m *mediaArtifactTool) Scope() tools.ToolScope { return tools.ScopeGeneral }
 func (m *mediaArtifactTool) Description() string {
 	return "Returns a media artifact that the agent can forward or save later"
 }
@@ -1231,10 +1236,8 @@ func (m *mediaArtifactTool) Execute(ctx context.Context, args map[string]any) *t
 
 type toolLimitTestTool struct{}
 
-func (m *toolLimitTestTool) Name() string {
-	return "tool_limit_test_tool"
-}
-
+func (m *toolLimitTestTool) Name() string        { return "tool_limit_test_tool" }
+func (m *toolLimitTestTool) Scope() tools.ToolScope { return tools.ScopeGeneral }
 func (m *toolLimitTestTool) Description() string {
 	return "Tool used to exhaust the iteration budget in tests"
 }

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -1236,7 +1236,7 @@ func (m *mediaArtifactTool) Execute(ctx context.Context, args map[string]any) *t
 
 type toolLimitTestTool struct{}
 
-func (m *toolLimitTestTool) Name() string        { return "tool_limit_test_tool" }
+func (m *toolLimitTestTool) Name() string           { return "tool_limit_test_tool" }
 func (m *toolLimitTestTool) Scope() tools.ToolScope { return tools.ScopeGeneral }
 func (m *toolLimitTestTool) Description() string {
 	return "Tool used to exhaust the iteration budget in tests"

--- a/pkg/agent/steering_test.go
+++ b/pkg/agent/steering_test.go
@@ -446,8 +446,9 @@ type slowTool struct {
 	execCh   chan struct{} // closed when Execute starts
 }
 
-func (t *slowTool) Name() string        { return t.name }
-func (t *slowTool) Description() string { return "slow tool for testing" }
+func (t *slowTool) Name() string           { return t.name }
+func (t *slowTool) Description() string    { return "slow tool for testing" }
+func (t *slowTool) Scope() tools.ToolScope { return tools.ScopeGeneral }
 func (t *slowTool) Parameters() map[string]any {
 	return map[string]any{
 		"type":       "object",
@@ -626,8 +627,9 @@ type interruptibleTool struct {
 	once    sync.Once
 }
 
-func (t *interruptibleTool) Name() string        { return t.name }
-func (t *interruptibleTool) Description() string { return "interruptible tool for testing" }
+func (t *interruptibleTool) Name() string           { return t.name }
+func (t *interruptibleTool) Description() string    { return "interruptible tool for testing" }
+func (t *interruptibleTool) Scope() tools.ToolScope { return tools.ScopeGeneral }
 func (t *interruptibleTool) Parameters() map[string]any {
 	return map[string]any{
 		"type":       "object",

--- a/pkg/channels/matrix/init.go
+++ b/pkg/channels/matrix/init.go
@@ -12,12 +12,15 @@ import (
 )
 
 func init() {
-	channels.RegisterFactory("matrix", func(cfg *config.Config, secrets credentials.SecretBundle, b *bus.MessageBus) (channels.Channel, error) {
-		matrixCfg := cfg.Channels.Matrix
-		cryptoDatabasePath := matrixCfg.CryptoDatabasePath
-		if cryptoDatabasePath == "" {
-			cryptoDatabasePath = filepath.Join(cfg.WorkspacePath(), "matrix")
-		}
-		return NewMatrixChannel(matrixCfg, secrets, b, cryptoDatabasePath)
-	})
+	channels.RegisterFactory(
+		"matrix",
+		func(cfg *config.Config, secrets credentials.SecretBundle, b *bus.MessageBus) (channels.Channel, error) {
+			matrixCfg := cfg.Channels.Matrix
+			cryptoDatabasePath := matrixCfg.CryptoDatabasePath
+			if cryptoDatabasePath == "" {
+				cryptoDatabasePath = filepath.Join(cfg.WorkspacePath(), "matrix")
+			}
+			return NewMatrixChannel(matrixCfg, secrets, b, cryptoDatabasePath)
+		},
+	)
 }

--- a/pkg/channels/matrix/matrix.go
+++ b/pkg/channels/matrix/matrix.go
@@ -213,7 +213,10 @@ func NewMatrixChannel(
 		return nil, fmt.Errorf("matrix user_id is required")
 	}
 	if accessToken == "" {
-		return nil, fmt.Errorf("matrix: access_token not resolved (access_token_ref=%q): check credential store", cfg.AccessTokenRef)
+		return nil, fmt.Errorf(
+			"matrix: access_token not resolved (access_token_ref=%q): check credential store",
+			cfg.AccessTokenRef,
+		)
 	}
 
 	client, err := mautrix.NewClient(homeserver, id.UserID(userID), accessToken)
@@ -231,7 +234,10 @@ func NewMatrixChannel(
 
 	cryptoPassphrase := secrets.GetString(cfg.CryptoPassphraseRef)
 	if cfg.CryptoPassphraseRef != "" && cryptoPassphrase == "" {
-		return nil, fmt.Errorf("matrix: crypto_passphrase not resolved (crypto_passphrase_ref=%q): check credential store", cfg.CryptoPassphraseRef)
+		return nil, fmt.Errorf(
+			"matrix: crypto_passphrase not resolved (crypto_passphrase_ref=%q): check credential store",
+			cfg.CryptoPassphraseRef,
+		)
 	}
 
 	base := channels.NewBaseChannel(

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -394,6 +394,12 @@ type AgentConfig struct {
 	Color string `json:"color,omitempty"`
 	// Icon is the Phosphor icon name for this agent's avatar in the UI (e.g. "robot").
 	Icon string `json:"icon,omitempty"`
+	// Type classifies the agent. Empty defaults to AgentTypeCustom for stored agents;
+	// use ResolveType() to get the effective type.
+	Type AgentType `json:"type,omitempty"`
+	// Tools, when non-nil, overrides scope-based tool visibility for this agent.
+	// Nil means all tools allowed by the agent's type are available.
+	Tools *AgentToolsCfg `json:"tools,omitempty"`
 }
 
 // IsActive returns the effective active state of this agent.
@@ -402,6 +408,67 @@ type AgentConfig struct {
 // Agents with Enabled=false are inactive; Enabled=true are explicitly active.
 func (a AgentConfig) IsActive() bool {
 	return a.Enabled == nil || *a.Enabled
+}
+
+// AgentType classifies an agent for scope-based tool visibility filtering.
+type AgentType string
+
+const (
+	AgentTypeSystem AgentType = "system"
+	AgentTypeCore   AgentType = "core"
+	AgentTypeCustom AgentType = "custom"
+)
+
+// AgentToolsCfg holds per-agent overrides for builtin tool visibility and MCP server bindings.
+type AgentToolsCfg struct {
+	Builtin AgentBuiltinToolsCfg `json:"builtin,omitempty"`
+	MCP     AgentMCPToolsCfg     `json:"mcp,omitempty"`
+}
+
+// AgentBuiltinToolsCfg controls which builtin tools are visible to an agent.
+type AgentBuiltinToolsCfg struct {
+	// Mode determines how the tool set is computed:
+	//   - "inherit": agent inherits tools based on its type (default)
+	//   - "explicit": only tools listed in Visible are available
+	Mode    VisibilityMode `json:"mode"`
+	Visible []string       `json:"visible,omitempty"` // tool names when Mode=explicit
+}
+
+// AgentMCPToolsCfg controls which MCP servers are available to an agent.
+type AgentMCPToolsCfg struct {
+	Servers []AgentMCPServerBinding `json:"servers,omitempty"`
+}
+
+// AgentMCPServerBinding binds an MCP server to an agent.
+type AgentMCPServerBinding struct {
+	ID    string   `json:"id"`
+	Tools []string `json:"tools,omitempty"` // empty or ["*"] = all tools from that server
+}
+
+// VisibilityMode determines how an agent's tool set is computed.
+type VisibilityMode string
+
+const (
+	VisibilityInherit  VisibilityMode = "inherit"
+	VisibilityExplicit VisibilityMode = "explicit"
+)
+
+// ResolveType returns the effective agent type. If the Type field is set, it is
+// returned directly. Otherwise the type is inferred: "omnipus-system" →
+// AgentTypeSystem; known core agent IDs → AgentTypeCore; everything else →
+// AgentTypeCustom. The caller must provide isCoreAgent to avoid an import cycle
+// with the coreagent package.
+func (a AgentConfig) ResolveType(isCoreAgent func(string) bool) AgentType {
+	if a.Type != "" {
+		return a.Type
+	}
+	if a.ID == "omnipus-system" {
+		return AgentTypeSystem
+	}
+	if isCoreAgent != nil && isCoreAgent(a.ID) {
+		return AgentTypeCore
+	}
+	return AgentTypeCustom
 }
 
 type SubagentsConfig struct {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1246,3 +1246,209 @@ func TestAgentConfig_IsActive_NilDefaultsToTrue(t *testing.T) {
 		})
 	}
 }
+
+// --- ResolveType tests ---
+
+// TestResolveType_ExplicitType verifies that when AgentConfig.Type is set, it
+// is returned directly without inspecting the ID or calling isCoreAgent.
+//
+// BDD: Given an AgentConfig with Type="core"
+//
+//	When ResolveType is called
+//	Then "core" is returned without calling isCoreAgent
+//
+// Traces to: config.go AgentConfig.ResolveType — "if a.Type != "" { return a.Type }" branch
+func TestResolveType_ExplicitType(t *testing.T) {
+	a := AgentConfig{ID: "some-agent", Type: AgentTypeCore}
+
+	// isCoreAgent must not be called when Type is set explicitly.
+	called := false
+	got := a.ResolveType(func(id string) bool {
+		called = true
+		return false
+	})
+
+	if got != AgentTypeCore {
+		t.Errorf("ResolveType() = %q, want %q", got, AgentTypeCore)
+	}
+	if called {
+		t.Error("isCoreAgent should not be called when Type is set explicitly")
+	}
+
+	// Differentiation: a different explicit type returns a different result.
+	a2 := AgentConfig{ID: "some-agent", Type: AgentTypeSystem}
+	got2 := a2.ResolveType(nil)
+	if got2 != AgentTypeSystem {
+		t.Errorf("ResolveType() = %q, want %q", got2, AgentTypeSystem)
+	}
+	if got == got2 {
+		t.Error("different explicit types must produce different results")
+	}
+}
+
+// TestResolveType_SystemAgentID verifies that the canonical system agent ID
+// "omnipus-system" resolves to AgentTypeSystem even when Type is not set.
+//
+// BDD: Given an AgentConfig with ID="omnipus-system" and no explicit Type
+//
+//	When ResolveType is called
+//	Then AgentTypeSystem is returned
+//
+// Traces to: config.go AgentConfig.ResolveType — system ID guard
+func TestResolveType_SystemAgentID(t *testing.T) {
+	a := AgentConfig{ID: "omnipus-system"}
+
+	got := a.ResolveType(func(_ string) bool { return false })
+
+	if got != AgentTypeSystem {
+		t.Errorf("ResolveType() = %q, want AgentTypeSystem", got)
+	}
+}
+
+// TestResolveType_CoreAgentID verifies that an agent whose ID is recognized by
+// isCoreAgent resolves to AgentTypeCore.
+//
+// BDD: Given an AgentConfig with ID="researcher" and isCoreAgent returns true for it
+//
+//	When ResolveType is called
+//	Then AgentTypeCore is returned
+//
+// Traces to: config.go AgentConfig.ResolveType — isCoreAgent(a.ID) branch
+func TestResolveType_CoreAgentID(t *testing.T) {
+	a := AgentConfig{ID: "researcher"}
+
+	coreIDs := map[string]bool{"researcher": true, "assistant": true}
+	got := a.ResolveType(func(id string) bool { return coreIDs[id] })
+
+	if got != AgentTypeCore {
+		t.Errorf("ResolveType() = %q, want AgentTypeCore", got)
+	}
+
+	// Differentiation: a different ID not in coreIDs resolves to custom.
+	a2 := AgentConfig{ID: "my-custom-bot"}
+	got2 := a2.ResolveType(func(id string) bool { return coreIDs[id] })
+	if got2 != AgentTypeCustom {
+		t.Errorf("ResolveType() = %q, want AgentTypeCustom for unrecognized ID", got2)
+	}
+	if got == got2 {
+		t.Error("core agent ID and custom agent ID must resolve to different types")
+	}
+}
+
+// TestResolveType_CustomAgentID verifies that an agent not recognized by
+// isCoreAgent and not the system ID resolves to AgentTypeCustom.
+//
+// BDD: Given an AgentConfig with ID="my-bot" and isCoreAgent returns false
+//
+//	When ResolveType is called
+//	Then AgentTypeCustom is returned
+//
+// Traces to: config.go AgentConfig.ResolveType — else → AgentTypeCustom
+func TestResolveType_CustomAgentID(t *testing.T) {
+	a := AgentConfig{ID: "my-bot"}
+
+	got := a.ResolveType(func(_ string) bool { return false })
+
+	if got != AgentTypeCustom {
+		t.Errorf("ResolveType() = %q, want AgentTypeCustom", got)
+	}
+}
+
+// TestResolveType_NilCallback verifies that passing nil for isCoreAgent does
+// not panic; the agent falls through to AgentTypeCustom.
+//
+// BDD: Given an AgentConfig with ID="my-bot" and isCoreAgent=nil
+//
+//	When ResolveType is called
+//	Then AgentTypeCustom is returned without panicking
+//
+// Traces to: config.go AgentConfig.ResolveType — nil isCoreAgent guard
+func TestResolveType_NilCallback(t *testing.T) {
+	a := AgentConfig{ID: "my-bot"}
+
+	// Must not panic.
+	got := a.ResolveType(nil)
+
+	if got != AgentTypeCustom {
+		t.Errorf("ResolveType() = %q, want AgentTypeCustom when isCoreAgent is nil", got)
+	}
+}
+
+// --- AgentToolsCfg JSON round-trip test ---
+
+// TestAgentToolsCfg_JSONRoundTrip verifies that AgentToolsCfg serializes to
+// JSON and deserializes back with all fields preserved, including nested structs
+// (Builtin.Mode, Builtin.Visible, MCP.Servers).
+//
+// BDD: Given a fully-populated AgentToolsCfg
+//
+//	When it is marshaled to JSON and unmarshaled back
+//	Then all field values are identical to the original
+//
+// Traces to: config.go AgentToolsCfg, AgentBuiltinToolsCfg, AgentMCPToolsCfg
+func TestAgentToolsCfg_JSONRoundTrip(t *testing.T) {
+	original := AgentToolsCfg{
+		Builtin: AgentBuiltinToolsCfg{
+			Mode:    VisibilityExplicit,
+			Visible: []string{"exec", "web_search", "read_file"},
+		},
+		MCP: AgentMCPToolsCfg{
+			Servers: []AgentMCPServerBinding{
+				{ID: "github-server", Tools: []string{"create_issue", "list_prs"}},
+				{ID: "jira-server", Tools: []string{"*"}},
+			},
+		},
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("json.Marshal(AgentToolsCfg): %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatal("marshaled JSON must not be empty")
+	}
+
+	var decoded AgentToolsCfg
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal(AgentToolsCfg): %v", err)
+	}
+
+	// Builtin.Mode
+	if decoded.Builtin.Mode != original.Builtin.Mode {
+		t.Errorf("Builtin.Mode = %q, want %q", decoded.Builtin.Mode, original.Builtin.Mode)
+	}
+
+	// Builtin.Visible — length and contents
+	if len(decoded.Builtin.Visible) != len(original.Builtin.Visible) {
+		t.Fatalf("Builtin.Visible len = %d, want %d", len(decoded.Builtin.Visible), len(original.Builtin.Visible))
+	}
+	for i, name := range original.Builtin.Visible {
+		if decoded.Builtin.Visible[i] != name {
+			t.Errorf("Builtin.Visible[%d] = %q, want %q", i, decoded.Builtin.Visible[i], name)
+		}
+	}
+
+	// MCP.Servers — count and contents
+	if len(decoded.MCP.Servers) != len(original.MCP.Servers) {
+		t.Fatalf("MCP.Servers len = %d, want %d", len(decoded.MCP.Servers), len(original.MCP.Servers))
+	}
+	for i, srv := range original.MCP.Servers {
+		if decoded.MCP.Servers[i].ID != srv.ID {
+			t.Errorf("MCP.Servers[%d].ID = %q, want %q", i, decoded.MCP.Servers[i].ID, srv.ID)
+		}
+		if len(decoded.MCP.Servers[i].Tools) != len(srv.Tools) {
+			t.Errorf("MCP.Servers[%d].Tools len = %d, want %d",
+				i, len(decoded.MCP.Servers[i].Tools), len(srv.Tools))
+		}
+	}
+
+	// Content differentiation: marshal again and compare bytes to confirm
+	// the round-trip is stable (not just shape-preserving).
+	data2, err := json.Marshal(decoded)
+	if err != nil {
+		t.Fatalf("second json.Marshal: %v", err)
+	}
+	if string(data) != string(data2) {
+		t.Errorf("second marshal differs from first:\n  first:  %s\n  second: %s", data, data2)
+	}
+}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1409,8 +1409,8 @@ func TestAgentToolsCfg_JSONRoundTrip(t *testing.T) {
 	}
 
 	var decoded AgentToolsCfg
-	if err := json.Unmarshal(data, &decoded); err != nil {
-		t.Fatalf("json.Unmarshal(AgentToolsCfg): %v", err)
+	if unmarshalErr := json.Unmarshal(data, &decoded); unmarshalErr != nil {
+		t.Fatalf("json.Unmarshal(AgentToolsCfg): %v", unmarshalErr)
 	}
 
 	// Builtin.Mode

--- a/pkg/gateway/rest.go
+++ b/pkg/gateway/rest.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/dapicom-ai/omnipus/pkg/agent"
 	"github.com/dapicom-ai/omnipus/pkg/config"
+	"github.com/dapicom-ai/omnipus/pkg/coreagent"
 	"github.com/dapicom-ai/omnipus/pkg/credentials"
 	"github.com/dapicom-ai/omnipus/pkg/fileutil"
 	"github.com/dapicom-ai/omnipus/pkg/onboarding"
@@ -38,6 +39,7 @@ import (
 	"github.com/dapicom-ai/omnipus/pkg/session"
 	"github.com/dapicom-ai/omnipus/pkg/skills"
 	"github.com/dapicom-ai/omnipus/pkg/taskstore"
+	"github.com/dapicom-ai/omnipus/pkg/tools"
 )
 
 // Version is set at build time via -ldflags "-X github.com/dapicom-ai/omnipus/pkg/gateway.Version=x.y.z".
@@ -451,6 +453,19 @@ func (a *restAPI) HandleAgents(w http.ResponseWriter, r *http.Request) {
 	// GET /api/v1/agents/{id}/sessions
 	if r.Method == http.MethodGet && agentID != "" && subPath == "sessions" {
 		a.listAgentSessions(w, agentID)
+		return
+	}
+
+	// GET/PUT /api/v1/agents/{id}/tools — per-agent tool visibility config
+	if agentID != "" && subPath == "tools" {
+		switch r.Method {
+		case http.MethodGet:
+			a.getAgentTools(w, agentID)
+		case http.MethodPut:
+			a.updateAgentTools(w, r, agentID)
+		default:
+			jsonErr(w, http.StatusMethodNotAllowed, "method not allowed")
+		}
 		return
 	}
 
@@ -924,6 +939,20 @@ func (a *restAPI) createAgent(w http.ResponseWriter, r *http.Request) {
 		Name        string `json:"name"`
 		Description string `json:"description"`
 		Model       string `json:"model"`
+		Color       string `json:"color"`
+		Icon        string `json:"icon"`
+		ToolsCfg    *struct {
+			Builtin struct {
+				Mode    string   `json:"mode"`
+				Visible []string `json:"visible"`
+			} `json:"builtin"`
+			MCP struct {
+				Servers []struct {
+					ID    string   `json:"id"`
+					Tools []string `json:"tools"`
+				} `json:"servers"`
+			} `json:"mcp"`
+		} `json:"tools_cfg"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		jsonErr(w, http.StatusBadRequest, "invalid JSON body")
@@ -937,9 +966,35 @@ func (a *restAPI) createAgent(w http.ResponseWriter, r *http.Request) {
 		ID:          uuid.New().String(),
 		Name:        req.Name,
 		Description: strings.TrimSpace(req.Description),
+		Color:       req.Color,
+		Icon:        req.Icon,
+		Type:        config.AgentTypeCustom,
 	}
 	if req.Model != "" {
 		ac.Model = &config.AgentModelConfig{Primary: req.Model}
+	}
+	if req.ToolsCfg != nil {
+		mode := config.VisibilityMode(req.ToolsCfg.Builtin.Mode)
+		if mode == "" {
+			mode = config.VisibilityInherit
+		}
+		if mode != config.VisibilityInherit && mode != config.VisibilityExplicit {
+			jsonErr(w, http.StatusUnprocessableEntity, "tools_cfg.builtin.mode must be 'inherit' or 'explicit'")
+			return
+		}
+		ac.Tools = &config.AgentToolsCfg{
+			Builtin: config.AgentBuiltinToolsCfg{
+				Mode:    mode,
+				Visible: req.ToolsCfg.Builtin.Visible,
+			},
+		}
+		if len(req.ToolsCfg.MCP.Servers) > 0 {
+			servers := make([]config.AgentMCPServerBinding, 0, len(req.ToolsCfg.MCP.Servers))
+			for _, s := range req.ToolsCfg.MCP.Servers {
+				servers = append(servers, config.AgentMCPServerBinding{ID: s.ID, Tools: s.Tools})
+			}
+			ac.Tools.MCP = config.AgentMCPToolsCfg{Servers: servers}
+		}
 	}
 	// Persist the new agent to config.json BEFORE mutating the live config.
 	// If persistence fails, the in-memory config stays consistent with disk.
@@ -953,12 +1008,39 @@ func (a *restAPI) createAgent(w http.ResponseWriter, r *http.Request) {
 		newAgent := map[string]any{
 			"id":   ac.ID,
 			"name": ac.Name,
+			"type": string(ac.Type),
 		}
 		if ac.Description != "" {
 			newAgent["description"] = ac.Description
 		}
+		if ac.Color != "" {
+			newAgent["color"] = ac.Color
+		}
+		if ac.Icon != "" {
+			newAgent["icon"] = ac.Icon
+		}
 		if ac.Model != nil {
 			newAgent["model"] = map[string]any{"primary": ac.Model.Primary}
+		}
+		if ac.Tools != nil {
+			toolsCfg := map[string]any{
+				"builtin": map[string]any{
+					"mode":    string(ac.Tools.Builtin.Mode),
+					"visible": ac.Tools.Builtin.Visible,
+				},
+			}
+			if len(ac.Tools.MCP.Servers) > 0 {
+				servers := make([]map[string]any, 0, len(ac.Tools.MCP.Servers))
+				for _, s := range ac.Tools.MCP.Servers {
+					srv := map[string]any{"id": s.ID}
+					if len(s.Tools) > 0 {
+						srv["tools"] = s.Tools
+					}
+					servers = append(servers, srv)
+				}
+				toolsCfg["mcp"] = map[string]any{"servers": servers}
+			}
+			newAgent["tools"] = toolsCfg
 		}
 		agents["list"] = append(list, newAgent)
 		return nil
@@ -1737,6 +1819,8 @@ func (a *restAPI) registerAdditionalEndpoints(cm httpHandlerRegistrar) {
 	cm.RegisterHTTPHandler("/api/v1/mcp-servers/", a.withAuth(a.HandleMCPServers))
 	cm.RegisterHTTPHandler("/api/v1/storage/stats", a.withAuth(a.HandleStorageStats))
 	cm.RegisterHTTPHandler("/api/v1/tools", a.withAuth(a.HandleTools))
+	cm.RegisterHTTPHandler("/api/v1/tools/builtin", a.withAuth(a.HandleBuiltinTools))
+	cm.RegisterHTTPHandler("/api/v1/tools/mcp", a.withAuth(a.HandleMCPTools))
 	cm.RegisterHTTPHandler("/api/v1/channels", a.withAuth(a.HandleChannels))
 	cm.RegisterHTTPHandler("/api/v1/channels/", a.withAuth(a.HandleChannels))
 	cm.RegisterHTTPHandler("/api/v1/agents/", a.withAuth(a.HandleAgents))
@@ -2706,6 +2790,301 @@ func (a *restAPI) HandleTools(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 	jsonOK(w, tools)
+}
+
+// --- Tool Visibility (Issue #41) ---
+
+// toolToMap converts a Tool to its REST representation. The category is derived
+// from the name prefix before the first dot (e.g. "system.agent_list" →
+// "system"). Falls back to defaultCategory when no dot is present.
+func toolToMap(t tools.Tool, defaultCategory string) map[string]any {
+	name := t.Name()
+	category := defaultCategory
+	if idx := strings.Index(name, "."); idx > 0 {
+		category = name[:idx]
+	}
+	return map[string]any{
+		"name":        name,
+		"scope":       string(t.Scope()),
+		"category":    category,
+		"description": t.Description(),
+	}
+}
+
+// HandleBuiltinTools handles GET /api/v1/tools/builtin — returns tools from the
+// default agent and the system agent (omnipus-system) merged into a single list,
+// each annotated with scope and category, for the tool picker UI.
+func (a *restAPI) HandleBuiltinTools(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		jsonErr(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	registry := a.agentLoop.GetRegistry()
+	defaultAgent := registry.GetDefaultAgent()
+	if defaultAgent == nil {
+		jsonOK(w, []map[string]any{})
+		return
+	}
+	seen := make(map[string]struct{})
+	result := make([]map[string]any, 0)
+	for _, t := range defaultAgent.Tools.GetAll() {
+		seen[t.Name()] = struct{}{}
+		result = append(result, toolToMap(t, "general"))
+	}
+	// Also include system agent tools if they exist, deduplicating by name.
+	if sysAgent, ok := registry.GetAgent("omnipus-system"); ok && sysAgent != nil {
+		for _, t := range sysAgent.Tools.GetAll() {
+			if _, dup := seen[t.Name()]; dup {
+				continue
+			}
+			seen[t.Name()] = struct{}{}
+			result = append(result, toolToMap(t, "system"))
+		}
+	}
+	jsonOK(w, result)
+}
+
+// HandleMCPTools handles GET /api/v1/tools/mcp — returns all configured MCP
+// servers with their status and tool lists for the agent tool picker UI.
+func (a *restAPI) HandleMCPTools(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		jsonErr(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	cfg := a.agentLoop.GetConfig()
+	servers := make([]map[string]any, 0, len(cfg.Tools.MCP.Servers))
+	for name, srv := range cfg.Tools.MCP.Servers {
+		entry := map[string]any{
+			"id":      name,
+			"name":    name,
+			"enabled": srv.Enabled,
+			"command": srv.Command,
+		}
+		if len(srv.Args) > 0 {
+			entry["args"] = srv.Args
+		}
+		servers = append(servers, entry)
+	}
+	jsonOK(w, servers)
+}
+
+// getAgentTools handles GET /api/v1/agents/{id}/tools — returns the agent's
+// tool visibility config and the resolved effective tool list.
+func (a *restAPI) getAgentTools(w http.ResponseWriter, agentID string) {
+	cfg := a.agentLoop.GetConfig()
+
+	// Determine agent type and tool config.
+	agentType := "custom"
+	var toolsCfg *config.AgentToolsCfg
+	if agentID == "omnipus-system" {
+		agentType = "system"
+	} else {
+		for _, ac := range cfg.Agents.List {
+			if ac.ID == agentID {
+				at := ac.ResolveType(coreagent.IsCoreAgent)
+				agentType = string(at)
+				toolsCfg = ac.Tools
+				break
+			}
+		}
+		// Core agents may not be in cfg.Agents.List (runtime-only). Detect them
+		// so FilterToolsByVisibility applies the correct scope gate.
+		if agentType == "custom" && coreagent.IsCoreAgent(agentID) {
+			agentType = "core"
+		}
+	}
+
+	// Build the effective tool list using scope filtering.
+	registry := a.agentLoop.GetRegistry()
+	agent, ok := registry.GetAgent(agentID)
+	if !ok {
+		slog.Warn("rest: agent found in config but not in registry, tool list may be stale",
+			"agent_id", agentID)
+		agent = registry.GetDefaultAgent()
+	}
+
+	effectiveTools := []map[string]any{}
+	if agent != nil {
+		filtered := tools.FilterToolsByVisibility(agent.Tools.GetAll(), agentType, toolsCfgToVisibility(toolsCfg))
+		for _, t := range filtered {
+			effectiveTools = append(effectiveTools, toolToMap(t, "general"))
+		}
+	}
+
+	// Build the response config. Return the stored config or a default.
+	respCfg := map[string]any{
+		"builtin": map[string]any{"mode": "inherit"},
+		"mcp":     map[string]any{"servers": []any{}},
+	}
+	if toolsCfg != nil {
+		mode := string(toolsCfg.Builtin.Mode)
+		if mode == "" {
+			mode = "inherit"
+		}
+		visible := toolsCfg.Builtin.Visible
+		if visible == nil {
+			visible = []string{}
+		}
+		servers := make([]map[string]any, 0, len(toolsCfg.MCP.Servers))
+		for _, s := range toolsCfg.MCP.Servers {
+			srv := map[string]any{"id": s.ID}
+			if len(s.Tools) > 0 {
+				srv["tools"] = s.Tools
+			}
+			servers = append(servers, srv)
+		}
+		respCfg = map[string]any{
+			"builtin": map[string]any{"mode": mode, "visible": visible},
+			"mcp":     map[string]any{"servers": servers},
+		}
+	}
+
+	jsonOK(w, map[string]any{
+		"config":          respCfg,
+		"effective_tools": effectiveTools,
+		"agent_type":      agentType,
+	})
+}
+
+// updateAgentTools handles PUT /api/v1/agents/{id}/tools — replaces the
+// agent's tool visibility config.
+func (a *restAPI) updateAgentTools(w http.ResponseWriter, r *http.Request, agentID string) {
+	if agentID == "omnipus-system" {
+		jsonErr(w, http.StatusForbidden, "cannot modify system agent tools")
+		return
+	}
+
+	cfg := a.agentLoop.GetConfig()
+	found := false
+	for _, ac := range cfg.Agents.List {
+		if ac.ID == agentID {
+			if ac.ResolveType(coreagent.IsCoreAgent) == config.AgentTypeCore {
+				jsonErr(w, http.StatusForbidden, "cannot modify core agent tools")
+				return
+			}
+			found = true
+			break
+		}
+	}
+	if !found {
+		jsonErr(w, http.StatusNotFound, fmt.Sprintf("agent %q not found", agentID))
+		return
+	}
+
+	var req struct {
+		Builtin struct {
+			Mode    string   `json:"mode"`
+			Visible []string `json:"visible"`
+		} `json:"builtin"`
+		MCP struct {
+			Servers []struct {
+				ID    string   `json:"id"`
+				Tools []string `json:"tools"`
+			} `json:"servers"`
+		} `json:"mcp"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonErr(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+
+	// Validate mode.
+	mode := req.Builtin.Mode
+	if mode == "" {
+		mode = "inherit"
+	}
+	if mode != "inherit" && mode != "explicit" {
+		jsonErr(w, http.StatusUnprocessableEntity, "builtin.mode must be 'inherit' or 'explicit'")
+		return
+	}
+
+	// Validate MCP server IDs reference configured servers.
+	if len(req.MCP.Servers) > 0 {
+		configuredServers := cfg.Tools.MCP.Servers
+		for _, s := range req.MCP.Servers {
+			if s.ID == "" {
+				jsonErr(w, http.StatusUnprocessableEntity, "mcp.servers[].id must not be empty")
+				return
+			}
+			if _, exists := configuredServers[s.ID]; !exists {
+				jsonErr(w, http.StatusUnprocessableEntity, fmt.Sprintf("MCP server %q is not configured", s.ID))
+				return
+			}
+		}
+	}
+
+	// Persist to config.json.
+	if err := a.safeUpdateConfigJSON(func(m map[string]any) error {
+		agents, _ := m["agents"].(map[string]any)
+		if agents == nil {
+			return fmt.Errorf("agents section not found in config")
+		}
+		list, _ := agents["list"].([]any)
+		for i, raw := range list {
+			agentMap, ok := raw.(map[string]any)
+			if !ok {
+				continue
+			}
+			if agentMap["id"] == agentID {
+				toolsCfg := map[string]any{
+					"builtin": map[string]any{
+						"mode":    mode,
+						"visible": req.Builtin.Visible,
+					},
+				}
+				if len(req.MCP.Servers) > 0 {
+					servers := make([]map[string]any, 0, len(req.MCP.Servers))
+					for _, s := range req.MCP.Servers {
+						srv := map[string]any{"id": s.ID}
+						if len(s.Tools) > 0 {
+							srv["tools"] = s.Tools
+						}
+						servers = append(servers, srv)
+					}
+					toolsCfg["mcp"] = map[string]any{"servers": servers}
+				}
+				agentMap["tools"] = toolsCfg
+				list[i] = agentMap
+				return nil
+			}
+		}
+		return fmt.Errorf("agent %q not found in config list", agentID)
+	}); err != nil {
+		slog.Error("rest: update agent tools config", "agent_id", agentID, "error", err)
+		jsonErr(w, http.StatusInternalServerError, fmt.Sprintf("could not save config: %v", err))
+		return
+	}
+
+	var reloadWarning string
+	if err := a.agentLoop.TriggerReload(); err != nil {
+		slog.Error("config reload after agent tools update failed", "agent_id", agentID, "error", err)
+		reloadWarning = fmt.Sprintf("config saved but runtime reload failed: %v", err)
+	}
+
+	// Return the updated state. If reload failed, include a warning so the
+	// client knows the effective_tools may be stale until next restart.
+	if reloadWarning != "" {
+		// Still return 200 — the config was saved, just the live reload failed.
+		// The frontend can show a warning banner.
+		w.Header().Set("X-Omnipus-Warning", reloadWarning)
+	}
+	a.getAgentTools(w, agentID)
+}
+
+// toolsCfgToVisibility converts a config.AgentToolsCfg to the tools package's
+// ToolVisibilityCfg for use with FilterToolsByVisibility.
+func toolsCfgToVisibility(cfg *config.AgentToolsCfg) *tools.ToolVisibilityCfg {
+	if cfg == nil {
+		return &tools.ToolVisibilityCfg{Mode: "inherit"}
+	}
+	mode := string(cfg.Builtin.Mode)
+	if mode == "" {
+		mode = "inherit"
+	}
+	return &tools.ToolVisibilityCfg{
+		Mode:    mode,
+		Visible: cfg.Builtin.Visible,
+	}
 }
 
 // --- Channels ---

--- a/pkg/gateway/rest_test.go
+++ b/pkg/gateway/rest_test.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 
@@ -527,4 +528,376 @@ func TestAgentListStatus_CustomAgentActive(t *testing.T) {
 	// TODO: Blocked — turnState.agentID and AgentLoop.activeTurnStates are unexported.
 	// See testability comment above. This scenario is covered in pkg/agent/turn_test.go.
 	t.Skip("BLOCKED: activeTurnStates injection requires exported test helper in pkg/agent — see TODO above")
+}
+
+// --- Tool Visibility Endpoints (Issue #41) ---
+
+// TestHandleBuiltinTools_ReturnsJSON verifies GET /api/v1/tools/builtin returns a JSON array.
+// BDD: Given a running gateway,
+// When GET /api/v1/tools/builtin is called,
+// Then the response is 200 with a JSON array (possibly empty for test config).
+// Traces to: parsed-inventing-gem.md — PR 2 REST endpoints
+func TestHandleBuiltinTools_ReturnsJSON(t *testing.T) {
+	api, cleanup := newTestRestAPI(t)
+	defer cleanup()
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/tools/builtin", nil)
+	api.HandleBuiltinTools(w, r)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var result []map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
+	// May be empty in test config — the shape is what matters.
+	for _, tool := range result {
+		assert.Contains(t, tool, "name")
+		assert.Contains(t, tool, "scope")
+		assert.Contains(t, tool, "category")
+		assert.Contains(t, tool, "description")
+	}
+}
+
+// TestHandleBuiltinTools_MethodNotAllowed verifies POST is rejected.
+func TestHandleBuiltinTools_MethodNotAllowed(t *testing.T) {
+	api, cleanup := newTestRestAPI(t)
+	defer cleanup()
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/tools/builtin", nil)
+	api.HandleBuiltinTools(w, r)
+
+	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+}
+
+// TestHandleMCPTools_ReturnsJSON verifies GET /api/v1/tools/mcp returns a JSON response.
+// BDD: Given a running gateway with no MCP servers,
+// When GET /api/v1/tools/mcp is called,
+// Then the response is 200 with a JSON array.
+// Traces to: parsed-inventing-gem.md — PR 2 REST endpoints
+func TestHandleMCPTools_ReturnsJSON(t *testing.T) {
+	api, cleanup := newTestRestAPI(t)
+	defer cleanup()
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/tools/mcp", nil)
+	api.HandleMCPTools(w, r)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	// Response should be valid JSON (array or object).
+	var result any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
+}
+
+// TestGetAgentTools_SystemAgent verifies GET /api/v1/agents/omnipus-system/tools returns
+// agent_type "system" and a config object.
+// BDD: Given the system agent,
+// When GET /api/v1/agents/omnipus-system/tools is called,
+// Then the response includes agent_type "system", config, and effective_tools.
+// Traces to: parsed-inventing-gem.md — PR 2 REST endpoints
+func TestGetAgentTools_SystemAgent(t *testing.T) {
+	api, cleanup := newTestRestAPI(t)
+	defer cleanup()
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/agents/omnipus-system/tools", nil)
+	api.HandleAgents(w, r)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp struct {
+		AgentType      string           `json:"agent_type"`
+		Config         map[string]any   `json:"config"`
+		EffectiveTools []map[string]any `json:"effective_tools"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "system", resp.AgentType)
+	assert.NotNil(t, resp.Config)
+	assert.Contains(t, resp.Config, "builtin")
+}
+
+// TestGetAgentTools_CustomAgent verifies GET /api/v1/agents/{id}/tools for a custom agent.
+// BDD: Given a custom agent with tools config,
+// When GET /api/v1/agents/{id}/tools is called,
+// Then the response includes agent_type "custom" and the stored config.
+// Traces to: parsed-inventing-gem.md — PR 2 REST endpoints
+func TestGetAgentTools_CustomAgent(t *testing.T) {
+	t.Setenv("OMNIPUS_BEARER_TOKEN", "")
+
+	tmpDir := t.TempDir()
+	cfg := &config.Config{
+		Gateway: config.GatewayConfig{Host: "127.0.0.1", Port: 8080},
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{
+				Workspace: tmpDir,
+				ModelName: "test-model",
+				MaxTokens: 4096,
+			},
+			List: []config.AgentConfig{
+				{
+					ID:   "tool-agent",
+					Name: "Tool Agent",
+					Tools: &config.AgentToolsCfg{
+						Builtin: config.AgentBuiltinToolsCfg{
+							Mode:    config.VisibilityExplicit,
+							Visible: []string{"read_file", "web_search"},
+						},
+					},
+				},
+			},
+		},
+	}
+	msgBus := bus.NewMessageBus()
+	al := agent.NewAgentLoop(cfg, msgBus, &restMockProvider{})
+	api := &restAPI{agentLoop: al}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/agents/tool-agent/tools", nil)
+	api.HandleAgents(w, r)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp struct {
+		AgentType string         `json:"agent_type"`
+		Config    map[string]any `json:"config"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "custom", resp.AgentType)
+	builtin, ok := resp.Config["builtin"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "explicit", builtin["mode"])
+}
+
+// TestUpdateAgentTools_SystemAgentForbidden verifies PUT /api/v1/agents/omnipus-system/tools returns 403.
+// BDD: Given the system agent,
+// When PUT /api/v1/agents/omnipus-system/tools is called,
+// Then the response is 403 Forbidden.
+// Traces to: parsed-inventing-gem.md — system agent tools cannot be modified
+func TestUpdateAgentTools_SystemAgentForbidden(t *testing.T) {
+	api, cleanup := newTestRestAPI(t)
+	defer cleanup()
+
+	body := `{"builtin":{"mode":"explicit","visible":["read_file"]}}`
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPut, "/api/v1/agents/omnipus-system/tools", strings.NewReader(body))
+	api.HandleAgents(w, r)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+// TestUpdateAgentTools_NotFound verifies PUT /api/v1/agents/{unknown}/tools returns 404.
+func TestUpdateAgentTools_NotFound(t *testing.T) {
+	api, cleanup := newTestRestAPI(t)
+	defer cleanup()
+
+	body := `{"builtin":{"mode":"inherit"}}`
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPut, "/api/v1/agents/nonexistent/tools", strings.NewReader(body))
+	api.HandleAgents(w, r)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// TestUpdateAgentTools_InvalidMode verifies PUT with bad mode returns 422.
+func TestUpdateAgentTools_InvalidMode(t *testing.T) {
+	t.Setenv("OMNIPUS_BEARER_TOKEN", "")
+
+	tmpDir := t.TempDir()
+	cfgPath := tmpDir + "/config.json"
+	// Write a minimal config.json so safeUpdateConfigJSON can read it.
+	cfgJSON := `{"agents":{"list":[{"id":"test-agent","name":"Test"}]}}`
+	require.NoError(t, os.WriteFile(cfgPath, []byte(cfgJSON), 0o600))
+
+	cfg := &config.Config{
+		Gateway: config.GatewayConfig{Host: "127.0.0.1", Port: 8080},
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{
+				Workspace: tmpDir,
+				ModelName: "test-model",
+				MaxTokens: 4096,
+			},
+			List: []config.AgentConfig{
+				{ID: "test-agent", Name: "Test"},
+			},
+		},
+	}
+	msgBus := bus.NewMessageBus()
+	al := agent.NewAgentLoop(cfg, msgBus, &restMockProvider{})
+	api := &restAPI{agentLoop: al, homePath: tmpDir}
+
+	body := `{"builtin":{"mode":"bogus"}}`
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPut, "/api/v1/agents/test-agent/tools", strings.NewReader(body))
+	api.HandleAgents(w, r)
+
+	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
+}
+
+// TestCreateAgent_WithToolsCfg verifies POST /api/v1/agents with tools_cfg persists the tools config.
+// BDD: Given a create-agent request with tools_cfg,
+// When POST /api/v1/agents is called,
+// Then the response includes the agent and the tools config is accepted.
+// Traces to: parsed-inventing-gem.md — createAgent accepts tools_cfg
+func TestCreateAgent_WithToolsCfg(t *testing.T) {
+	t.Setenv("OMNIPUS_BEARER_TOKEN", "")
+
+	tmpDir := t.TempDir()
+	cfgPath := tmpDir + "/config.json"
+	cfgJSON := `{"agents":{"defaults":{"workspace":"` + tmpDir + `","model_name":"test-model","max_tokens":4096},"list":[]}}`
+	require.NoError(t, os.WriteFile(cfgPath, []byte(cfgJSON), 0o600))
+
+	cfg := &config.Config{
+		Gateway: config.GatewayConfig{Host: "127.0.0.1", Port: 8080},
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{
+				Workspace: tmpDir,
+				ModelName: "test-model",
+				MaxTokens: 4096,
+			},
+		},
+	}
+	msgBus := bus.NewMessageBus()
+	al := agent.NewAgentLoop(cfg, msgBus, &restMockProvider{})
+	api := &restAPI{agentLoop: al, homePath: tmpDir}
+
+	body := `{
+		"name": "Research Bot",
+		"description": "A researcher",
+		"color": "#22C55E",
+		"icon": "magnifying-glass",
+		"tools_cfg": {
+			"builtin": {
+				"mode": "explicit",
+				"visible": ["read_file", "web_search", "web_fetch"]
+			},
+			"mcp": {
+				"servers": [{"id": "my-server"}]
+			}
+		}
+	}`
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/agents", strings.NewReader(body))
+	api.HandleAgents(w, r)
+
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	var resp struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+		Type string `json:"type"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "Research Bot", resp.Name)
+	assert.Equal(t, "custom", resp.Type)
+	assert.NotEmpty(t, resp.ID)
+
+	// Verify the config.json was updated with the tools config.
+	savedCfg, err := os.ReadFile(cfgPath)
+	require.NoError(t, err)
+	var savedMap map[string]any
+	require.NoError(t, json.Unmarshal(savedCfg, &savedMap))
+	agentsMap, _ := savedMap["agents"].(map[string]any)
+	list, _ := agentsMap["list"].([]any)
+	require.Len(t, list, 1)
+	agentMap, _ := list[0].(map[string]any)
+	assert.Equal(t, "#22C55E", agentMap["color"])
+	assert.Equal(t, "magnifying-glass", agentMap["icon"])
+	toolsMap, ok := agentMap["tools"].(map[string]any)
+	require.True(t, ok, "tools config must be persisted")
+	builtinMap, _ := toolsMap["builtin"].(map[string]any)
+	assert.Equal(t, "explicit", builtinMap["mode"])
+}
+
+// TestUpdateAgentTools_Success verifies PUT /api/v1/agents/{id}/tools returns 200,
+// updates the response body with the correct agent_type and mode, and persists the
+// tools config to config.json on disk.
+//
+// BDD: Given a custom agent exists in config and a config.json is on disk,
+//
+//	When PUT /api/v1/agents/{id}/tools is called with mode=explicit and visible=["read_file","web_search"],
+//	Then the response is 200, agent_type is "custom", config.builtin.mode is "explicit",
+//	And config.json on disk reflects the persisted tools config.
+//
+// Traces to: parsed-inventing-gem.md — PR #41 Per-Agent Tool Visibility, updateAgentTools success path
+func TestUpdateAgentTools_Success(t *testing.T) {
+	t.Setenv("OMNIPUS_BEARER_TOKEN", "")
+
+	tmpDir := t.TempDir()
+	cfgPath := tmpDir + "/config.json"
+	// Write a minimal config.json so safeUpdateConfigJSON can read it.
+	cfgJSON := `{"agents":{"defaults":{"workspace":"` + tmpDir + `","model_name":"test-model","max_tokens":4096},"list":[{"id":"update-agent","name":"Update Agent"}]}}`
+	require.NoError(t, os.WriteFile(cfgPath, []byte(cfgJSON), 0o600))
+
+	cfg := &config.Config{
+		Gateway: config.GatewayConfig{Host: "127.0.0.1", Port: 8080},
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{
+				Workspace: tmpDir,
+				ModelName: "test-model",
+				MaxTokens: 4096,
+			},
+			List: []config.AgentConfig{
+				{ID: "update-agent", Name: "Update Agent"},
+			},
+		},
+	}
+	msgBus := bus.NewMessageBus()
+	al := agent.NewAgentLoop(cfg, msgBus, &restMockProvider{})
+	api := &restAPI{agentLoop: al, homePath: tmpDir}
+
+	body := `{"builtin":{"mode":"explicit","visible":["read_file","web_search"]}}`
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPut, "/api/v1/agents/update-agent/tools", strings.NewReader(body))
+	api.HandleAgents(w, r)
+
+	// Then: HTTP 200
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// Then: response body has agent_type="custom" and config.builtin.mode="explicit"
+	var resp struct {
+		AgentType string         `json:"agent_type"`
+		Config    map[string]any `json:"config"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "custom", resp.AgentType,
+		"updateAgentTools must return agent_type=custom for a custom agent")
+	builtin, ok := resp.Config["builtin"].(map[string]any)
+	require.True(t, ok, "response config must contain a builtin object")
+	assert.Equal(t, "explicit", builtin["mode"],
+		"response config.builtin.mode must reflect the submitted mode")
+
+	// Then: config.json on disk was updated with the tools config
+	savedCfg, err := os.ReadFile(cfgPath)
+	require.NoError(t, err)
+	var savedMap map[string]any
+	require.NoError(t, json.Unmarshal(savedCfg, &savedMap))
+	agentsMap, _ := savedMap["agents"].(map[string]any)
+	list, _ := agentsMap["list"].([]any)
+	require.Len(t, list, 1, "config.json must contain exactly one agent")
+	agentMap, _ := list[0].(map[string]any)
+	toolsMap, ok := agentMap["tools"].(map[string]any)
+	require.True(t, ok, "tools config must be persisted to config.json")
+	persistedBuiltin, _ := toolsMap["builtin"].(map[string]any)
+	assert.Equal(t, "explicit", persistedBuiltin["mode"],
+		"config.json must persist mode=explicit")
+	visibleRaw, _ := persistedBuiltin["visible"].([]any)
+	require.Len(t, visibleRaw, 2, "config.json must persist visible list with 2 entries")
+	assert.Equal(t, "read_file", visibleRaw[0])
+	assert.Equal(t, "web_search", visibleRaw[1])
+}
+
+// TestHandleMCPTools_MethodNotAllowed verifies that POST to HandleMCPTools returns 405.
+//
+// BDD: Given a running gateway,
+//
+//	When POST /api/v1/tools/mcp is called,
+//	Then the response is 405 Method Not Allowed.
+//
+// Traces to: parsed-inventing-gem.md — PR 2 REST endpoints method guards
+func TestHandleMCPTools_MethodNotAllowed(t *testing.T) {
+	api, cleanup := newTestRestAPI(t)
+	defer cleanup()
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/tools/mcp", nil)
+	api.HandleMCPTools(w, r)
+
+	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
 }

--- a/pkg/sysagent/guarded_tool.go
+++ b/pkg/sysagent/guarded_tool.go
@@ -54,6 +54,10 @@ func (g *GuardedTool) Description() string { return g.inner.Description() }
 // Parameters delegates to the inner tool.
 func (g *GuardedTool) Parameters() map[string]any { return g.inner.Parameters() }
 
+// Scope delegates to the inner tool — the guard wrapper preserves the inner
+// tool's scope so the ToolCompositor's scope gate fires correctly.
+func (g *GuardedTool) Scope() tools.ToolScope { return g.inner.Scope() }
+
 // Execute routes through SystemToolHandler.Handle which enforces:
 //  1. RBAC check (CheckRBAC) — SEC-19
 //  2. Rate limit check (SystemRateLimiter.Check)

--- a/pkg/sysagent/sysagent_test.go
+++ b/pkg/sysagent/sysagent_test.go
@@ -39,6 +39,7 @@ type mockSystemTool struct {
 func (m *mockSystemTool) Name() string               { return m.name }
 func (m *mockSystemTool) Description() string        { return m.description }
 func (m *mockSystemTool) Parameters() map[string]any { return m.params }
+func (m *mockSystemTool) Scope() tools.ToolScope     { return tools.ScopeSystem }
 func (m *mockSystemTool) Execute(_ context.Context, _ map[string]any) *tools.ToolResult {
 	m.executed.Store(true)
 	return tools.NewToolResult(`{"success":true}`)
@@ -879,6 +880,80 @@ func TestSysagentGuardedTool_ConfirmationPaths(t *testing.T) {
 		assert.False(t, mock.executed.Load(), "inner tool must NOT have executed")
 	})
 }
+
+// =====================================================================
+// TestGuardedToolScope_DelegatesToInner
+// =====================================================================
+
+// TestGuardedToolScope_DelegatesToInner verifies that GuardedTool.Scope()
+// delegates to the inner tool's Scope() rather than returning a hardcoded value.
+// Two different inner scopes are tested to prove delegation, not hardcoding.
+//
+// BDD: Given a GuardedTool wrapping an inner tool with a specific Scope,
+//
+//	When GuardedTool.Scope() is called,
+//	Then it returns the same scope as the inner tool (not a hardcoded value).
+//
+// Traces to: pkg/sysagent/guarded_tool.go — Scope() delegates to inner tool
+// so ToolCompositor's scope gate fires correctly (PR #41 Per-Agent Tool Visibility).
+func TestGuardedToolScope_DelegatesToInner(t *testing.T) {
+	tests := []struct {
+		name          string
+		innerScope    tools.ToolScope
+		expectedScope tools.ToolScope
+	}{
+		{
+			name:          "ScopeSystem_inner_returns_ScopeSystem",
+			innerScope:    tools.ScopeSystem,
+			expectedScope: tools.ScopeSystem,
+		},
+		{
+			name:          "ScopeCore_inner_returns_ScopeCore",
+			innerScope:    tools.ScopeCore,
+			expectedScope: tools.ScopeCore,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Given: a mock inner tool with a configurable scope
+			inner := &scopedInnerTool{
+				mockSystemTool: mockSystemTool{
+					name:        "test.tool",
+					description: "test",
+					params:      map[string]any{"type": "object"},
+				},
+				scope: tc.innerScope,
+			}
+			// And: a real tool registry with the inner tool registered
+			reg := tools.NewToolRegistry()
+			reg.Register(inner)
+			handler := sysagent.NewSystemToolHandler(sysagent.HandlerConfig{
+				Registry: reg,
+			})
+
+			// When: GuardedTool wraps the inner tool
+			guarded := sysagent.NewGuardedTool(inner, handler, sysagent.RoleSingleUser, "")
+
+			// Then: GuardedTool.Scope() returns the inner tool's scope
+			assert.Equal(t, tc.expectedScope, guarded.Scope(),
+				"GuardedTool must delegate Scope() to inner tool, not hardcode a value")
+		})
+	}
+
+	// Differentiation check: ensure the two test cases actually produced different scopes,
+	// proving the test is not trivially always-true.
+	require.NotEqual(t, tests[0].expectedScope, tests[1].expectedScope,
+		"test dataset must include two DIFFERENT scopes to prove delegation, not hardcoding")
+}
+
+// scopedInnerTool extends mockSystemTool with a configurable Scope() for GuardedTool delegation tests.
+type scopedInnerTool struct {
+	mockSystemTool
+	scope tools.ToolScope
+}
+
+func (s *scopedInnerTool) Scope() tools.ToolScope { return s.scope }
 
 // =====================================================================
 // Helper: verify strings import used

--- a/pkg/sysagent/tools/agent.go
+++ b/pkg/sysagent/tools/agent.go
@@ -115,8 +115,8 @@ type AgentCreateTool struct{ deps *Deps }
 
 func NewAgentCreateTool(d *Deps) *AgentCreateTool { return &AgentCreateTool{deps: d} }
 
-func (t *AgentCreateTool) Name() string              { return "system.agent.create" }
-func (t *AgentCreateTool) Scope() tools.ToolScope    { return tools.ScopeSystem }
+func (t *AgentCreateTool) Name() string           { return "system.agent.create" }
+func (t *AgentCreateTool) Scope() tools.ToolScope { return tools.ScopeSystem }
 func (t *AgentCreateTool) Description() string {
 	return "Create a new custom agent.\nParameters: name (required), description, model, provider, color, icon."
 }
@@ -209,8 +209,8 @@ type AgentUpdateTool struct{ deps *Deps }
 
 func NewAgentUpdateTool(d *Deps) *AgentUpdateTool { return &AgentUpdateTool{deps: d} }
 
-func (t *AgentUpdateTool) Name() string              { return "system.agent.update" }
-func (t *AgentUpdateTool) Scope() tools.ToolScope    { return tools.ScopeSystem }
+func (t *AgentUpdateTool) Name() string           { return "system.agent.update" }
+func (t *AgentUpdateTool) Scope() tools.ToolScope { return tools.ScopeSystem }
 func (t *AgentUpdateTool) Description() string {
 	return "Update an existing agent's configuration.\nParameters: id (required), name, description, model, provider, color, icon."
 }
@@ -301,8 +301,8 @@ type AgentDeleteTool struct{ deps *Deps }
 
 func NewAgentDeleteTool(d *Deps) *AgentDeleteTool { return &AgentDeleteTool{deps: d} }
 
-func (t *AgentDeleteTool) Name() string              { return "system.agent.delete" }
-func (t *AgentDeleteTool) Scope() tools.ToolScope    { return tools.ScopeSystem }
+func (t *AgentDeleteTool) Name() string           { return "system.agent.delete" }
+func (t *AgentDeleteTool) Scope() tools.ToolScope { return tools.ScopeSystem }
 func (t *AgentDeleteTool) Description() string {
 	return "Delete an agent and all its data (sessions, memory, workspace).\nParameters: id (required), confirm (bool, must be true)."
 }
@@ -376,8 +376,8 @@ type AgentListTool struct{ deps *Deps }
 
 func NewAgentListTool(d *Deps) *AgentListTool { return &AgentListTool{deps: d} }
 
-func (t *AgentListTool) Name() string              { return "system.agent.list" }
-func (t *AgentListTool) Scope() tools.ToolScope    { return tools.ScopeSystem }
+func (t *AgentListTool) Name() string           { return "system.agent.list" }
+func (t *AgentListTool) Scope() tools.ToolScope { return tools.ScopeSystem }
 func (t *AgentListTool) Description() string {
 	return "List all agents with their status, model, and task count.\nParameters: status (optional: active/inactive/all, default all)."
 }
@@ -436,8 +436,8 @@ type AgentActivateTool struct{ deps *Deps }
 
 func NewAgentActivateTool(d *Deps) *AgentActivateTool { return &AgentActivateTool{deps: d} }
 
-func (t *AgentActivateTool) Name() string              { return "system.agent.activate" }
-func (t *AgentActivateTool) Scope() tools.ToolScope    { return tools.ScopeSystem }
+func (t *AgentActivateTool) Name() string           { return "system.agent.activate" }
+func (t *AgentActivateTool) Scope() tools.ToolScope { return tools.ScopeSystem }
 func (t *AgentActivateTool) Description() string {
 	return "Activate a core or custom agent, persisting the enabled state.\nParameters: id (required)."
 }
@@ -463,8 +463,8 @@ type AgentDeactivateTool struct{ deps *Deps }
 
 func NewAgentDeactivateTool(d *Deps) *AgentDeactivateTool { return &AgentDeactivateTool{deps: d} }
 
-func (t *AgentDeactivateTool) Name() string              { return "system.agent.deactivate" }
-func (t *AgentDeactivateTool) Scope() tools.ToolScope    { return tools.ScopeSystem }
+func (t *AgentDeactivateTool) Name() string           { return "system.agent.deactivate" }
+func (t *AgentDeactivateTool) Scope() tools.ToolScope { return tools.ScopeSystem }
 func (t *AgentDeactivateTool) Description() string {
 	return "Deactivate an agent (makes it unavailable for new sessions), persisting the disabled state.\nParameters: id (required)."
 }

--- a/pkg/sysagent/tools/agent.go
+++ b/pkg/sysagent/tools/agent.go
@@ -115,7 +115,8 @@ type AgentCreateTool struct{ deps *Deps }
 
 func NewAgentCreateTool(d *Deps) *AgentCreateTool { return &AgentCreateTool{deps: d} }
 
-func (t *AgentCreateTool) Name() string { return "system.agent.create" }
+func (t *AgentCreateTool) Name() string              { return "system.agent.create" }
+func (t *AgentCreateTool) Scope() tools.ToolScope    { return tools.ScopeSystem }
 func (t *AgentCreateTool) Description() string {
 	return "Create a new custom agent.\nParameters: name (required), description, model, provider, color, icon."
 }
@@ -196,7 +197,7 @@ func (t *AgentCreateTool) Execute(_ context.Context, args map[string]any) *tools
 	return tools.NewToolResult(successJSON(map[string]any{
 		"id":     finalID,
 		"name":   name,
-		"type":   "custom",
+		"type":   string(config.AgentTypeCustom),
 		"status": "active",
 	}))
 }
@@ -208,7 +209,8 @@ type AgentUpdateTool struct{ deps *Deps }
 
 func NewAgentUpdateTool(d *Deps) *AgentUpdateTool { return &AgentUpdateTool{deps: d} }
 
-func (t *AgentUpdateTool) Name() string { return "system.agent.update" }
+func (t *AgentUpdateTool) Name() string              { return "system.agent.update" }
+func (t *AgentUpdateTool) Scope() tools.ToolScope    { return tools.ScopeSystem }
 func (t *AgentUpdateTool) Description() string {
 	return "Update an existing agent's configuration.\nParameters: id (required), name, description, model, provider, color, icon."
 }
@@ -299,7 +301,8 @@ type AgentDeleteTool struct{ deps *Deps }
 
 func NewAgentDeleteTool(d *Deps) *AgentDeleteTool { return &AgentDeleteTool{deps: d} }
 
-func (t *AgentDeleteTool) Name() string { return "system.agent.delete" }
+func (t *AgentDeleteTool) Name() string              { return "system.agent.delete" }
+func (t *AgentDeleteTool) Scope() tools.ToolScope    { return tools.ScopeSystem }
 func (t *AgentDeleteTool) Description() string {
 	return "Delete an agent and all its data (sessions, memory, workspace).\nParameters: id (required), confirm (bool, must be true)."
 }
@@ -373,7 +376,8 @@ type AgentListTool struct{ deps *Deps }
 
 func NewAgentListTool(d *Deps) *AgentListTool { return &AgentListTool{deps: d} }
 
-func (t *AgentListTool) Name() string { return "system.agent.list" }
+func (t *AgentListTool) Name() string              { return "system.agent.list" }
+func (t *AgentListTool) Scope() tools.ToolScope    { return tools.ScopeSystem }
 func (t *AgentListTool) Description() string {
 	return "List all agents with their status, model, and task count.\nParameters: status (optional: active/inactive/all, default all)."
 }
@@ -416,7 +420,7 @@ func (t *AgentListTool) Execute(_ context.Context, args map[string]any) *tools.T
 		result = append(result, agentSummary{
 			ID:     a.ID,
 			Name:   a.Name,
-			Type:   "custom",
+			Type:   string(a.ResolveType(nil)),
 			Status: status,
 			Model:  model,
 		})
@@ -432,7 +436,8 @@ type AgentActivateTool struct{ deps *Deps }
 
 func NewAgentActivateTool(d *Deps) *AgentActivateTool { return &AgentActivateTool{deps: d} }
 
-func (t *AgentActivateTool) Name() string { return "system.agent.activate" }
+func (t *AgentActivateTool) Name() string              { return "system.agent.activate" }
+func (t *AgentActivateTool) Scope() tools.ToolScope    { return tools.ScopeSystem }
 func (t *AgentActivateTool) Description() string {
 	return "Activate a core or custom agent, persisting the enabled state.\nParameters: id (required)."
 }
@@ -458,7 +463,8 @@ type AgentDeactivateTool struct{ deps *Deps }
 
 func NewAgentDeactivateTool(d *Deps) *AgentDeactivateTool { return &AgentDeactivateTool{deps: d} }
 
-func (t *AgentDeactivateTool) Name() string { return "system.agent.deactivate" }
+func (t *AgentDeactivateTool) Name() string              { return "system.agent.deactivate" }
+func (t *AgentDeactivateTool) Scope() tools.ToolScope    { return tools.ScopeSystem }
 func (t *AgentDeactivateTool) Description() string {
 	return "Deactivate an agent (makes it unavailable for new sessions), persisting the disabled state.\nParameters: id (required)."
 }

--- a/pkg/sysagent/tools/channel.go
+++ b/pkg/sysagent/tools/channel.go
@@ -182,7 +182,7 @@ type ChannelListTool struct{ deps *Deps }
 
 func NewChannelListTool(d *Deps) *ChannelListTool { return &ChannelListTool{deps: d} }
 func (t *ChannelListTool) Name() string           { return "system.channel.list" }
-func (t *ChannelListTool) Scope() tools.ToolScope  { return tools.ScopeSystem }
+func (t *ChannelListTool) Scope() tools.ToolScope { return tools.ScopeSystem }
 func (t *ChannelListTool) Description() string {
 	return "List all channels with status and implementation tier. No parameters required."
 }
@@ -201,7 +201,7 @@ type ChannelTestTool struct{ deps *Deps }
 
 func NewChannelTestTool(d *Deps) *ChannelTestTool { return &ChannelTestTool{deps: d} }
 func (t *ChannelTestTool) Name() string           { return "system.channel.test" }
-func (t *ChannelTestTool) Scope() tools.ToolScope  { return tools.ScopeSystem }
+func (t *ChannelTestTool) Scope() tools.ToolScope { return tools.ScopeSystem }
 func (t *ChannelTestTool) Description() string {
 	return "Test a channel connection. Parameters: id (required)."
 }

--- a/pkg/sysagent/tools/channel.go
+++ b/pkg/sysagent/tools/channel.go
@@ -49,6 +49,7 @@ type ChannelEnableTool struct{ deps *Deps }
 
 func NewChannelEnableTool(d *Deps) *ChannelEnableTool { return &ChannelEnableTool{deps: d} }
 func (t *ChannelEnableTool) Name() string             { return "system.channel.enable" }
+func (t *ChannelEnableTool) Scope() tools.ToolScope   { return tools.ScopeSystem }
 func (t *ChannelEnableTool) Description() string {
 	return "Enable a channel so it can be configured and connected.\nParameters: id (required)."
 }
@@ -90,6 +91,7 @@ type ChannelConfigureTool struct{ deps *Deps }
 
 func NewChannelConfigureTool(d *Deps) *ChannelConfigureTool { return &ChannelConfigureTool{deps: d} }
 func (t *ChannelConfigureTool) Name() string                { return "system.channel.configure" }
+func (t *ChannelConfigureTool) Scope() tools.ToolScope      { return tools.ScopeSystem }
 func (t *ChannelConfigureTool) Description() string {
 	return "Configure an enabled channel with its credentials (token, phone_number, etc).\nParameters: id (required), plus channel-specific credentials."
 }
@@ -144,6 +146,7 @@ type ChannelDisableTool struct{ deps *Deps }
 
 func NewChannelDisableTool(d *Deps) *ChannelDisableTool { return &ChannelDisableTool{deps: d} }
 func (t *ChannelDisableTool) Name() string              { return "system.channel.disable" }
+func (t *ChannelDisableTool) Scope() tools.ToolScope    { return tools.ScopeSystem }
 func (t *ChannelDisableTool) Description() string {
 	return "Disable a channel. Parameters: id (required)."
 }
@@ -179,6 +182,7 @@ type ChannelListTool struct{ deps *Deps }
 
 func NewChannelListTool(d *Deps) *ChannelListTool { return &ChannelListTool{deps: d} }
 func (t *ChannelListTool) Name() string           { return "system.channel.list" }
+func (t *ChannelListTool) Scope() tools.ToolScope  { return tools.ScopeSystem }
 func (t *ChannelListTool) Description() string {
 	return "List all channels with status and implementation tier. No parameters required."
 }
@@ -197,6 +201,7 @@ type ChannelTestTool struct{ deps *Deps }
 
 func NewChannelTestTool(d *Deps) *ChannelTestTool { return &ChannelTestTool{deps: d} }
 func (t *ChannelTestTool) Name() string           { return "system.channel.test" }
+func (t *ChannelTestTool) Scope() tools.ToolScope  { return tools.ScopeSystem }
 func (t *ChannelTestTool) Description() string {
 	return "Test a channel connection. Parameters: id (required)."
 }

--- a/pkg/sysagent/tools/config.go
+++ b/pkg/sysagent/tools/config.go
@@ -18,9 +18,9 @@ import (
 
 type ConfigGetTool struct{ deps *Deps }
 
-func NewConfigGetTool(d *Deps) *ConfigGetTool    { return &ConfigGetTool{deps: d} }
-func (t *ConfigGetTool) Name() string             { return "system.config.get" }
-func (t *ConfigGetTool) Scope() tools.ToolScope   { return tools.ScopeSystem }
+func NewConfigGetTool(d *Deps) *ConfigGetTool   { return &ConfigGetTool{deps: d} }
+func (t *ConfigGetTool) Name() string           { return "system.config.get" }
+func (t *ConfigGetTool) Scope() tools.ToolScope { return tools.ScopeSystem }
 func (t *ConfigGetTool) Description() string {
 	return "Read a configuration value by dot-notation key.\nParameters: key (required, e.g. 'gateway.port')."
 }
@@ -65,9 +65,9 @@ func (t *ConfigGetTool) Execute(_ context.Context, args map[string]any) *tools.T
 
 type ConfigSetTool struct{ deps *Deps }
 
-func NewConfigSetTool(d *Deps) *ConfigSetTool { return &ConfigSetTool{deps: d} }
-func (t *ConfigSetTool) Name() string             { return "system.config.set" }
-func (t *ConfigSetTool) Scope() tools.ToolScope   { return tools.ScopeSystem }
+func NewConfigSetTool(d *Deps) *ConfigSetTool   { return &ConfigSetTool{deps: d} }
+func (t *ConfigSetTool) Name() string           { return "system.config.set" }
+func (t *ConfigSetTool) Scope() tools.ToolScope { return tools.ScopeSystem }
 func (t *ConfigSetTool) Description() string {
 	return "Update a configuration value.\nParameters: key (required), value (required)."
 }

--- a/pkg/sysagent/tools/config.go
+++ b/pkg/sysagent/tools/config.go
@@ -18,8 +18,9 @@ import (
 
 type ConfigGetTool struct{ deps *Deps }
 
-func NewConfigGetTool(d *Deps) *ConfigGetTool { return &ConfigGetTool{deps: d} }
-func (t *ConfigGetTool) Name() string         { return "system.config.get" }
+func NewConfigGetTool(d *Deps) *ConfigGetTool    { return &ConfigGetTool{deps: d} }
+func (t *ConfigGetTool) Name() string             { return "system.config.get" }
+func (t *ConfigGetTool) Scope() tools.ToolScope   { return tools.ScopeSystem }
 func (t *ConfigGetTool) Description() string {
 	return "Read a configuration value by dot-notation key.\nParameters: key (required, e.g. 'gateway.port')."
 }
@@ -65,7 +66,8 @@ func (t *ConfigGetTool) Execute(_ context.Context, args map[string]any) *tools.T
 type ConfigSetTool struct{ deps *Deps }
 
 func NewConfigSetTool(d *Deps) *ConfigSetTool { return &ConfigSetTool{deps: d} }
-func (t *ConfigSetTool) Name() string         { return "system.config.set" }
+func (t *ConfigSetTool) Name() string             { return "system.config.set" }
+func (t *ConfigSetTool) Scope() tools.ToolScope   { return tools.ScopeSystem }
 func (t *ConfigSetTool) Description() string {
 	return "Update a configuration value.\nParameters: key (required), value (required)."
 }

--- a/pkg/sysagent/tools/diag.go
+++ b/pkg/sysagent/tools/diag.go
@@ -20,8 +20,9 @@ import (
 
 type DoctorRunTool struct{ deps *Deps }
 
-func NewDoctorRunTool(d *Deps) *DoctorRunTool { return &DoctorRunTool{deps: d} }
-func (t *DoctorRunTool) Name() string         { return "system.doctor.run" }
+func NewDoctorRunTool(d *Deps) *DoctorRunTool    { return &DoctorRunTool{deps: d} }
+func (t *DoctorRunTool) Name() string             { return "system.doctor.run" }
+func (t *DoctorRunTool) Scope() tools.ToolScope   { return tools.ScopeSystem }
 func (t *DoctorRunTool) Description() string {
 	return "Run security diagnostics and return a risk score (0-100) with actionable recommendations. No parameters required."
 }
@@ -123,7 +124,8 @@ func (t *DoctorRunTool) Execute(_ context.Context, _ map[string]any) *tools.Tool
 type BackupCreateTool struct{ deps *Deps }
 
 func NewBackupCreateTool(d *Deps) *BackupCreateTool { return &BackupCreateTool{deps: d} }
-func (t *BackupCreateTool) Name() string            { return "system.backup.create" }
+func (t *BackupCreateTool) Name() string              { return "system.backup.create" }
+func (t *BackupCreateTool) Scope() tools.ToolScope    { return tools.ScopeSystem }
 func (t *BackupCreateTool) Description() string {
 	return "Create a backup of the Omnipus data directory. Parameters: encrypt (bool, default false)."
 }
@@ -163,7 +165,8 @@ func (t *BackupCreateTool) Execute(_ context.Context, args map[string]any) *tool
 type CostQueryTool struct{ deps *Deps }
 
 func NewCostQueryTool(d *Deps) *CostQueryTool { return &CostQueryTool{deps: d} }
-func (t *CostQueryTool) Name() string         { return "system.cost.query" }
+func (t *CostQueryTool) Name() string             { return "system.cost.query" }
+func (t *CostQueryTool) Scope() tools.ToolScope   { return tools.ScopeSystem }
 func (t *CostQueryTool) Description() string {
 	return "Query LLM cost data by period. Parameters: period (today/week/month/custom), start_date, end_date, agent_id, group_by."
 }

--- a/pkg/sysagent/tools/diag.go
+++ b/pkg/sysagent/tools/diag.go
@@ -20,9 +20,9 @@ import (
 
 type DoctorRunTool struct{ deps *Deps }
 
-func NewDoctorRunTool(d *Deps) *DoctorRunTool    { return &DoctorRunTool{deps: d} }
-func (t *DoctorRunTool) Name() string             { return "system.doctor.run" }
-func (t *DoctorRunTool) Scope() tools.ToolScope   { return tools.ScopeSystem }
+func NewDoctorRunTool(d *Deps) *DoctorRunTool   { return &DoctorRunTool{deps: d} }
+func (t *DoctorRunTool) Name() string           { return "system.doctor.run" }
+func (t *DoctorRunTool) Scope() tools.ToolScope { return tools.ScopeSystem }
 func (t *DoctorRunTool) Description() string {
 	return "Run security diagnostics and return a risk score (0-100) with actionable recommendations. No parameters required."
 }
@@ -124,8 +124,8 @@ func (t *DoctorRunTool) Execute(_ context.Context, _ map[string]any) *tools.Tool
 type BackupCreateTool struct{ deps *Deps }
 
 func NewBackupCreateTool(d *Deps) *BackupCreateTool { return &BackupCreateTool{deps: d} }
-func (t *BackupCreateTool) Name() string              { return "system.backup.create" }
-func (t *BackupCreateTool) Scope() tools.ToolScope    { return tools.ScopeSystem }
+func (t *BackupCreateTool) Name() string            { return "system.backup.create" }
+func (t *BackupCreateTool) Scope() tools.ToolScope  { return tools.ScopeSystem }
 func (t *BackupCreateTool) Description() string {
 	return "Create a backup of the Omnipus data directory. Parameters: encrypt (bool, default false)."
 }
@@ -164,9 +164,9 @@ func (t *BackupCreateTool) Execute(_ context.Context, args map[string]any) *tool
 
 type CostQueryTool struct{ deps *Deps }
 
-func NewCostQueryTool(d *Deps) *CostQueryTool { return &CostQueryTool{deps: d} }
-func (t *CostQueryTool) Name() string             { return "system.cost.query" }
-func (t *CostQueryTool) Scope() tools.ToolScope   { return tools.ScopeSystem }
+func NewCostQueryTool(d *Deps) *CostQueryTool   { return &CostQueryTool{deps: d} }
+func (t *CostQueryTool) Name() string           { return "system.cost.query" }
+func (t *CostQueryTool) Scope() tools.ToolScope { return tools.ScopeSystem }
 func (t *CostQueryTool) Description() string {
 	return "Query LLM cost data by period. Parameters: period (today/week/month/custom), start_date, end_date, agent_id, group_by."
 }

--- a/pkg/sysagent/tools/mcp.go
+++ b/pkg/sysagent/tools/mcp.go
@@ -15,8 +15,8 @@ import (
 
 type MCPAddTool struct{ deps *Deps }
 
-func NewMCPAddTool(d *Deps) *MCPAddTool    { return &MCPAddTool{deps: d} }
-func (t *MCPAddTool) Name() string          { return "system.mcp.add" }
+func NewMCPAddTool(d *Deps) *MCPAddTool      { return &MCPAddTool{deps: d} }
+func (t *MCPAddTool) Name() string           { return "system.mcp.add" }
 func (t *MCPAddTool) Scope() tools.ToolScope { return tools.ScopeSystem }
 func (t *MCPAddTool) Description() string {
 	return "Add an MCP server.\nParameters: name (required), transport (stdio/sse/http), command, args, url, env, agent_ids."
@@ -56,9 +56,9 @@ func (t *MCPAddTool) Execute(_ context.Context, args map[string]any) *tools.Tool
 
 type MCPRemoveTool struct{ deps *Deps }
 
-func NewMCPRemoveTool(d *Deps) *MCPRemoveTool { return &MCPRemoveTool{deps: d} }
-func (t *MCPRemoveTool) Name() string              { return "system.mcp.remove" }
-func (t *MCPRemoveTool) Scope() tools.ToolScope    { return tools.ScopeSystem }
+func NewMCPRemoveTool(d *Deps) *MCPRemoveTool   { return &MCPRemoveTool{deps: d} }
+func (t *MCPRemoveTool) Name() string           { return "system.mcp.remove" }
+func (t *MCPRemoveTool) Scope() tools.ToolScope { return tools.ScopeSystem }
 func (t *MCPRemoveTool) Description() string {
 	return "Remove an MCP server. Parameters: name (required), confirm (bool, must be true)."
 }
@@ -97,9 +97,9 @@ func (t *MCPRemoveTool) Execute(_ context.Context, args map[string]any) *tools.T
 
 type MCPListTool struct{ deps *Deps }
 
-func NewMCPListTool(d *Deps) *MCPListTool { return &MCPListTool{deps: d} }
+func NewMCPListTool(d *Deps) *MCPListTool     { return &MCPListTool{deps: d} }
 func (t *MCPListTool) Name() string           { return "system.mcp.list" }
-func (t *MCPListTool) Scope() tools.ToolScope  { return tools.ScopeSystem }
+func (t *MCPListTool) Scope() tools.ToolScope { return tools.ScopeSystem }
 func (t *MCPListTool) Description() string {
 	return "List all MCP servers with status and assigned agents. No parameters required."
 }

--- a/pkg/sysagent/tools/mcp.go
+++ b/pkg/sysagent/tools/mcp.go
@@ -15,8 +15,9 @@ import (
 
 type MCPAddTool struct{ deps *Deps }
 
-func NewMCPAddTool(d *Deps) *MCPAddTool { return &MCPAddTool{deps: d} }
-func (t *MCPAddTool) Name() string      { return "system.mcp.add" }
+func NewMCPAddTool(d *Deps) *MCPAddTool    { return &MCPAddTool{deps: d} }
+func (t *MCPAddTool) Name() string          { return "system.mcp.add" }
+func (t *MCPAddTool) Scope() tools.ToolScope { return tools.ScopeSystem }
 func (t *MCPAddTool) Description() string {
 	return "Add an MCP server.\nParameters: name (required), transport (stdio/sse/http), command, args, url, env, agent_ids."
 }
@@ -56,7 +57,8 @@ func (t *MCPAddTool) Execute(_ context.Context, args map[string]any) *tools.Tool
 type MCPRemoveTool struct{ deps *Deps }
 
 func NewMCPRemoveTool(d *Deps) *MCPRemoveTool { return &MCPRemoveTool{deps: d} }
-func (t *MCPRemoveTool) Name() string         { return "system.mcp.remove" }
+func (t *MCPRemoveTool) Name() string              { return "system.mcp.remove" }
+func (t *MCPRemoveTool) Scope() tools.ToolScope    { return tools.ScopeSystem }
 func (t *MCPRemoveTool) Description() string {
 	return "Remove an MCP server. Parameters: name (required), confirm (bool, must be true)."
 }
@@ -96,7 +98,8 @@ func (t *MCPRemoveTool) Execute(_ context.Context, args map[string]any) *tools.T
 type MCPListTool struct{ deps *Deps }
 
 func NewMCPListTool(d *Deps) *MCPListTool { return &MCPListTool{deps: d} }
-func (t *MCPListTool) Name() string       { return "system.mcp.list" }
+func (t *MCPListTool) Name() string           { return "system.mcp.list" }
+func (t *MCPListTool) Scope() tools.ToolScope  { return tools.ScopeSystem }
 func (t *MCPListTool) Description() string {
 	return "List all MCP servers with status and assigned agents. No parameters required."
 }

--- a/pkg/sysagent/tools/navigate.go
+++ b/pkg/sysagent/tools/navigate.go
@@ -26,7 +26,8 @@ type NavigateTool struct {
 func NewNavigateTool(d *Deps, cb NavigateCallback) *NavigateTool {
 	return &NavigateTool{deps: d, callback: cb}
 }
-func (t *NavigateTool) Name() string { return "system.navigate" }
+func (t *NavigateTool) Name() string            { return "system.navigate" }
+func (t *NavigateTool) Scope() tools.ToolScope  { return tools.ScopeSystem }
 func (t *NavigateTool) Description() string {
 	return "Navigate the UI to a specific screen.\nParameters: screen (chat/command-center/agents/skills/settings), agent_id (optional), section (optional)."
 }

--- a/pkg/sysagent/tools/navigate.go
+++ b/pkg/sysagent/tools/navigate.go
@@ -26,8 +26,8 @@ type NavigateTool struct {
 func NewNavigateTool(d *Deps, cb NavigateCallback) *NavigateTool {
 	return &NavigateTool{deps: d, callback: cb}
 }
-func (t *NavigateTool) Name() string            { return "system.navigate" }
-func (t *NavigateTool) Scope() tools.ToolScope  { return tools.ScopeSystem }
+func (t *NavigateTool) Name() string           { return "system.navigate" }
+func (t *NavigateTool) Scope() tools.ToolScope { return tools.ScopeSystem }
 func (t *NavigateTool) Description() string {
 	return "Navigate the UI to a specific screen.\nParameters: screen (chat/command-center/agents/skills/settings), agent_id (optional), section (optional)."
 }

--- a/pkg/sysagent/tools/pin.go
+++ b/pkg/sysagent/tools/pin.go
@@ -33,9 +33,9 @@ func pinsDir(home string) string { return filepath.Join(home, "pins") }
 
 type PinListTool struct{ deps *Deps }
 
-func NewPinListTool(d *Deps) *PinListTool { return &PinListTool{deps: d} }
+func NewPinListTool(d *Deps) *PinListTool     { return &PinListTool{deps: d} }
 func (t *PinListTool) Name() string           { return "system.pin.list" }
-func (t *PinListTool) Scope() tools.ToolScope  { return tools.ScopeSystem }
+func (t *PinListTool) Scope() tools.ToolScope { return tools.ScopeSystem }
 func (t *PinListTool) Description() string {
 	return "List pinned artifacts with optional filters.\nParameters: agent_id, project_id, tags, search (all optional)."
 }
@@ -78,9 +78,9 @@ func (t *PinListTool) Execute(_ context.Context, args map[string]any) *tools.Too
 
 type PinCreateTool struct{ deps *Deps }
 
-func NewPinCreateTool(d *Deps) *PinCreateTool { return &PinCreateTool{deps: d} }
-func (t *PinCreateTool) Name() string             { return "system.pin.create" }
-func (t *PinCreateTool) Scope() tools.ToolScope   { return tools.ScopeSystem }
+func NewPinCreateTool(d *Deps) *PinCreateTool   { return &PinCreateTool{deps: d} }
+func (t *PinCreateTool) Name() string           { return "system.pin.create" }
+func (t *PinCreateTool) Scope() tools.ToolScope { return tools.ScopeSystem }
 func (t *PinCreateTool) Description() string {
 	return "Pin a chat response.\nParameters: session_id (required), message_id (required), title, tags, project_id."
 }
@@ -139,9 +139,9 @@ func (t *PinCreateTool) Execute(_ context.Context, args map[string]any) *tools.T
 
 type PinDeleteTool struct{ deps *Deps }
 
-func NewPinDeleteTool(d *Deps) *PinDeleteTool { return &PinDeleteTool{deps: d} }
-func (t *PinDeleteTool) Name() string             { return "system.pin.delete" }
-func (t *PinDeleteTool) Scope() tools.ToolScope   { return tools.ScopeSystem }
+func NewPinDeleteTool(d *Deps) *PinDeleteTool   { return &PinDeleteTool{deps: d} }
+func (t *PinDeleteTool) Name() string           { return "system.pin.delete" }
+func (t *PinDeleteTool) Scope() tools.ToolScope { return tools.ScopeSystem }
 func (t *PinDeleteTool) Description() string {
 	return "Delete a pin. Parameters: id (required), confirm (bool, must be true)."
 }

--- a/pkg/sysagent/tools/pin.go
+++ b/pkg/sysagent/tools/pin.go
@@ -34,7 +34,8 @@ func pinsDir(home string) string { return filepath.Join(home, "pins") }
 type PinListTool struct{ deps *Deps }
 
 func NewPinListTool(d *Deps) *PinListTool { return &PinListTool{deps: d} }
-func (t *PinListTool) Name() string       { return "system.pin.list" }
+func (t *PinListTool) Name() string           { return "system.pin.list" }
+func (t *PinListTool) Scope() tools.ToolScope  { return tools.ScopeSystem }
 func (t *PinListTool) Description() string {
 	return "List pinned artifacts with optional filters.\nParameters: agent_id, project_id, tags, search (all optional)."
 }
@@ -78,7 +79,8 @@ func (t *PinListTool) Execute(_ context.Context, args map[string]any) *tools.Too
 type PinCreateTool struct{ deps *Deps }
 
 func NewPinCreateTool(d *Deps) *PinCreateTool { return &PinCreateTool{deps: d} }
-func (t *PinCreateTool) Name() string         { return "system.pin.create" }
+func (t *PinCreateTool) Name() string             { return "system.pin.create" }
+func (t *PinCreateTool) Scope() tools.ToolScope   { return tools.ScopeSystem }
 func (t *PinCreateTool) Description() string {
 	return "Pin a chat response.\nParameters: session_id (required), message_id (required), title, tags, project_id."
 }
@@ -138,7 +140,8 @@ func (t *PinCreateTool) Execute(_ context.Context, args map[string]any) *tools.T
 type PinDeleteTool struct{ deps *Deps }
 
 func NewPinDeleteTool(d *Deps) *PinDeleteTool { return &PinDeleteTool{deps: d} }
-func (t *PinDeleteTool) Name() string         { return "system.pin.delete" }
+func (t *PinDeleteTool) Name() string             { return "system.pin.delete" }
+func (t *PinDeleteTool) Scope() tools.ToolScope   { return tools.ScopeSystem }
 func (t *PinDeleteTool) Description() string {
 	return "Delete a pin. Parameters: id (required), confirm (bool, must be true)."
 }

--- a/pkg/sysagent/tools/project.go
+++ b/pkg/sysagent/tools/project.go
@@ -32,8 +32,8 @@ func projectsDir(home string) string { return filepath.Join(home, "projects") }
 type ProjectCreateTool struct{ deps *Deps }
 
 func NewProjectCreateTool(d *Deps) *ProjectCreateTool { return &ProjectCreateTool{deps: d} }
-func (t *ProjectCreateTool) Name() string              { return "system.project.create" }
-func (t *ProjectCreateTool) Scope() tools.ToolScope    { return tools.ScopeSystem }
+func (t *ProjectCreateTool) Name() string             { return "system.project.create" }
+func (t *ProjectCreateTool) Scope() tools.ToolScope   { return tools.ScopeSystem }
 func (t *ProjectCreateTool) Description() string {
 	return "Create a new project.\nParameters: name (required), description, color, agent_ids."
 }
@@ -90,8 +90,8 @@ func (t *ProjectCreateTool) Execute(_ context.Context, args map[string]any) *too
 type ProjectUpdateTool struct{ deps *Deps }
 
 func NewProjectUpdateTool(d *Deps) *ProjectUpdateTool { return &ProjectUpdateTool{deps: d} }
-func (t *ProjectUpdateTool) Name() string              { return "system.project.update" }
-func (t *ProjectUpdateTool) Scope() tools.ToolScope    { return tools.ScopeSystem }
+func (t *ProjectUpdateTool) Name() string             { return "system.project.update" }
+func (t *ProjectUpdateTool) Scope() tools.ToolScope   { return tools.ScopeSystem }
 func (t *ProjectUpdateTool) Description() string {
 	return "Update an existing project.\nParameters: id (required), name, description, color, agent_ids."
 }
@@ -145,8 +145,8 @@ func (t *ProjectUpdateTool) Execute(_ context.Context, args map[string]any) *too
 type ProjectDeleteTool struct{ deps *Deps }
 
 func NewProjectDeleteTool(d *Deps) *ProjectDeleteTool { return &ProjectDeleteTool{deps: d} }
-func (t *ProjectDeleteTool) Name() string              { return "system.project.delete" }
-func (t *ProjectDeleteTool) Scope() tools.ToolScope    { return tools.ScopeSystem }
+func (t *ProjectDeleteTool) Name() string             { return "system.project.delete" }
+func (t *ProjectDeleteTool) Scope() tools.ToolScope   { return tools.ScopeSystem }
 func (t *ProjectDeleteTool) Description() string {
 	return "Delete a project. Parameters: id (required), confirm (bool, must be true)."
 }
@@ -186,8 +186,8 @@ func (t *ProjectDeleteTool) Execute(_ context.Context, args map[string]any) *too
 type ProjectListTool struct{ deps *Deps }
 
 func NewProjectListTool(d *Deps) *ProjectListTool { return &ProjectListTool{deps: d} }
-func (t *ProjectListTool) Name() string              { return "system.project.list" }
-func (t *ProjectListTool) Scope() tools.ToolScope    { return tools.ScopeSystem }
+func (t *ProjectListTool) Name() string           { return "system.project.list" }
+func (t *ProjectListTool) Scope() tools.ToolScope { return tools.ScopeSystem }
 func (t *ProjectListTool) Description() string {
 	return "List all projects with task counts. No parameters required."
 }

--- a/pkg/sysagent/tools/project.go
+++ b/pkg/sysagent/tools/project.go
@@ -32,7 +32,8 @@ func projectsDir(home string) string { return filepath.Join(home, "projects") }
 type ProjectCreateTool struct{ deps *Deps }
 
 func NewProjectCreateTool(d *Deps) *ProjectCreateTool { return &ProjectCreateTool{deps: d} }
-func (t *ProjectCreateTool) Name() string             { return "system.project.create" }
+func (t *ProjectCreateTool) Name() string              { return "system.project.create" }
+func (t *ProjectCreateTool) Scope() tools.ToolScope    { return tools.ScopeSystem }
 func (t *ProjectCreateTool) Description() string {
 	return "Create a new project.\nParameters: name (required), description, color, agent_ids."
 }
@@ -89,7 +90,8 @@ func (t *ProjectCreateTool) Execute(_ context.Context, args map[string]any) *too
 type ProjectUpdateTool struct{ deps *Deps }
 
 func NewProjectUpdateTool(d *Deps) *ProjectUpdateTool { return &ProjectUpdateTool{deps: d} }
-func (t *ProjectUpdateTool) Name() string             { return "system.project.update" }
+func (t *ProjectUpdateTool) Name() string              { return "system.project.update" }
+func (t *ProjectUpdateTool) Scope() tools.ToolScope    { return tools.ScopeSystem }
 func (t *ProjectUpdateTool) Description() string {
 	return "Update an existing project.\nParameters: id (required), name, description, color, agent_ids."
 }
@@ -143,7 +145,8 @@ func (t *ProjectUpdateTool) Execute(_ context.Context, args map[string]any) *too
 type ProjectDeleteTool struct{ deps *Deps }
 
 func NewProjectDeleteTool(d *Deps) *ProjectDeleteTool { return &ProjectDeleteTool{deps: d} }
-func (t *ProjectDeleteTool) Name() string             { return "system.project.delete" }
+func (t *ProjectDeleteTool) Name() string              { return "system.project.delete" }
+func (t *ProjectDeleteTool) Scope() tools.ToolScope    { return tools.ScopeSystem }
 func (t *ProjectDeleteTool) Description() string {
 	return "Delete a project. Parameters: id (required), confirm (bool, must be true)."
 }
@@ -183,7 +186,8 @@ func (t *ProjectDeleteTool) Execute(_ context.Context, args map[string]any) *too
 type ProjectListTool struct{ deps *Deps }
 
 func NewProjectListTool(d *Deps) *ProjectListTool { return &ProjectListTool{deps: d} }
-func (t *ProjectListTool) Name() string           { return "system.project.list" }
+func (t *ProjectListTool) Name() string              { return "system.project.list" }
+func (t *ProjectListTool) Scope() tools.ToolScope    { return tools.ScopeSystem }
 func (t *ProjectListTool) Description() string {
 	return "List all projects with task counts. No parameters required."
 }

--- a/pkg/sysagent/tools/provider.go
+++ b/pkg/sysagent/tools/provider.go
@@ -41,8 +41,8 @@ type ProviderConfigureTool struct{ deps *Deps }
 func NewProviderConfigureTool(d *Deps) *ProviderConfigureTool {
 	return &ProviderConfigureTool{deps: d}
 }
-func (t *ProviderConfigureTool) Name() string             { return "system.provider.configure" }
-func (t *ProviderConfigureTool) Scope() tools.ToolScope   { return tools.ScopeSystem }
+func (t *ProviderConfigureTool) Name() string           { return "system.provider.configure" }
+func (t *ProviderConfigureTool) Scope() tools.ToolScope { return tools.ScopeSystem }
 func (t *ProviderConfigureTool) Description() string {
 	return "Add or update an LLM provider with its API key.\nParameters: name (required), api_key (for cloud), api_base (optional)."
 }
@@ -94,8 +94,8 @@ func (t *ProviderConfigureTool) Execute(_ context.Context, args map[string]any) 
 type ProviderListTool struct{ deps *Deps }
 
 func NewProviderListTool(d *Deps) *ProviderListTool { return &ProviderListTool{deps: d} }
-func (t *ProviderListTool) Name() string              { return "system.provider.list" }
-func (t *ProviderListTool) Scope() tools.ToolScope    { return tools.ScopeSystem }
+func (t *ProviderListTool) Name() string            { return "system.provider.list" }
+func (t *ProviderListTool) Scope() tools.ToolScope  { return tools.ScopeSystem }
 func (t *ProviderListTool) Description() string {
 	return "List configured providers with connection status. API keys are never returned. No parameters required."
 }
@@ -138,8 +138,8 @@ func (t *ProviderListTool) Execute(_ context.Context, _ map[string]any) *tools.T
 type ProviderTestTool struct{ deps *Deps }
 
 func NewProviderTestTool(d *Deps) *ProviderTestTool { return &ProviderTestTool{deps: d} }
-func (t *ProviderTestTool) Name() string              { return "system.provider.test" }
-func (t *ProviderTestTool) Scope() tools.ToolScope    { return tools.ScopeSystem }
+func (t *ProviderTestTool) Name() string            { return "system.provider.test" }
+func (t *ProviderTestTool) Scope() tools.ToolScope  { return tools.ScopeSystem }
 func (t *ProviderTestTool) Description() string {
 	return "Test a provider connection. Parameters: name (required)."
 }

--- a/pkg/sysagent/tools/provider.go
+++ b/pkg/sysagent/tools/provider.go
@@ -41,7 +41,8 @@ type ProviderConfigureTool struct{ deps *Deps }
 func NewProviderConfigureTool(d *Deps) *ProviderConfigureTool {
 	return &ProviderConfigureTool{deps: d}
 }
-func (t *ProviderConfigureTool) Name() string { return "system.provider.configure" }
+func (t *ProviderConfigureTool) Name() string             { return "system.provider.configure" }
+func (t *ProviderConfigureTool) Scope() tools.ToolScope   { return tools.ScopeSystem }
 func (t *ProviderConfigureTool) Description() string {
 	return "Add or update an LLM provider with its API key.\nParameters: name (required), api_key (for cloud), api_base (optional)."
 }
@@ -93,7 +94,8 @@ func (t *ProviderConfigureTool) Execute(_ context.Context, args map[string]any) 
 type ProviderListTool struct{ deps *Deps }
 
 func NewProviderListTool(d *Deps) *ProviderListTool { return &ProviderListTool{deps: d} }
-func (t *ProviderListTool) Name() string            { return "system.provider.list" }
+func (t *ProviderListTool) Name() string              { return "system.provider.list" }
+func (t *ProviderListTool) Scope() tools.ToolScope    { return tools.ScopeSystem }
 func (t *ProviderListTool) Description() string {
 	return "List configured providers with connection status. API keys are never returned. No parameters required."
 }
@@ -136,7 +138,8 @@ func (t *ProviderListTool) Execute(_ context.Context, _ map[string]any) *tools.T
 type ProviderTestTool struct{ deps *Deps }
 
 func NewProviderTestTool(d *Deps) *ProviderTestTool { return &ProviderTestTool{deps: d} }
-func (t *ProviderTestTool) Name() string            { return "system.provider.test" }
+func (t *ProviderTestTool) Name() string              { return "system.provider.test" }
+func (t *ProviderTestTool) Scope() tools.ToolScope    { return tools.ScopeSystem }
 func (t *ProviderTestTool) Description() string {
 	return "Test a provider connection. Parameters: name (required)."
 }

--- a/pkg/sysagent/tools/skill.go
+++ b/pkg/sysagent/tools/skill.go
@@ -16,8 +16,9 @@ import (
 
 type SkillInstallTool struct{ deps *Deps }
 
-func NewSkillInstallTool(d *Deps) *SkillInstallTool { return &SkillInstallTool{deps: d} }
-func (t *SkillInstallTool) Name() string            { return "system.skill.install" }
+func NewSkillInstallTool(d *Deps) *SkillInstallTool  { return &SkillInstallTool{deps: d} }
+func (t *SkillInstallTool) Name() string              { return "system.skill.install" }
+func (t *SkillInstallTool) Scope() tools.ToolScope    { return tools.ScopeSystem }
 func (t *SkillInstallTool) Description() string {
 	return "Install a skill from ClawHub.\nParameters: name (required), agent_ids (optional), credentials (optional)."
 }
@@ -64,7 +65,8 @@ func (t *SkillInstallTool) Execute(_ context.Context, args map[string]any) *tool
 type SkillRemoveTool struct{ deps *Deps }
 
 func NewSkillRemoveTool(d *Deps) *SkillRemoveTool { return &SkillRemoveTool{deps: d} }
-func (t *SkillRemoveTool) Name() string           { return "system.skill.remove" }
+func (t *SkillRemoveTool) Name() string              { return "system.skill.remove" }
+func (t *SkillRemoveTool) Scope() tools.ToolScope    { return tools.ScopeSystem }
 func (t *SkillRemoveTool) Description() string {
 	return "Remove an installed skill. Parameters: name (required), confirm (bool, must be true)."
 }
@@ -104,7 +106,8 @@ func (t *SkillRemoveTool) Execute(_ context.Context, args map[string]any) *tools
 type SkillSearchTool struct{ deps *Deps }
 
 func NewSkillSearchTool(d *Deps) *SkillSearchTool { return &SkillSearchTool{deps: d} }
-func (t *SkillSearchTool) Name() string           { return "system.skill.search" }
+func (t *SkillSearchTool) Name() string              { return "system.skill.search" }
+func (t *SkillSearchTool) Scope() tools.ToolScope    { return tools.ScopeSystem }
 func (t *SkillSearchTool) Description() string {
 	return "Search ClawHub for skills.\nParameters: query (required), sort (trending/new/popular), limit."
 }
@@ -140,7 +143,8 @@ func (t *SkillSearchTool) Execute(_ context.Context, args map[string]any) *tools
 type SkillListTool struct{ deps *Deps }
 
 func NewSkillListTool(d *Deps) *SkillListTool { return &SkillListTool{deps: d} }
-func (t *SkillListTool) Name() string         { return "system.skill.list" }
+func (t *SkillListTool) Name() string             { return "system.skill.list" }
+func (t *SkillListTool) Scope() tools.ToolScope   { return tools.ScopeSystem }
 func (t *SkillListTool) Description() string {
 	return "List all installed skills. No parameters required."
 }

--- a/pkg/sysagent/tools/skill.go
+++ b/pkg/sysagent/tools/skill.go
@@ -16,9 +16,9 @@ import (
 
 type SkillInstallTool struct{ deps *Deps }
 
-func NewSkillInstallTool(d *Deps) *SkillInstallTool  { return &SkillInstallTool{deps: d} }
-func (t *SkillInstallTool) Name() string              { return "system.skill.install" }
-func (t *SkillInstallTool) Scope() tools.ToolScope    { return tools.ScopeSystem }
+func NewSkillInstallTool(d *Deps) *SkillInstallTool { return &SkillInstallTool{deps: d} }
+func (t *SkillInstallTool) Name() string            { return "system.skill.install" }
+func (t *SkillInstallTool) Scope() tools.ToolScope  { return tools.ScopeSystem }
 func (t *SkillInstallTool) Description() string {
 	return "Install a skill from ClawHub.\nParameters: name (required), agent_ids (optional), credentials (optional)."
 }
@@ -65,8 +65,8 @@ func (t *SkillInstallTool) Execute(_ context.Context, args map[string]any) *tool
 type SkillRemoveTool struct{ deps *Deps }
 
 func NewSkillRemoveTool(d *Deps) *SkillRemoveTool { return &SkillRemoveTool{deps: d} }
-func (t *SkillRemoveTool) Name() string              { return "system.skill.remove" }
-func (t *SkillRemoveTool) Scope() tools.ToolScope    { return tools.ScopeSystem }
+func (t *SkillRemoveTool) Name() string           { return "system.skill.remove" }
+func (t *SkillRemoveTool) Scope() tools.ToolScope { return tools.ScopeSystem }
 func (t *SkillRemoveTool) Description() string {
 	return "Remove an installed skill. Parameters: name (required), confirm (bool, must be true)."
 }
@@ -106,8 +106,8 @@ func (t *SkillRemoveTool) Execute(_ context.Context, args map[string]any) *tools
 type SkillSearchTool struct{ deps *Deps }
 
 func NewSkillSearchTool(d *Deps) *SkillSearchTool { return &SkillSearchTool{deps: d} }
-func (t *SkillSearchTool) Name() string              { return "system.skill.search" }
-func (t *SkillSearchTool) Scope() tools.ToolScope    { return tools.ScopeSystem }
+func (t *SkillSearchTool) Name() string           { return "system.skill.search" }
+func (t *SkillSearchTool) Scope() tools.ToolScope { return tools.ScopeSystem }
 func (t *SkillSearchTool) Description() string {
 	return "Search ClawHub for skills.\nParameters: query (required), sort (trending/new/popular), limit."
 }
@@ -142,9 +142,9 @@ func (t *SkillSearchTool) Execute(_ context.Context, args map[string]any) *tools
 
 type SkillListTool struct{ deps *Deps }
 
-func NewSkillListTool(d *Deps) *SkillListTool { return &SkillListTool{deps: d} }
-func (t *SkillListTool) Name() string             { return "system.skill.list" }
-func (t *SkillListTool) Scope() tools.ToolScope   { return tools.ScopeSystem }
+func NewSkillListTool(d *Deps) *SkillListTool   { return &SkillListTool{deps: d} }
+func (t *SkillListTool) Name() string           { return "system.skill.list" }
+func (t *SkillListTool) Scope() tools.ToolScope { return tools.ScopeSystem }
 func (t *SkillListTool) Description() string {
 	return "List all installed skills. No parameters required."
 }

--- a/pkg/sysagent/tools/task.go
+++ b/pkg/sysagent/tools/task.go
@@ -40,9 +40,9 @@ func validTaskStatus(s string) bool {
 
 type TaskCreateTool struct{ deps *Deps }
 
-func NewTaskCreateTool(d *Deps) *TaskCreateTool { return &TaskCreateTool{deps: d} }
-func (t *TaskCreateTool) Name() string              { return "system.task.create" }
-func (t *TaskCreateTool) Scope() tools.ToolScope    { return tools.ScopeSystem }
+func NewTaskCreateTool(d *Deps) *TaskCreateTool  { return &TaskCreateTool{deps: d} }
+func (t *TaskCreateTool) Name() string           { return "system.task.create" }
+func (t *TaskCreateTool) Scope() tools.ToolScope { return tools.ScopeSystem }
 func (t *TaskCreateTool) Description() string {
 	return "Create a task on the GTD board.\nParameters: name (required), description, project_id, agent_id, status (inbox/next/active/waiting/done)."
 }
@@ -100,9 +100,9 @@ func (t *TaskCreateTool) Execute(_ context.Context, args map[string]any) *tools.
 
 type TaskUpdateTool struct{ deps *Deps }
 
-func NewTaskUpdateTool(d *Deps) *TaskUpdateTool { return &TaskUpdateTool{deps: d} }
-func (t *TaskUpdateTool) Name() string              { return "system.task.update" }
-func (t *TaskUpdateTool) Scope() tools.ToolScope    { return tools.ScopeSystem }
+func NewTaskUpdateTool(d *Deps) *TaskUpdateTool  { return &TaskUpdateTool{deps: d} }
+func (t *TaskUpdateTool) Name() string           { return "system.task.update" }
+func (t *TaskUpdateTool) Scope() tools.ToolScope { return tools.ScopeSystem }
 func (t *TaskUpdateTool) Description() string {
 	return "Update a task's status, assignment, or details.\nParameters: id (required), name, description, status, agent_id, project_id."
 }
@@ -164,9 +164,9 @@ func (t *TaskUpdateTool) Execute(_ context.Context, args map[string]any) *tools.
 
 type TaskDeleteTool struct{ deps *Deps }
 
-func NewTaskDeleteTool(d *Deps) *TaskDeleteTool { return &TaskDeleteTool{deps: d} }
-func (t *TaskDeleteTool) Name() string              { return "system.task.delete" }
-func (t *TaskDeleteTool) Scope() tools.ToolScope    { return tools.ScopeSystem }
+func NewTaskDeleteTool(d *Deps) *TaskDeleteTool  { return &TaskDeleteTool{deps: d} }
+func (t *TaskDeleteTool) Name() string           { return "system.task.delete" }
+func (t *TaskDeleteTool) Scope() tools.ToolScope { return tools.ScopeSystem }
 func (t *TaskDeleteTool) Description() string {
 	return "Delete a task. Parameters: id (required), confirm (bool, must be true)."
 }
@@ -203,9 +203,9 @@ func (t *TaskDeleteTool) Execute(_ context.Context, args map[string]any) *tools.
 
 type TaskListTool struct{ deps *Deps }
 
-func NewTaskListTool(d *Deps) *TaskListTool { return &TaskListTool{deps: d} }
-func (t *TaskListTool) Name() string            { return "system.task.list" }
-func (t *TaskListTool) Scope() tools.ToolScope  { return tools.ScopeSystem }
+func NewTaskListTool(d *Deps) *TaskListTool    { return &TaskListTool{deps: d} }
+func (t *TaskListTool) Name() string           { return "system.task.list" }
+func (t *TaskListTool) Scope() tools.ToolScope { return tools.ScopeSystem }
 func (t *TaskListTool) Description() string {
 	return "List tasks with optional filters.\nParameters: project_id, agent_id, status (all optional)."
 }

--- a/pkg/sysagent/tools/task.go
+++ b/pkg/sysagent/tools/task.go
@@ -41,7 +41,8 @@ func validTaskStatus(s string) bool {
 type TaskCreateTool struct{ deps *Deps }
 
 func NewTaskCreateTool(d *Deps) *TaskCreateTool { return &TaskCreateTool{deps: d} }
-func (t *TaskCreateTool) Name() string          { return "system.task.create" }
+func (t *TaskCreateTool) Name() string              { return "system.task.create" }
+func (t *TaskCreateTool) Scope() tools.ToolScope    { return tools.ScopeSystem }
 func (t *TaskCreateTool) Description() string {
 	return "Create a task on the GTD board.\nParameters: name (required), description, project_id, agent_id, status (inbox/next/active/waiting/done)."
 }
@@ -100,7 +101,8 @@ func (t *TaskCreateTool) Execute(_ context.Context, args map[string]any) *tools.
 type TaskUpdateTool struct{ deps *Deps }
 
 func NewTaskUpdateTool(d *Deps) *TaskUpdateTool { return &TaskUpdateTool{deps: d} }
-func (t *TaskUpdateTool) Name() string          { return "system.task.update" }
+func (t *TaskUpdateTool) Name() string              { return "system.task.update" }
+func (t *TaskUpdateTool) Scope() tools.ToolScope    { return tools.ScopeSystem }
 func (t *TaskUpdateTool) Description() string {
 	return "Update a task's status, assignment, or details.\nParameters: id (required), name, description, status, agent_id, project_id."
 }
@@ -163,7 +165,8 @@ func (t *TaskUpdateTool) Execute(_ context.Context, args map[string]any) *tools.
 type TaskDeleteTool struct{ deps *Deps }
 
 func NewTaskDeleteTool(d *Deps) *TaskDeleteTool { return &TaskDeleteTool{deps: d} }
-func (t *TaskDeleteTool) Name() string          { return "system.task.delete" }
+func (t *TaskDeleteTool) Name() string              { return "system.task.delete" }
+func (t *TaskDeleteTool) Scope() tools.ToolScope    { return tools.ScopeSystem }
 func (t *TaskDeleteTool) Description() string {
 	return "Delete a task. Parameters: id (required), confirm (bool, must be true)."
 }
@@ -201,7 +204,8 @@ func (t *TaskDeleteTool) Execute(_ context.Context, args map[string]any) *tools.
 type TaskListTool struct{ deps *Deps }
 
 func NewTaskListTool(d *Deps) *TaskListTool { return &TaskListTool{deps: d} }
-func (t *TaskListTool) Name() string        { return "system.task.list" }
+func (t *TaskListTool) Name() string            { return "system.task.list" }
+func (t *TaskListTool) Scope() tools.ToolScope  { return tools.ScopeSystem }
 func (t *TaskListTool) Description() string {
 	return "List tasks with optional filters.\nParameters: project_id, agent_id, status (all optional)."
 }

--- a/pkg/tools/base.go
+++ b/pkg/tools/base.go
@@ -2,12 +2,31 @@ package tools
 
 import "context"
 
+// ToolScope classifies a tool's privilege level for per-agent visibility filtering.
+type ToolScope string
+
+const (
+	// ScopeSystem tools are exclusive to the system agent (omnipus-system).
+	// They manage agents, channels, providers, MCP servers, and other infrastructure.
+	ScopeSystem ToolScope = "system"
+	// ScopeCore tools are available to system and core agents, and to custom
+	// agents only when explicitly listed in their tools.builtin.visible config.
+	// Examples: exec, browser.*, write_file, edit_file, spawn, subagent.
+	ScopeCore ToolScope = "core"
+	// ScopeGeneral tools are available to all agent types by default.
+	// Examples: read_file, list_dir, web_search, web_fetch, message, task_*.
+	ScopeGeneral ToolScope = "general"
+)
+
 // Tool is the interface that all tools must implement.
 type Tool interface {
 	Name() string
 	Description() string
 	Parameters() map[string]any
 	Execute(ctx context.Context, args map[string]any) *ToolResult
+	// Scope returns the privilege level of this tool, used by the ToolCompositor
+	// to apply scope-based visibility filtering per agent type.
+	Scope() ToolScope
 }
 
 // --- Request-scoped tool context (channel / chatID) ---

--- a/pkg/tools/browser/tools.go
+++ b/pkg/tools/browser/tools.go
@@ -25,7 +25,8 @@ const defaultSessionID = "default"
 
 type NavigateTool struct{ mgr *BrowserManager }
 
-func (t *NavigateTool) Name() string { return "browser.navigate" }
+func (t *NavigateTool) Name() string        { return "browser.navigate" }
+func (t *NavigateTool) Scope() tools.ToolScope { return tools.ScopeCore }
 func (t *NavigateTool) Description() string {
 	return "Navigate to a URL and return page metadata. Subject to SSRF protection."
 }
@@ -102,8 +103,9 @@ func (t *NavigateTool) Execute(ctx context.Context, args map[string]any) *tools.
 
 type ClickTool struct{ mgr *BrowserManager }
 
-func (t *ClickTool) Name() string        { return "browser.click" }
-func (t *ClickTool) Description() string { return "Click an element matching a CSS selector." }
+func (t *ClickTool) Name() string           { return "browser.click" }
+func (t *ClickTool) Scope() tools.ToolScope  { return tools.ScopeCore }
+func (t *ClickTool) Description() string    { return "Click an element matching a CSS selector." }
 func (t *ClickTool) Parameters() map[string]any {
 	return map[string]any{
 		"type": "object",
@@ -143,7 +145,8 @@ func (t *ClickTool) Execute(ctx context.Context, args map[string]any) *tools.Too
 
 type TypeTool struct{ mgr *BrowserManager }
 
-func (t *TypeTool) Name() string { return "browser.type" }
+func (t *TypeTool) Name() string        { return "browser.type" }
+func (t *TypeTool) Scope() tools.ToolScope { return tools.ScopeCore }
 func (t *TypeTool) Description() string {
 	return "Type text into an input element matching a CSS selector."
 }
@@ -189,8 +192,9 @@ func (t *TypeTool) Execute(ctx context.Context, args map[string]any) *tools.Tool
 
 type ScreenshotTool struct{ mgr *BrowserManager }
 
-func (t *ScreenshotTool) Name() string        { return "browser.screenshot" }
-func (t *ScreenshotTool) Description() string { return "Capture a PNG screenshot of the current page." }
+func (t *ScreenshotTool) Name() string           { return "browser.screenshot" }
+func (t *ScreenshotTool) Scope() tools.ToolScope  { return tools.ScopeCore }
+func (t *ScreenshotTool) Description() string    { return "Capture a PNG screenshot of the current page." }
 func (t *ScreenshotTool) Parameters() map[string]any {
 	return map[string]any{
 		"type":       "object",
@@ -227,7 +231,8 @@ func (t *ScreenshotTool) Execute(ctx context.Context, args map[string]any) *tool
 
 type GetTextTool struct{ mgr *BrowserManager }
 
-func (t *GetTextTool) Name() string { return "browser.get_text" }
+func (t *GetTextTool) Name() string        { return "browser.get_text" }
+func (t *GetTextTool) Scope() tools.ToolScope { return tools.ScopeCore }
 func (t *GetTextTool) Description() string {
 	return "Get the inner text of an element matching a CSS selector."
 }
@@ -276,7 +281,8 @@ func (t *GetTextTool) Execute(ctx context.Context, args map[string]any) *tools.T
 
 type WaitTool struct{ mgr *BrowserManager }
 
-func (t *WaitTool) Name() string { return "browser.wait" }
+func (t *WaitTool) Name() string        { return "browser.wait" }
+func (t *WaitTool) Scope() tools.ToolScope { return tools.ScopeCore }
 func (t *WaitTool) Description() string {
 	return "Wait for an element matching a CSS selector to appear in the DOM."
 }
@@ -318,7 +324,8 @@ func (t *WaitTool) Execute(ctx context.Context, args map[string]any) *tools.Tool
 
 type EvaluateTool struct{ mgr *BrowserManager }
 
-func (t *EvaluateTool) Name() string { return "browser.evaluate" }
+func (t *EvaluateTool) Name() string        { return "browser.evaluate" }
+func (t *EvaluateTool) Scope() tools.ToolScope { return tools.ScopeCore }
 func (t *EvaluateTool) Description() string {
 	return "Execute JavaScript in the page context. Denied by default — must be explicitly allowed by policy."
 }

--- a/pkg/tools/browser/tools.go
+++ b/pkg/tools/browser/tools.go
@@ -25,7 +25,7 @@ const defaultSessionID = "default"
 
 type NavigateTool struct{ mgr *BrowserManager }
 
-func (t *NavigateTool) Name() string        { return "browser.navigate" }
+func (t *NavigateTool) Name() string           { return "browser.navigate" }
 func (t *NavigateTool) Scope() tools.ToolScope { return tools.ScopeCore }
 func (t *NavigateTool) Description() string {
 	return "Navigate to a URL and return page metadata. Subject to SSRF protection."
@@ -104,7 +104,7 @@ func (t *NavigateTool) Execute(ctx context.Context, args map[string]any) *tools.
 type ClickTool struct{ mgr *BrowserManager }
 
 func (t *ClickTool) Name() string           { return "browser.click" }
-func (t *ClickTool) Scope() tools.ToolScope  { return tools.ScopeCore }
+func (t *ClickTool) Scope() tools.ToolScope { return tools.ScopeCore }
 func (t *ClickTool) Description() string    { return "Click an element matching a CSS selector." }
 func (t *ClickTool) Parameters() map[string]any {
 	return map[string]any{
@@ -145,7 +145,7 @@ func (t *ClickTool) Execute(ctx context.Context, args map[string]any) *tools.Too
 
 type TypeTool struct{ mgr *BrowserManager }
 
-func (t *TypeTool) Name() string        { return "browser.type" }
+func (t *TypeTool) Name() string           { return "browser.type" }
 func (t *TypeTool) Scope() tools.ToolScope { return tools.ScopeCore }
 func (t *TypeTool) Description() string {
 	return "Type text into an input element matching a CSS selector."
@@ -193,7 +193,7 @@ func (t *TypeTool) Execute(ctx context.Context, args map[string]any) *tools.Tool
 type ScreenshotTool struct{ mgr *BrowserManager }
 
 func (t *ScreenshotTool) Name() string           { return "browser.screenshot" }
-func (t *ScreenshotTool) Scope() tools.ToolScope  { return tools.ScopeCore }
+func (t *ScreenshotTool) Scope() tools.ToolScope { return tools.ScopeCore }
 func (t *ScreenshotTool) Description() string    { return "Capture a PNG screenshot of the current page." }
 func (t *ScreenshotTool) Parameters() map[string]any {
 	return map[string]any{
@@ -231,7 +231,7 @@ func (t *ScreenshotTool) Execute(ctx context.Context, args map[string]any) *tool
 
 type GetTextTool struct{ mgr *BrowserManager }
 
-func (t *GetTextTool) Name() string        { return "browser.get_text" }
+func (t *GetTextTool) Name() string           { return "browser.get_text" }
 func (t *GetTextTool) Scope() tools.ToolScope { return tools.ScopeCore }
 func (t *GetTextTool) Description() string {
 	return "Get the inner text of an element matching a CSS selector."
@@ -281,7 +281,7 @@ func (t *GetTextTool) Execute(ctx context.Context, args map[string]any) *tools.T
 
 type WaitTool struct{ mgr *BrowserManager }
 
-func (t *WaitTool) Name() string        { return "browser.wait" }
+func (t *WaitTool) Name() string           { return "browser.wait" }
 func (t *WaitTool) Scope() tools.ToolScope { return tools.ScopeCore }
 func (t *WaitTool) Description() string {
 	return "Wait for an element matching a CSS selector to appear in the DOM."
@@ -324,7 +324,7 @@ func (t *WaitTool) Execute(ctx context.Context, args map[string]any) *tools.Tool
 
 type EvaluateTool struct{ mgr *BrowserManager }
 
-func (t *EvaluateTool) Name() string        { return "browser.evaluate" }
+func (t *EvaluateTool) Name() string           { return "browser.evaluate" }
 func (t *EvaluateTool) Scope() tools.ToolScope { return tools.ScopeCore }
 func (t *EvaluateTool) Description() string {
 	return "Execute JavaScript in the page context. Denied by default — must be explicitly allowed by policy."

--- a/pkg/tools/compositor.go
+++ b/pkg/tools/compositor.go
@@ -181,6 +181,93 @@ func (tc *ToolCompositor) ComposeAndRegister(agentID string) int {
 	return registered
 }
 
+// FilterToolsByVisibility returns the subset of tools that the given agent type
+// and tools config allow. It implements a 2-layer scope + visibility filter:
+//
+//  1. Scope gate: ScopeSystem → only system agents; ScopeCore → system+core
+//     agents (custom agents only if explicitly listed); ScopeGeneral → all.
+//  2. Explicit mode: if cfg.Mode == "explicit", only tools named in
+//     cfg.Visible pass (scope gate still applies as outer guard).
+//
+// MCP server-level filtering is not yet implemented; all MCP tools that pass
+// the scope and visibility gates are returned.
+//
+// The existing policy evaluator (allow/deny lists) remains a backstop run by
+// the caller — this function only handles scope + visibility.
+func FilterToolsByVisibility(allTools []Tool, agentType string, cfg *ToolVisibilityCfg) []Tool {
+	if cfg == nil {
+		cfg = &ToolVisibilityCfg{Mode: "inherit"}
+	}
+
+	// Warn on unrecognized mode — treated as "inherit" (scope-only filtering).
+	switch cfg.Mode {
+	case "explicit", "inherit", "":
+		// valid
+	default:
+		slog.Warn("FilterToolsByVisibility: unrecognized mode, treating as inherit",
+			"mode", cfg.Mode)
+	}
+
+	// Build a fast lookup set for explicit mode. Always build the set when
+	// mode is explicit, even if Visible is empty — an empty explicit list
+	// means zero tools (deny-by-default per CLAUDE.md hard constraint 6).
+	var visibleSet map[string]struct{}
+	if cfg.Mode == "explicit" {
+		visibleSet = make(map[string]struct{}, len(cfg.Visible))
+		for _, name := range cfg.Visible {
+			visibleSet[name] = struct{}{}
+		}
+	}
+
+	out := make([]Tool, 0, len(allTools))
+	for _, t := range allTools {
+		scope := t.Scope()
+
+		// Layer 1: scope gate based on agent type.
+		switch scope {
+		case ScopeSystem:
+			if agentType != "system" {
+				continue
+			}
+		case ScopeCore:
+			switch agentType {
+			case "system", "core":
+				// allowed by default
+			default:
+				// Custom agents only get core tools if explicitly listed.
+				if visibleSet == nil {
+					continue
+				}
+				if _, ok := visibleSet[t.Name()]; !ok {
+					continue
+				}
+			}
+		case ScopeGeneral:
+			// allowed for all agent types
+		default:
+			// Unknown or zero-value scope: deny by default (hard constraint 6).
+			continue
+		}
+
+		// Layer 2: explicit visibility filter.
+		if cfg.Mode == "explicit" {
+			if _, ok := visibleSet[t.Name()]; !ok {
+				continue
+			}
+		}
+
+		out = append(out, t)
+	}
+	return out
+}
+
+// ToolVisibilityCfg is a simplified view of the agent's tool visibility config,
+// used by FilterToolsByVisibility. Callers convert from config.AgentToolsCfg.
+type ToolVisibilityCfg struct {
+	Mode    string   // "inherit" or "explicit"
+	Visible []string // tool names when Mode == "explicit"
+}
+
 // mcpToolAdapter wraps a single MCP tool as a Tool, forwarding Execute calls
 // through the MCPCaller.  It is registered as a hidden tool (requires TTL
 // promotion before the agent loop exposes it).
@@ -209,6 +296,7 @@ func newMCPToolAdapter(serverName string, toolDef *mcp.Tool, caller MCPCaller) *
 func (a *mcpToolAdapter) Name() string               { return a.toolDef.Name }
 func (a *mcpToolAdapter) Description() string        { return a.toolDef.Description }
 func (a *mcpToolAdapter) Parameters() map[string]any { return a.params }
+func (a *mcpToolAdapter) Scope() ToolScope           { return ScopeGeneral }
 
 func (a *mcpToolAdapter) Execute(ctx context.Context, args map[string]any) *ToolResult {
 	result, err := a.caller.CallTool(ctx, a.serverName, a.toolDef.Name, args)

--- a/pkg/tools/compositor_test.go
+++ b/pkg/tools/compositor_test.go
@@ -338,6 +338,255 @@ func TestMCPToolAdapter_Execute_TextContent(t *testing.T) {
 	assert.Equal(t, "mcp result", result.ForLLM, "adapter must return MCPCaller text content")
 }
 
+// --- scopedMockTool — configurable-scope mock for FilterToolsByVisibility tests ---
+
+// scopedMockTool is a mock Tool with a user-supplied ToolScope for testing
+// FilterToolsByVisibility. The existing mockRegistryTool always returns
+// ScopeGeneral; this variant allows tests to configure each tool's scope.
+type scopedMockTool struct {
+	name  string
+	scope ToolScope
+}
+
+func (s *scopedMockTool) Name() string               { return s.name }
+func (s *scopedMockTool) Description() string        { return "scoped mock tool" }
+func (s *scopedMockTool) Parameters() map[string]any { return map[string]any{"type": "object"} }
+func (s *scopedMockTool) Scope() ToolScope           { return s.scope }
+func (s *scopedMockTool) Execute(_ context.Context, _ map[string]any) *ToolResult {
+	return SilentResult("ok")
+}
+
+// makeScopedTool is a helper to create a *scopedMockTool wrapped as Tool.
+func makeScopedTool(name string, scope ToolScope) Tool {
+	return &scopedMockTool{name: name, scope: scope}
+}
+
+// allScopeTools returns a representative tool set containing one tool per scope.
+func allScopeTools() []Tool {
+	return []Tool{
+		makeScopedTool("system.manage_agents", ScopeSystem),
+		makeScopedTool("exec", ScopeCore),
+		makeScopedTool("web_search", ScopeGeneral),
+	}
+}
+
+// --- FilterToolsByVisibility tests ---
+
+// TestFilterToolsByVisibility_InheritMode_SystemAgent verifies that a system
+// agent in inherit mode receives tools from every scope (system, core, general).
+//
+// BDD: Given a system agent with nil/inherit config
+//
+//	When FilterToolsByVisibility is called with all three scope tools
+//	Then all three tools are returned
+//
+// Traces to: compositor.go FilterToolsByVisibility — scope gate ScopeSystem passes for "system"
+func TestFilterToolsByVisibility_InheritMode_SystemAgent(t *testing.T) {
+	tools := allScopeTools()
+	cfg := &ToolVisibilityCfg{Mode: "inherit"}
+
+	got := FilterToolsByVisibility(tools, "system", cfg)
+
+	require.Len(t, got, 3, "system agent in inherit mode must see all three scope levels")
+
+	names := make(map[string]bool, len(got))
+	for _, t := range got {
+		names[t.Name()] = true
+	}
+	assert.True(t, names["system.manage_agents"], "system tool must pass for system agent")
+	assert.True(t, names["exec"], "core tool must pass for system agent")
+	assert.True(t, names["web_search"], "general tool must pass for system agent")
+}
+
+// TestFilterToolsByVisibility_InheritMode_CoreAgent verifies that a core agent
+// in inherit mode sees core and general tools but NOT system-scoped tools.
+//
+// BDD: Given a core agent with inherit config
+//
+//	When FilterToolsByVisibility is called with all three scope tools
+//	Then core and general tools pass; system tool does not
+//
+// Traces to: compositor.go FilterToolsByVisibility — ScopeSystem blocks "core" agentType
+func TestFilterToolsByVisibility_InheritMode_CoreAgent(t *testing.T) {
+	tools := allScopeTools()
+	cfg := &ToolVisibilityCfg{Mode: "inherit"}
+
+	got := FilterToolsByVisibility(tools, "core", cfg)
+
+	require.Len(t, got, 2, "core agent must see core+general but not system tools")
+
+	names := make(map[string]bool, len(got))
+	for _, t := range got {
+		names[t.Name()] = true
+	}
+	assert.False(t, names["system.manage_agents"], "system tool must NOT pass for core agent")
+	assert.True(t, names["exec"], "core tool must pass for core agent")
+	assert.True(t, names["web_search"], "general tool must pass for core agent")
+}
+
+// TestFilterToolsByVisibility_InheritMode_CustomAgent verifies that a custom
+// agent in inherit mode sees only general-scoped tools.
+//
+// BDD: Given a custom agent with inherit config
+//
+//	When FilterToolsByVisibility is called with all three scope tools
+//	Then only general tool passes
+//
+// Traces to: compositor.go FilterToolsByVisibility — ScopeCore blocks "custom" without visibleSet
+func TestFilterToolsByVisibility_InheritMode_CustomAgent(t *testing.T) {
+	tools := allScopeTools()
+	cfg := &ToolVisibilityCfg{Mode: "inherit"}
+
+	got := FilterToolsByVisibility(tools, "custom", cfg)
+
+	require.Len(t, got, 1, "custom agent must see only general tools in inherit mode")
+	assert.Equal(t, "web_search", got[0].Name(), "only the general-scope tool must pass")
+}
+
+// TestFilterToolsByVisibility_ExplicitMode_CustomAgent verifies that a custom
+// agent with explicit mode sees exactly the named tools, including a core-scope
+// tool if it is listed in Visible (per the spec's "custom agents only if
+// explicitly listed" rule).
+//
+// BDD: Given a custom agent with explicit mode and Visible=["exec","web_search"]
+//
+//	When FilterToolsByVisibility is called
+//	Then both "exec" (core) and "web_search" (general) pass; system tool does not
+//
+// Traces to: compositor.go FilterToolsByVisibility — ScopeCore custom path + explicit mode layer
+func TestFilterToolsByVisibility_ExplicitMode_CustomAgent(t *testing.T) {
+	tools := allScopeTools()
+	cfg := &ToolVisibilityCfg{
+		Mode:    "explicit",
+		Visible: []string{"exec", "web_search"},
+	}
+
+	got := FilterToolsByVisibility(tools, "custom", cfg)
+
+	require.Len(t, got, 2, "explicit mode must return exactly the two listed tools")
+
+	names := make(map[string]bool, len(got))
+	for _, t := range got {
+		names[t.Name()] = true
+	}
+	assert.False(t, names["system.manage_agents"], "system tool must not pass even when agent is custom+explicit")
+	assert.True(t, names["exec"], "core tool must pass when explicitly listed for custom agent")
+	assert.True(t, names["web_search"], "general tool must pass when explicitly listed")
+}
+
+// TestFilterToolsByVisibility_ExplicitMode_CannotEscapeScope verifies that a
+// custom agent cannot gain access to system-scoped tools by listing them in the
+// explicit Visible set — the scope gate is an outer guard that cannot be bypassed.
+//
+// BDD: Given a custom agent with explicit mode listing a system-scoped tool
+//
+//	When FilterToolsByVisibility is called
+//	Then the system tool is still blocked (scope gate fires first)
+//
+// Traces to: compositor.go FilterToolsByVisibility — scope gate runs before explicit layer
+func TestFilterToolsByVisibility_ExplicitMode_CannotEscapeScope(t *testing.T) {
+	tools := []Tool{
+		makeScopedTool("system.manage_agents", ScopeSystem),
+		makeScopedTool("web_search", ScopeGeneral),
+	}
+	cfg := &ToolVisibilityCfg{
+		Mode:    "explicit",
+		Visible: []string{"system.manage_agents", "web_search"},
+	}
+
+	got := FilterToolsByVisibility(tools, "custom", cfg)
+
+	// Only the general tool may pass; system is blocked by the scope gate.
+	require.Len(t, got, 1, "system-scoped tool must be blocked even when listed in explicit Visible")
+	assert.Equal(t, "web_search", got[0].Name())
+}
+
+// TestFilterToolsByVisibility_NilConfig verifies that passing a nil cfg
+// defaults to inherit mode so the function does not panic.
+//
+// BDD: Given a nil ToolVisibilityCfg
+//
+//	When FilterToolsByVisibility is called for a custom agent
+//	Then it behaves identically to inherit mode
+//
+// Traces to: compositor.go FilterToolsByVisibility — nil cfg guard at top of function
+func TestFilterToolsByVisibility_NilConfig(t *testing.T) {
+	tools := allScopeTools()
+
+	// Must not panic.
+	got := FilterToolsByVisibility(tools, "custom", nil)
+
+	// Inherit mode for custom: only general passes.
+	require.Len(t, got, 1, "nil config must behave as inherit mode")
+	assert.Equal(t, "web_search", got[0].Name())
+}
+
+// TestFilterToolsByVisibility_EmptyVisibleList verifies that explicit mode with
+// an empty Visible list returns zero tools for non-system agents (nothing is
+// explicitly named, so nothing can pass the explicit layer).
+//
+// BDD: Given a custom agent with explicit mode and empty Visible list
+//
+//	When FilterToolsByVisibility is called
+//	Then no tools are returned
+//
+// Traces to: compositor.go FilterToolsByVisibility — explicit mode with nil visibleSet
+func TestFilterToolsByVisibility_EmptyVisibleList(t *testing.T) {
+	tools := allScopeTools()
+	cfg := &ToolVisibilityCfg{
+		Mode:    "explicit",
+		Visible: []string{}, // intentionally empty
+	}
+
+	got := FilterToolsByVisibility(tools, "custom", cfg)
+
+	// Explicit mode with empty Visible list: deny-by-default (CLAUDE.md hard constraint 6).
+	// No tools should pass — the empty visibleSet blocks everything in Layer 2.
+	require.Len(t, got, 0, "explicit mode with empty Visible must return zero tools")
+}
+
+// TestFilterToolsByVisibility_ExplicitMode_CoreAgent verifies that a core agent
+// with explicit mode receives only the tools named in the Visible list, and that
+// system-scoped tools are never returned regardless of the explicit list.
+//
+// BDD: Given a mix of system, core, and general tools,
+//
+//	When FilterToolsByVisibility is called with agentType="core", Mode="explicit",
+//	and Visible=["web_search"],
+//	Then only "web_search" is returned (the explicit list narrows the core agent's view),
+//	And system tools are never returned.
+//
+// Traces to: compositor.go FilterToolsByVisibility — explicit mode layer 2 applies to core agents;
+// scope gate layer 1 blocks system tools regardless of mode (PR #41 Per-Agent Tool Visibility).
+func TestFilterToolsByVisibility_ExplicitMode_CoreAgent(t *testing.T) {
+	// Given: one tool per scope (system, core, general)
+	input := allScopeTools()
+	// system.manage_agents (ScopeSystem), exec (ScopeCore), web_search (ScopeGeneral)
+
+	cfg := &ToolVisibilityCfg{
+		Mode:    "explicit",
+		Visible: []string{"web_search"},
+	}
+
+	// When: core agent with explicit mode listing only "web_search"
+	got := FilterToolsByVisibility(input, "core", cfg)
+
+	// Then: only web_search is returned
+	require.Len(t, got, 1, "explicit mode must filter core agent to exactly the listed tool")
+	assert.Equal(t, "web_search", got[0].Name(),
+		"explicit visible list must be the only tool returned")
+
+	// Then: system tool is never returned for a core agent regardless of mode
+	names := make(map[string]bool, len(got))
+	for _, t := range got {
+		names[t.Name()] = true
+	}
+	assert.False(t, names["system.manage_agents"],
+		"system-scoped tool must NEVER be returned for a core agent (scope gate blocks it)")
+	assert.False(t, names["exec"],
+		"core-scoped tool not in explicit Visible must be filtered out")
+}
+
 // TestMCPContentText_ConcatenatesTextContent verifies that mcpContentText
 // joins TextContent entries without a separator and silently skips non-text items.
 //

--- a/pkg/tools/cron.go
+++ b/pkg/tools/cron.go
@@ -73,6 +73,9 @@ func (t *CronTool) Description() string {
 	return "Schedule reminders, tasks, or system commands. IMPORTANT: When user asks to be reminded or scheduled, you MUST call this tool. Use 'at_seconds' for one-time reminders (e.g., 'remind me in 10 minutes' → at_seconds=600). Use 'every_seconds' ONLY for recurring tasks (e.g., 'every 2 hours' → every_seconds=7200). Use 'cron_expr' for complex recurring schedules. Use 'command' to execute shell commands directly."
 }
 
+// Scope returns the tool's privilege level.
+func (t *CronTool) Scope() ToolScope { return ScopeGeneral }
+
 // Parameters returns the tool parameters schema
 func (t *CronTool) Parameters() map[string]any {
 	return map[string]any{

--- a/pkg/tools/edit.go
+++ b/pkg/tools/edit.go
@@ -32,6 +32,8 @@ func (t *EditFileTool) Description() string {
 	return "Edit a file by replacing old_text with new_text. The old_text must exist exactly in the file."
 }
 
+func (t *EditFileTool) Scope() ToolScope { return ScopeCore }
+
 func (t *EditFileTool) Parameters() map[string]any {
 	return map[string]any{
 		"type": "object",
@@ -94,6 +96,8 @@ func (t *AppendFileTool) Name() string {
 func (t *AppendFileTool) Description() string {
 	return "Append content to the end of a file"
 }
+
+func (t *AppendFileTool) Scope() ToolScope { return ScopeCore }
 
 func (t *AppendFileTool) Parameters() map[string]any {
 	return map[string]any{

--- a/pkg/tools/filesystem.go
+++ b/pkg/tools/filesystem.go
@@ -307,6 +307,8 @@ func (t *ReadFileTool) Description() string {
 	return "Read the contents of a file. Supports pagination via `offset` and `length`."
 }
 
+func (t *ReadFileTool) Scope() ToolScope { return ScopeGeneral }
+
 func (t *ReadFileTool) Parameters() map[string]any {
 	return map[string]any{
 		"type": "object",
@@ -536,6 +538,8 @@ func (t *WriteFileTool) Description() string {
 	return "Write content to a file. If the file already exists, you must set overwrite=true to replace it."
 }
 
+func (t *WriteFileTool) Scope() ToolScope { return ScopeCore }
+
 func (t *WriteFileTool) Parameters() map[string]any {
 	return map[string]any{
 		"type": "object",
@@ -604,6 +608,8 @@ func (t *ListDirTool) Name() string {
 func (t *ListDirTool) Description() string {
 	return "List files and directories in a path"
 }
+
+func (t *ListDirTool) Scope() ToolScope { return ScopeGeneral }
 
 func (t *ListDirTool) Parameters() map[string]any {
 	return map[string]any{

--- a/pkg/tools/i2c.go
+++ b/pkg/tools/i2c.go
@@ -24,6 +24,8 @@ func (t *I2CTool) Description() string {
 	return "Interact with I2C bus devices for reading sensors and controlling peripherals. Actions: detect (list buses), scan (find devices on a bus), read (read bytes from device), write (send bytes to device). Linux only."
 }
 
+func (t *I2CTool) Scope() ToolScope { return ScopeCore }
+
 func (t *I2CTool) Parameters() map[string]any {
 	return map[string]any{
 		"type": "object",

--- a/pkg/tools/mcp_tool.go
+++ b/pkg/tools/mcp_tool.go
@@ -143,6 +143,10 @@ func (t *MCPTool) Description() string {
 	return fmt.Sprintf("[MCP:%s] %s", t.serverName, desc)
 }
 
+// Scope returns ScopeGeneral — MCP tools are treated as general-purpose tools
+// and are available to all agent types (subject to per-agent MCP server binding config).
+func (t *MCPTool) Scope() ToolScope { return ScopeGeneral }
+
 // Parameters returns the tool parameters schema
 func (t *MCPTool) Parameters() map[string]any {
 	// The InputSchema is already a JSON Schema object

--- a/pkg/tools/message.go
+++ b/pkg/tools/message.go
@@ -25,6 +25,8 @@ func (t *MessageTool) Description() string {
 	return "Send a message to user on a chat channel. Use this when you want to communicate something."
 }
 
+func (t *MessageTool) Scope() ToolScope { return ScopeGeneral }
+
 func (t *MessageTool) Parameters() map[string]any {
 	return map[string]any{
 		"type": "object",

--- a/pkg/tools/registry_test.go
+++ b/pkg/tools/registry_test.go
@@ -25,6 +25,7 @@ type mockRegistryTool struct {
 func (m *mockRegistryTool) Name() string               { return m.name }
 func (m *mockRegistryTool) Description() string        { return m.desc }
 func (m *mockRegistryTool) Parameters() map[string]any { return m.params }
+func (m *mockRegistryTool) Scope() ToolScope           { return ScopeGeneral }
 func (m *mockRegistryTool) Execute(_ context.Context, _ map[string]any) *ToolResult {
 	return m.result
 }
@@ -473,6 +474,7 @@ type mockPanicTool struct {
 func (m *mockPanicTool) Name() string               { return m.name }
 func (m *mockPanicTool) Description() string        { return "a tool that panics" }
 func (m *mockPanicTool) Parameters() map[string]any { return map[string]any{"type": "object"} }
+func (m *mockPanicTool) Scope() ToolScope           { return ScopeGeneral }
 func (m *mockPanicTool) Execute(_ context.Context, _ map[string]any) *ToolResult {
 	panic(m.panicValue)
 }
@@ -485,6 +487,7 @@ type mockNilResultTool struct {
 func (m *mockNilResultTool) Name() string               { return m.name }
 func (m *mockNilResultTool) Description() string        { return "a tool that returns nil" }
 func (m *mockNilResultTool) Parameters() map[string]any { return map[string]any{"type": "object"} }
+func (m *mockNilResultTool) Scope() ToolScope           { return ScopeGeneral }
 func (m *mockNilResultTool) Execute(_ context.Context, _ map[string]any) *ToolResult {
 	return nil
 }

--- a/pkg/tools/search_tool.go
+++ b/pkg/tools/search_tool.go
@@ -34,6 +34,8 @@ func (t *RegexSearchTool) Description() string {
 	return "Search available hidden tools on-demand using a regex pattern. Returns JSON schemas of discovered tools."
 }
 
+func (t *RegexSearchTool) Scope() ToolScope { return ScopeGeneral }
+
 func (t *RegexSearchTool) Parameters() map[string]any {
 	return map[string]any{
 		"type": "object",
@@ -94,6 +96,8 @@ func (t *BM25SearchTool) Name() string {
 func (t *BM25SearchTool) Description() string {
 	return "Search available hidden tools on-demand using natural language query describing the action you need to perform. Returns JSON schemas of discovered tools."
 }
+
+func (t *BM25SearchTool) Scope() ToolScope { return ScopeGeneral }
 
 func (t *BM25SearchTool) Parameters() map[string]any {
 	return map[string]any{

--- a/pkg/tools/search_tools_test.go
+++ b/pkg/tools/search_tools_test.go
@@ -19,6 +19,7 @@ func (m *mockSearchableTool) Parameters() map[string]any {
 	return map[string]any{"type": "object"}
 }
 
+func (m *mockSearchableTool) Scope() ToolScope { return ScopeGeneral }
 func (m *mockSearchableTool) Execute(ctx context.Context, args map[string]any) *ToolResult {
 	return SilentResult("mock executed: " + m.name)
 }

--- a/pkg/tools/send_file.go
+++ b/pkg/tools/send_file.go
@@ -55,6 +55,7 @@ func (t *SendFileTool) Name() string { return "send_file" }
 func (t *SendFileTool) Description() string {
 	return "Send a local file (image, document, etc.) to the user on the current chat channel."
 }
+func (t *SendFileTool) Scope() ToolScope { return ScopeCore }
 
 func (t *SendFileTool) Parameters() map[string]any {
 	return map[string]any{

--- a/pkg/tools/shell.go
+++ b/pkg/tools/shell.go
@@ -317,6 +317,8 @@ func (t *ExecTool) Name() string {
 	return "exec"
 }
 
+func (t *ExecTool) Scope() ToolScope { return ScopeCore }
+
 func (t *ExecTool) Description() string {
 	return `Execute shell commands. Use background=true for long-running commands (returns sessionId). Use pty=true for interactive commands (can combine with background=true). Use poll/read/write/send-keys/kill with sessionId to manage background sessions. Sessions auto-cleanup 30 minutes after process exits; use kill to terminate early. Output buffer limit: 1MB.`
 }

--- a/pkg/tools/skills_install.go
+++ b/pkg/tools/skills_install.go
@@ -43,6 +43,8 @@ func (t *InstallSkillTool) Description() string {
 	return "Install a skill from a registry by slug. Downloads and extracts the skill into the workspace. Use find_skills first to discover available skills."
 }
 
+func (t *InstallSkillTool) Scope() ToolScope { return ScopeGeneral }
+
 func (t *InstallSkillTool) Parameters() map[string]any {
 	return map[string]any{
 		"type": "object",

--- a/pkg/tools/skills_remove.go
+++ b/pkg/tools/skills_remove.go
@@ -26,6 +26,8 @@ func (t *RemoveSkillTool) Description() string {
 	return "Remove an installed skill by name. The skill's directory is deleted and it becomes unavailable to the agent."
 }
 
+func (t *RemoveSkillTool) Scope() ToolScope { return ScopeGeneral }
+
 func (t *RemoveSkillTool) Parameters() map[string]any {
 	return map[string]any{
 		"type": "object",

--- a/pkg/tools/skills_search.go
+++ b/pkg/tools/skills_search.go
@@ -33,6 +33,8 @@ func (t *FindSkillsTool) Description() string {
 	return "Search for installable skills from skill registries. Returns skill slugs, descriptions, versions, and relevance scores. Use this to discover skills before installing them with install_skill."
 }
 
+func (t *FindSkillsTool) Scope() ToolScope { return ScopeGeneral }
+
 func (t *FindSkillsTool) Parameters() map[string]any {
 	return map[string]any{
 		"type": "object",

--- a/pkg/tools/spawn.go
+++ b/pkg/tools/spawn.go
@@ -42,6 +42,8 @@ func (t *SpawnTool) Description() string {
 	return "Spawn a subagent to handle a task in the background. Use this for complex or time-consuming tasks that can run independently. The subagent will complete the task and report back when done."
 }
 
+func (t *SpawnTool) Scope() ToolScope { return ScopeCore }
+
 func (t *SpawnTool) Parameters() map[string]any {
 	return map[string]any{
 		"type": "object",

--- a/pkg/tools/spawn_status.go
+++ b/pkg/tools/spawn_status.go
@@ -34,6 +34,8 @@ func (t *SpawnStatusTool) Description() string {
 		"(e.g. direct programmatic calls via Execute)."
 }
 
+func (t *SpawnStatusTool) Scope() ToolScope { return ScopeCore }
+
 func (t *SpawnStatusTool) Parameters() map[string]any {
 	return map[string]any{
 		"type": "object",

--- a/pkg/tools/spi.go
+++ b/pkg/tools/spi.go
@@ -24,6 +24,8 @@ func (t *SPITool) Description() string {
 	return "Interact with SPI bus devices for high-speed peripheral communication. Actions: list (find SPI devices), transfer (full-duplex send/receive), read (receive bytes). Linux only."
 }
 
+func (t *SPITool) Scope() ToolScope { return ScopeCore }
+
 func (t *SPITool) Parameters() map[string]any {
 	return map[string]any{
 		"type": "object",

--- a/pkg/tools/subagent.go
+++ b/pkg/tools/subagent.go
@@ -334,6 +334,8 @@ func (t *SubagentTool) Description() string {
 	return "Execute a subagent task synchronously and return the result. Use this for delegating specific tasks to an independent agent instance. Returns execution summary to user and full details to LLM."
 }
 
+func (t *SubagentTool) Scope() ToolScope { return ScopeCore }
+
 func (t *SubagentTool) Parameters() map[string]any {
 	return map[string]any{
 		"type": "object",

--- a/pkg/tools/task.go
+++ b/pkg/tools/task.go
@@ -19,7 +19,7 @@ func NewTaskListTool(store *taskstore.TaskStore) *TaskListTool {
 	return &TaskListTool{store: store}
 }
 
-func (t *TaskListTool) Name() string   { return "task_list" }
+func (t *TaskListTool) Name() string     { return "task_list" }
 func (t *TaskListTool) Scope() ToolScope { return ScopeGeneral }
 
 func (t *TaskListTool) Description() string {
@@ -88,7 +88,7 @@ func (t *TaskCreateTool) SetDelegateChecker(fn func(targetAgentID string) bool) 
 	t.delegateCheck = fn
 }
 
-func (t *TaskCreateTool) Name() string   { return "task_create" }
+func (t *TaskCreateTool) Name() string     { return "task_create" }
 func (t *TaskCreateTool) Scope() ToolScope { return ScopeGeneral }
 
 func (t *TaskCreateTool) Description() string {
@@ -217,7 +217,7 @@ func (t *TaskUpdateTool) SetOnComplete(fn func(*taskstore.TaskEntity)) {
 	t.onComplete = fn
 }
 
-func (t *TaskUpdateTool) Name() string   { return "task_update" }
+func (t *TaskUpdateTool) Name() string     { return "task_update" }
 func (t *TaskUpdateTool) Scope() ToolScope { return ScopeGeneral }
 
 func (t *TaskUpdateTool) Description() string {
@@ -324,7 +324,7 @@ func NewTaskDeleteTool(store *taskstore.TaskStore) *TaskDeleteTool {
 	return &TaskDeleteTool{store: store}
 }
 
-func (t *TaskDeleteTool) Name() string   { return "task_delete" }
+func (t *TaskDeleteTool) Name() string     { return "task_delete" }
 func (t *TaskDeleteTool) Scope() ToolScope { return ScopeGeneral }
 func (t *TaskDeleteTool) Description() string {
 	return "Delete a task by ID. Only use when explicitly asked to remove a task."
@@ -370,7 +370,7 @@ func NewAgentListTool(lister func() []AgentInfo) *AgentListTool {
 	return &AgentListTool{listAgents: lister}
 }
 
-func (t *AgentListTool) Name() string   { return "agent_list" }
+func (t *AgentListTool) Name() string     { return "agent_list" }
 func (t *AgentListTool) Scope() ToolScope { return ScopeGeneral }
 func (t *AgentListTool) Description() string {
 	return "List all available agents with their IDs and names. Use this to resolve agent names to IDs before delegating tasks."

--- a/pkg/tools/task.go
+++ b/pkg/tools/task.go
@@ -19,7 +19,8 @@ func NewTaskListTool(store *taskstore.TaskStore) *TaskListTool {
 	return &TaskListTool{store: store}
 }
 
-func (t *TaskListTool) Name() string { return "task_list" }
+func (t *TaskListTool) Name() string   { return "task_list" }
+func (t *TaskListTool) Scope() ToolScope { return ScopeGeneral }
 
 func (t *TaskListTool) Description() string {
 	return "List tasks. Use role='assignee' for tasks assigned to you, role='delegator' for tasks you created for other agents."
@@ -87,7 +88,8 @@ func (t *TaskCreateTool) SetDelegateChecker(fn func(targetAgentID string) bool) 
 	t.delegateCheck = fn
 }
 
-func (t *TaskCreateTool) Name() string { return "task_create" }
+func (t *TaskCreateTool) Name() string   { return "task_create" }
+func (t *TaskCreateTool) Scope() ToolScope { return ScopeGeneral }
 
 func (t *TaskCreateTool) Description() string {
 	return "Create a task and assign it to an agent for execution."
@@ -215,7 +217,8 @@ func (t *TaskUpdateTool) SetOnComplete(fn func(*taskstore.TaskEntity)) {
 	t.onComplete = fn
 }
 
-func (t *TaskUpdateTool) Name() string { return "task_update" }
+func (t *TaskUpdateTool) Name() string   { return "task_update" }
+func (t *TaskUpdateTool) Scope() ToolScope { return ScopeGeneral }
 
 func (t *TaskUpdateTool) Description() string {
 	return "Update status of a task assigned to you. Mark as running, completed, or failed."
@@ -321,7 +324,8 @@ func NewTaskDeleteTool(store *taskstore.TaskStore) *TaskDeleteTool {
 	return &TaskDeleteTool{store: store}
 }
 
-func (t *TaskDeleteTool) Name() string { return "task_delete" }
+func (t *TaskDeleteTool) Name() string   { return "task_delete" }
+func (t *TaskDeleteTool) Scope() ToolScope { return ScopeGeneral }
 func (t *TaskDeleteTool) Description() string {
 	return "Delete a task by ID. Only use when explicitly asked to remove a task."
 }
@@ -366,7 +370,8 @@ func NewAgentListTool(lister func() []AgentInfo) *AgentListTool {
 	return &AgentListTool{listAgents: lister}
 }
 
-func (t *AgentListTool) Name() string { return "agent_list" }
+func (t *AgentListTool) Name() string   { return "agent_list" }
+func (t *AgentListTool) Scope() ToolScope { return ScopeGeneral }
 func (t *AgentListTool) Description() string {
 	return "List all available agents with their IDs and names. Use this to resolve agent names to IDs before delegating tasks."
 }

--- a/pkg/tools/web.go
+++ b/pkg/tools/web.go
@@ -1025,6 +1025,8 @@ func (t *WebSearchTool) Description() string {
 	return "Search the web for current information. Supports query, count, and an optional temporal range filter. Returns titles, URLs, and snippets from search results."
 }
 
+func (t *WebSearchTool) Scope() ToolScope { return ScopeGeneral }
+
 func (t *WebSearchTool) Parameters() map[string]any {
 	return map[string]any{
 		"type": "object",
@@ -1178,6 +1180,8 @@ func (t *WebFetchTool) Name() string {
 func (t *WebFetchTool) Description() string {
 	return "Fetch a URL and extract readable content (HTML to text). Use this to get weather info, news, articles, or any web content."
 }
+
+func (t *WebFetchTool) Scope() ToolScope { return ScopeGeneral }
 
 func (t *WebFetchTool) Parameters() map[string]any {
 	return map[string]any{

--- a/src/components/agents/AgentProfile.tsx
+++ b/src/components/agents/AgentProfile.tsx
@@ -29,6 +29,8 @@ import { SmartSelect } from '@/components/ui/smart-select'
 import { ModelSelector } from '@/components/ui/model-selector'
 import { Switch } from '@/components/ui/switch'
 import { Separator } from '@/components/ui/separator'
+import { Accordion, AccordionItem, AccordionTrigger, AccordionContent } from '@/components/ui/accordion'
+import { ToolsAndPermissions } from './ToolsAndPermissions'
 import {
   fetchAgent,
   updateAgent,
@@ -37,6 +39,7 @@ import {
   fetchActivity,
   type AgentSession,
   type ActivityEvent,
+  type AgentToolsCfg,
 } from '@/lib/api'
 import { useUiStore } from '@/store/ui'
 import { AVATAR_COLORS } from '@/lib/constants'
@@ -138,6 +141,9 @@ export function AgentProfile({ agentId }: AgentProfileProps) {
   const [toolFeedback, setToolFeedback] = useState(false)
   const [heartbeatEnabled, setHeartbeatEnabled] = useState(false)
   const [heartbeatInterval, setHeartbeatInterval] = useState(30)
+  const [toolsCfg, setToolsCfg] = useState<AgentToolsCfg>({
+    builtin: { mode: 'inherit' },
+  })
 
   useEffect(() => {
     if (!agent) return
@@ -317,7 +323,7 @@ export function AgentProfile({ agentId }: AgentProfileProps) {
 
   return (
     <div className="absolute inset-0 overflow-y-auto">
-    <div className="max-w-2xl mx-auto px-4 py-6 space-y-6">
+    <div className="max-w-2xl mx-auto px-4 py-6 space-y-4">
       {/* Header */}
       <div className="flex items-center gap-3">
         <Button
@@ -362,459 +368,468 @@ export function AgentProfile({ agentId }: AgentProfileProps) {
 
       <Separator />
 
-      {/* Identity section */}
-      {canEdit && (
-        <>
-          <section className="space-y-3">
-            <h2 className="font-headline font-bold text-sm text-[var(--color-secondary)]">Identity</h2>
-            <div className="space-y-2">
-              <Input
-                value={name}
-                onChange={(e) => { markDirty(); setName(e.target.value) }}
-                placeholder="Agent name"
-                className="text-sm"
-              />
-              <Textarea
-                value={description}
-                onChange={(e) => { markDirty(); setDescription(e.target.value) }}
-                placeholder="Short description of this agent's purpose"
-                rows={2}
-                className="text-sm resize-none"
-              />
-            </div>
-
-            {/* Color picker */}
-            <div className="space-y-1.5">
-              <p className="text-xs text-[var(--color-muted)]">Avatar color</p>
-              <div className="flex gap-2">
-                {AVATAR_COLORS.map((color) => (
-                  <button
-                    key={color}
-                    type="button"
-                    onClick={() => { markDirty(); setSelectedColor(color) }}
-                    className="w-7 h-7 rounded-full transition-transform hover:scale-110 focus:outline-none focus:ring-2 focus:ring-[var(--color-accent)] focus:ring-offset-1 focus:ring-offset-[var(--color-primary)]"
-                    style={{
-                      backgroundColor: color,
-                      boxShadow: selectedColor === color ? `0 0 0 2px var(--color-primary), 0 0 0 4px ${color}` : undefined,
-                    }}
-                    aria-label={color}
-                  />
-                ))}
-              </div>
-            </div>
-
-            {/* Icon picker */}
-            <div className="space-y-1.5">
-              <p className="text-xs text-[var(--color-muted)]">Avatar icon</p>
-              <SmartSelect
-                value={selectedIcon}
-                onValueChange={(v) => { markDirty(); setSelectedIcon(v as IconName) }}
-                triggerClassName="w-48"
-                items={ICON_OPTIONS.map(({ name: iconName }) => ({ value: iconName, label: iconName }))}
-              />
-            </div>
-          </section>
-          <Separator />
-        </>
-      )}
-
-      {/* Model section */}
-      <section className="space-y-3">
-        <h2 className="font-headline font-bold text-sm text-[var(--color-secondary)]">Model</h2>
-        {providersError && (
-          <p className="text-xs text-[var(--color-warning)]">
-            Could not load providers. You can still enter a model slug manually.
-          </p>
-        )}
-        <ModelSelector
-          models={availableModels}
-          value={model}
-          onChange={(v) => { markDirty(); setModel(v) }}
-          placeholder="Provider default"
-          disabled={!canEdit}
-        />
-
-        {/* Fallback models */}
+      <Accordion
+        type="multiple"
+        defaultValue={['identity']}
+        className="rounded-lg border border-[var(--color-border)] divide-y divide-[var(--color-border)] overflow-hidden"
+      >
+        {/* Identity — default OPEN */}
         {canEdit && (
-          <div className="space-y-1.5">
-            <p className="text-xs text-[var(--color-muted)]">Fallback models (tried in order if primary fails)</p>
-            <div className="flex flex-wrap gap-1.5 p-2 rounded-md border border-[var(--color-border)] bg-[var(--color-surface-1)] min-h-[36px]">
-              {fallbackModels.map((m) => (
-                <span
-                  key={m}
-                  className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-[10px] font-mono bg-[var(--color-surface-2)] text-[var(--color-secondary)] border border-[var(--color-border)]"
-                >
-                  {m}
-                  <button
-                    type="button"
-                    onClick={() => setFallbackModels((prev) => prev.filter((x) => x !== m))}
-                    className="text-[var(--color-muted)] hover:text-[var(--color-error)] transition-colors"
-                  >
-                    <X size={10} />
-                  </button>
-                </span>
-              ))}
-              <input
-                value={fallbackInput}
-                onChange={(e) => { markDirty(); setFallbackInput(e.target.value) }}
-                onKeyDown={handleFallbackKeyDown}
-                onBlur={addFallbackModel}
-                placeholder={fallbackModels.length === 0 ? 'Type a model name, press Enter' : ''}
-                className="flex-1 min-w-[160px] bg-transparent text-xs text-[var(--color-secondary)] outline-none placeholder:text-[var(--color-muted)]"
-              />
-            </div>
-          </div>
-        )}
-
-        {/* Advanced model params */}
-        {canEdit && (
-          <div className="rounded-md border border-[var(--color-border)] bg-[var(--color-surface-1)] overflow-hidden">
-            <button
-              type="button"
-              onClick={() => setAdvancedOpen((o) => !o)}
-              className="flex items-center justify-between w-full px-3 py-2.5 text-sm font-medium text-[var(--color-secondary)] hover:text-[var(--color-accent)] transition-colors"
-            >
-              <span>Advanced parameters</span>
-              {advancedOpen ? <CaretUp size={13} /> : <CaretDown size={13} />}
-            </button>
-            {advancedOpen && (
-              <div className="px-3 pb-3 space-y-4 border-t border-[var(--color-border)]">
-                <RangeField
-                  label="Temperature"
-                  value={temperature}
-                  min={0}
-                  max={2}
-                  step={0.05}
-                  onChange={(v) => { markDirty(); setTemperature(v) }}
-                  format={(v) => v.toFixed(2)}
-                />
-                <RangeField
-                  label="Max tokens"
-                  value={maxTokens}
-                  min={256}
-                  max={32768}
-                  step={256}
-                  onChange={(v) => { markDirty(); setMaxTokens(v) }}
-                  format={(v) => v.toLocaleString()}
-                />
-                <RangeField
-                  label="Top P"
-                  value={topP}
-                  min={0}
-                  max={1}
-                  step={0.01}
-                  onChange={(v) => { markDirty(); setTopP(v) }}
-                  format={(v) => v.toFixed(2)}
-                />
-              </div>
-            )}
-          </div>
-        )}
-      </section>
-
-      {/* SOUL.md editor */}
-      {canEdit && (
-        <>
-          <Separator />
-          <section className="space-y-3">
-            <div className="flex items-center gap-2">
-              <Scroll size={14} className="text-[var(--color-accent)]" />
-              <h2 className="font-headline font-bold text-sm text-[var(--color-secondary)]">SOUL.md</h2>
-            </div>
-            <p className="text-xs text-[var(--color-muted)]">
-              The agent's personality and system prompt — defines who the agent is and how it behaves.
-            </p>
-            <Textarea
-              value={soul}
-              onChange={(e) => { markDirty(); setSoul(e.target.value) }}
-              placeholder={"# Soul\n\nDefine this agent's personality, expertise, and behavioral guidelines..."}
-              rows={8}
-              className="text-xs font-mono resize-none"
-            />
-            <SaveAllButton onUpload={setSoul} />
-          </section>
-        </>
-      )}
-
-      {/* Additional Instructions editor */}
-      {canEdit && (
-        <>
-          <Separator />
-          <section className="space-y-3">
-            <div className="flex items-center gap-2">
-              <NotePencil size={14} className="text-[var(--color-accent)]" />
-              <h2 className="font-headline font-bold text-sm text-[var(--color-secondary)]">Additional Instructions</h2>
-            </div>
-            <p className="text-xs text-[var(--color-muted)]">
-              Extra instructions appended to the agent's context — task-specific guidance, constraints, or domain knowledge.
-            </p>
-            <Textarea
-              value={instructions}
-              onChange={(e) => { markDirty(); setInstructions(e.target.value) }}
-              placeholder="Add specific instructions, constraints, or domain knowledge..."
-              rows={6}
-              className="text-xs font-mono resize-none"
-            />
-            <SaveAllButton onUpload={setInstructions} />
-          </section>
-        </>
-      )}
-
-      {/* HEARTBEAT.md editor */}
-      {canEdit && (
-        <>
-          <Separator />
-          <section className="space-y-3">
-            <h2 className="font-headline font-bold text-sm text-[var(--color-secondary)]">HEARTBEAT.md</h2>
-            <p className="text-xs text-[var(--color-muted)]">
-              The agent's persistent context — goals, preferences, and working memory.
-            </p>
-            <div className="rounded-lg border border-[var(--color-border)] bg-[var(--color-surface-1)] p-3 space-y-3">
-              <div className="flex items-center justify-between">
-                <div>
-                  <p className="text-sm text-[var(--color-secondary)]">Enable heartbeat</p>
-                  <p className="text-xs text-[var(--color-muted)]">Run this agent on a recurring schedule</p>
-                </div>
-                <Switch
-                  checked={heartbeatEnabled}
-                  onCheckedChange={(v) => { markDirty(); setHeartbeatEnabled(v) }}
-                  disabled={!canEdit}
-                />
-              </div>
-              {heartbeatEnabled && (
-                <div className="flex items-center gap-3 pt-1 border-t border-[var(--color-border)]">
-                  <label className="text-xs text-[var(--color-muted)] w-44 shrink-0">Interval (seconds)</label>
+          <AccordionItem value="identity" className="border-0">
+            <AccordionTrigger className="px-4 font-headline font-bold text-sm">
+              Identity
+            </AccordionTrigger>
+            <AccordionContent>
+              <div className="px-4 space-y-3">
+                <div className="space-y-2">
                   <Input
-                    type="number"
-                    min={1}
-                    value={heartbeatInterval}
-                    onChange={(e) => { markDirty(); setHeartbeatInterval(Number(e.target.value)) }}
-                    className="text-xs h-8"
-                    disabled={!canEdit}
+                    value={name}
+                    onChange={(e) => { markDirty(); setName(e.target.value) }}
+                    placeholder="Agent name"
+                    className="text-sm"
                   />
+                  <Textarea
+                    value={description}
+                    onChange={(e) => { markDirty(); setDescription(e.target.value) }}
+                    placeholder="Short description of this agent's purpose"
+                    rows={2}
+                    className="text-sm resize-none"
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <p className="text-xs text-[var(--color-muted)]">Avatar color</p>
+                  <div className="flex gap-2">
+                    {AVATAR_COLORS.map((color) => (
+                      <button
+                        key={color}
+                        type="button"
+                        onClick={() => { markDirty(); setSelectedColor(color) }}
+                        className="w-7 h-7 rounded-full transition-transform hover:scale-110 focus:outline-none focus:ring-2 focus:ring-[var(--color-accent)] focus:ring-offset-1 focus:ring-offset-[var(--color-primary)]"
+                        style={{
+                          backgroundColor: color,
+                          boxShadow: selectedColor === color ? `0 0 0 2px var(--color-primary), 0 0 0 4px ${color}` : undefined,
+                        }}
+                        aria-label={color}
+                      />
+                    ))}
+                  </div>
+                </div>
+                <div className="space-y-1.5">
+                  <p className="text-xs text-[var(--color-muted)]">Avatar icon</p>
+                  <SmartSelect
+                    value={selectedIcon}
+                    onValueChange={(v) => { markDirty(); setSelectedIcon(v as IconName) }}
+                    triggerClassName="w-48"
+                    items={ICON_OPTIONS.map(({ name: iconName }) => ({ value: iconName, label: iconName }))}
+                  />
+                </div>
+              </div>
+            </AccordionContent>
+          </AccordionItem>
+        )}
+
+        {/* Model Configuration — default CLOSED */}
+        <AccordionItem value="model" className="border-0">
+          <AccordionTrigger className="px-4 font-headline font-bold text-sm">
+            Model Configuration
+          </AccordionTrigger>
+          <AccordionContent>
+            <div className="px-4 space-y-3">
+              {providersError && (
+                <p className="text-xs text-[var(--color-warning)]">
+                  Could not load providers. You can still enter a model slug manually.
+                </p>
+              )}
+              <ModelSelector
+                models={availableModels}
+                value={model}
+                onChange={(v) => { markDirty(); setModel(v) }}
+                placeholder="Provider default"
+                disabled={!canEdit}
+              />
+              {canEdit && (
+                <div className="space-y-1.5">
+                  <p className="text-xs text-[var(--color-muted)]">Fallback models (tried in order if primary fails)</p>
+                  <div className="flex flex-wrap gap-1.5 p-2 rounded-md border border-[var(--color-border)] bg-[var(--color-surface-1)] min-h-[36px]">
+                    {fallbackModels.map((m) => (
+                      <span
+                        key={m}
+                        className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-[10px] font-mono bg-[var(--color-surface-2)] text-[var(--color-secondary)] border border-[var(--color-border)]"
+                      >
+                        {m}
+                        <button
+                          type="button"
+                          onClick={() => setFallbackModels((prev) => prev.filter((x) => x !== m))}
+                          className="text-[var(--color-muted)] hover:text-[var(--color-error)] transition-colors"
+                        >
+                          <X size={10} />
+                        </button>
+                      </span>
+                    ))}
+                    <input
+                      value={fallbackInput}
+                      onChange={(e) => { markDirty(); setFallbackInput(e.target.value) }}
+                      onKeyDown={handleFallbackKeyDown}
+                      onBlur={addFallbackModel}
+                      placeholder={fallbackModels.length === 0 ? 'Type a model name, press Enter' : ''}
+                      className="flex-1 min-w-[160px] bg-transparent text-xs text-[var(--color-secondary)] outline-none placeholder:text-[var(--color-muted)]"
+                    />
+                  </div>
+                </div>
+              )}
+              {canEdit && (
+                <div className="rounded-md border border-[var(--color-border)] bg-[var(--color-surface-1)] overflow-hidden">
+                  <button
+                    type="button"
+                    onClick={() => setAdvancedOpen((o) => !o)}
+                    className="flex items-center justify-between w-full px-3 py-2.5 text-sm font-medium text-[var(--color-secondary)] hover:text-[var(--color-accent)] transition-colors"
+                  >
+                    <span>Advanced parameters</span>
+                    {advancedOpen ? <CaretUp size={13} /> : <CaretDown size={13} />}
+                  </button>
+                  {advancedOpen && (
+                    <div className="px-3 pb-3 space-y-4 border-t border-[var(--color-border)]">
+                      <RangeField
+                        label="Temperature"
+                        value={temperature}
+                        min={0}
+                        max={2}
+                        step={0.05}
+                        onChange={(v) => { markDirty(); setTemperature(v) }}
+                        format={(v) => v.toFixed(2)}
+                      />
+                      <RangeField
+                        label="Max tokens"
+                        value={maxTokens}
+                        min={256}
+                        max={32768}
+                        step={256}
+                        onChange={(v) => { markDirty(); setMaxTokens(v) }}
+                        format={(v) => v.toLocaleString()}
+                      />
+                      <RangeField
+                        label="Top P"
+                        value={topP}
+                        min={0}
+                        max={1}
+                        step={0.01}
+                        onChange={(v) => { markDirty(); setTopP(v) }}
+                        format={(v) => v.toFixed(2)}
+                      />
+                    </div>
+                  )}
                 </div>
               )}
             </div>
-            <Textarea
-              value={heartbeat}
-              onChange={(e) => { markDirty(); setHeartbeat(e.target.value) }}
-              placeholder="# Heartbeat&#10;&#10;Write persistent context for this agent..."
-              rows={6}
-              className="text-xs font-mono resize-none"
-            />
-            <SaveAllButton onUpload={setHeartbeat} />
-          </section>
-        </>
-      )}
+          </AccordionContent>
+        </AccordionItem>
 
-      {/* Rate limits section */}
-      {agent.type !== 'system' && (
-        <>
-          <Separator />
-          <section className="space-y-3">
-            <h2 className="font-headline font-bold text-sm text-[var(--color-secondary)]">Rate Limits</h2>
-            <div className="flex items-center justify-between py-1">
-              <div>
-                <p className="text-sm text-[var(--color-secondary)]">Use global defaults</p>
-                <p className="text-xs text-[var(--color-muted)]">Inherit rate limits from global settings</p>
-              </div>
-              <Switch
-                checked={useGlobalRateLimits}
-                onCheckedChange={(v) => { markDirty(); setUseGlobalRateLimits(v) }}
-                disabled={!canEdit}
-              />
-            </div>
-            {!useGlobalRateLimits && (
-              <div className="space-y-2">
-                <div className="flex items-center gap-3">
-                  <label className="text-xs text-[var(--color-muted)] w-44 shrink-0">LLM calls / hour</label>
-                  <Input
-                    type="number"
-                    min={0}
-                    value={maxLlmCallsPerHour}
-                    onChange={(e) => { markDirty(); setMaxLlmCallsPerHour(e.target.value === '' ? '' : Number(e.target.value)) }}
-                    placeholder="Unlimited"
-                    className="text-xs h-8"
+        {/* Rate Limits — default CLOSED */}
+        {agent.type !== 'system' && (
+          <AccordionItem value="rate-limits" className="border-0">
+            <AccordionTrigger className="px-4 font-headline font-bold text-sm">
+              Rate Limits
+            </AccordionTrigger>
+            <AccordionContent>
+              <div className="px-4 space-y-3">
+                <div className="flex items-center justify-between py-1">
+                  <div>
+                    <p className="text-sm text-[var(--color-secondary)]">Use global defaults</p>
+                    <p className="text-xs text-[var(--color-muted)]">Inherit rate limits from global settings</p>
+                  </div>
+                  <Switch
+                    checked={useGlobalRateLimits}
+                    onCheckedChange={(v) => { markDirty(); setUseGlobalRateLimits(v) }}
                     disabled={!canEdit}
                   />
                 </div>
-                <div className="flex items-center gap-3">
-                  <label className="text-xs text-[var(--color-muted)] w-44 shrink-0">Tool calls / minute</label>
-                  <Input
-                    type="number"
-                    min={0}
-                    value={maxToolCallsPerMinute}
-                    onChange={(e) => { markDirty(); setMaxToolCallsPerMinute(e.target.value === '' ? '' : Number(e.target.value)) }}
-                    placeholder="Unlimited"
-                    className="text-xs h-8"
-                    disabled={!canEdit}
-                  />
-                </div>
-                <div className="flex items-center gap-3">
-                  <label className="text-xs text-[var(--color-muted)] w-44 shrink-0">Max cost / day ($)</label>
-                  <Input
-                    type="number"
-                    min={0}
-                    step={0.01}
-                    value={maxCostPerDay}
-                    onChange={(e) => { markDirty(); setMaxCostPerDay(e.target.value === '' ? '' : Number(e.target.value)) }}
-                    placeholder="Unlimited"
-                    className="text-xs h-8"
-                    disabled={!canEdit}
-                  />
-                </div>
+                {!useGlobalRateLimits && (
+                  <div className="space-y-2">
+                    <div className="flex items-center gap-3">
+                      <label className="text-xs text-[var(--color-muted)] w-44 shrink-0">LLM calls / hour</label>
+                      <Input
+                        type="number"
+                        min={0}
+                        value={maxLlmCallsPerHour}
+                        onChange={(e) => { markDirty(); setMaxLlmCallsPerHour(e.target.value === '' ? '' : Number(e.target.value)) }}
+                        placeholder="Unlimited"
+                        className="text-xs h-8"
+                        disabled={!canEdit}
+                      />
+                    </div>
+                    <div className="flex items-center gap-3">
+                      <label className="text-xs text-[var(--color-muted)] w-44 shrink-0">Tool calls / minute</label>
+                      <Input
+                        type="number"
+                        min={0}
+                        value={maxToolCallsPerMinute}
+                        onChange={(e) => { markDirty(); setMaxToolCallsPerMinute(e.target.value === '' ? '' : Number(e.target.value)) }}
+                        placeholder="Unlimited"
+                        className="text-xs h-8"
+                        disabled={!canEdit}
+                      />
+                    </div>
+                    <div className="flex items-center gap-3">
+                      <label className="text-xs text-[var(--color-muted)] w-44 shrink-0">Max cost / day ($)</label>
+                      <Input
+                        type="number"
+                        min={0}
+                        step={0.01}
+                        value={maxCostPerDay}
+                        onChange={(e) => { markDirty(); setMaxCostPerDay(e.target.value === '' ? '' : Number(e.target.value)) }}
+                        placeholder="Unlimited"
+                        className="text-xs h-8"
+                        disabled={!canEdit}
+                      />
+                    </div>
+                  </div>
+                )}
               </div>
-            )}
-          </section>
-        </>
-      )}
-
-      {/* Execution section */}
-      {agent.type !== 'system' && (
-        <>
-          <Separator />
-          <section className="space-y-3">
-            <h2 className="font-headline font-bold text-sm text-[var(--color-secondary)]">Execution</h2>
-            <div className="space-y-3 rounded-lg border border-[var(--color-border)] bg-[var(--color-surface-1)] p-4">
-              <div className="flex items-center gap-3">
-                <label className="text-xs text-[var(--color-muted)] w-44 shrink-0">
-                  Turn timeout (seconds)
-                  <span className="block text-[10px] text-[var(--color-muted)]/70">0 = no limit</span>
-                </label>
-                <Input
-                  type="number"
-                  min={0}
-                  value={timeoutSeconds}
-                  onChange={(e) => { markDirty(); setTimeoutSeconds(Number(e.target.value)) }}
-                  className="text-xs h-8"
-                  disabled={!canEdit}
-                />
-              </div>
-              <div className="flex items-center gap-3">
-                <label className="text-xs text-[var(--color-muted)] w-44 shrink-0">Max tool iterations</label>
-                <Input
-                  type="number"
-                  min={1}
-                  value={maxToolIterations}
-                  onChange={(e) => { markDirty(); setMaxToolIterations(Number(e.target.value)) }}
-                  className="text-xs h-8"
-                  disabled={!canEdit}
-                />
-              </div>
-              <div className="flex items-center gap-3">
-                <label className="text-xs text-[var(--color-muted)] w-44 shrink-0">Message handling</label>
-                <SmartSelect
-                  value={steeringMode}
-                  onValueChange={(v) => { markDirty(); setSteeringMode(v) }}
-                  disabled={!canEdit}
-                  triggerClassName="text-xs h-8"
-                  items={[
-                    { value: 'one-at-a-time', label: 'One at a time' },
-                    { value: 'parallel', label: 'Parallel' },
-                    { value: 'queue', label: 'Queue' },
-                  ]}
-                />
-              </div>
-              <div className="flex items-center justify-between py-1">
-                <div>
-                  <p className="text-sm text-[var(--color-secondary)]">Tool progress feedback</p>
-                  <p className="text-xs text-[var(--color-muted)]">Show tool call status while running</p>
-                </div>
-                <Switch
-                  checked={toolFeedback}
-                  onCheckedChange={(v) => { markDirty(); setToolFeedback(v) }}
-                  disabled={!canEdit}
-                />
-              </div>
-            </div>
-          </section>
-        </>
-      )}
-
-      {/* Stats */}
-      {agent.stats && (
-        <>
-          <Separator />
-          <section>
-            <h2 className="font-headline font-bold text-sm text-[var(--color-secondary)] mb-3">Stats</h2>
-            <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
-              <StatCard label="Sessions" value={agent.stats.total_sessions.toString()} />
-              <StatCard
-                label="Tokens"
-                value={
-                  agent.stats.total_tokens >= 1000
-                    ? `${(agent.stats.total_tokens / 1000).toFixed(1)}k`
-                    : agent.stats.total_tokens.toString()
-                }
-              />
-              <StatCard label="Cost" value={`$${agent.stats.total_cost.toFixed(4)}`} />
-              <StatCard
-                label="Last active"
-                value={
-                  agent.stats.last_active
-                    ? new Date(agent.stats.last_active).toLocaleDateString()
-                    : '—'
-                }
-              />
-            </div>
-          </section>
-        </>
-      )}
-
-      {/* Recent sessions */}
-      <>
-        <Separator />
-        <section>
-          <h2 className="font-headline font-bold text-sm text-[var(--color-secondary)] mb-3">Recent Sessions</h2>
-          {sessionsError ? (
-            <p className="text-sm text-[var(--color-error)]">Failed to load sessions</p>
-          ) : recentSessions.length > 0 ? (
-            <div className="space-y-1">
-              {recentSessions.map((s) => (
-                <SessionRow key={s.id} session={s} />
-              ))}
-            </div>
-          ) : (
-            <p className="text-xs text-[var(--color-muted)]">No sessions yet.</p>
-          )}
-        </section>
-      </>
-
-      {/* Tools */}
-      {agent.tools && agent.tools.length > 0 && (
-        <>
-          <Separator />
-          <section>
-            <h2 className="font-headline font-bold text-sm text-[var(--color-secondary)] mb-3">
-              Tools & Skills
-            </h2>
-            <div className="flex flex-wrap gap-2">
-              {agent.tools.map((tool) => (
-                <Badge key={tool} variant="outline" className="font-mono text-[10px]">
-                  {tool}
-                </Badge>
-              ))}
-            </div>
-          </section>
-        </>
-      )}
-
-      {/* Recent activity */}
-      <Separator />
-      <section>
-        <h2 className="font-headline font-bold text-sm text-[var(--color-secondary)] mb-3">Recent Activity</h2>
-        {activityError ? (
-          <p className="text-sm text-[var(--color-error)]">Failed to load activity</p>
-        ) : recentActivity.length === 0 ? (
-          <p className="text-xs text-[var(--color-muted)]">No recent activity for this agent.</p>
-        ) : (
-          <div className="space-y-1">
-            {recentActivity.map((event) => (
-              <ActivityRow key={event.id} event={event} />
-            ))}
-          </div>
+            </AccordionContent>
+          </AccordionItem>
         )}
-      </section>
+
+        {/* Behavior — default CLOSED (SOUL + Instructions + Heartbeat + Execution) */}
+        {canEdit && (
+          <AccordionItem value="behavior" className="border-0">
+            <AccordionTrigger className="px-4 font-headline font-bold text-sm">
+              Behavior
+            </AccordionTrigger>
+            <AccordionContent>
+              <div className="px-4 space-y-5">
+                {/* SOUL.md */}
+                <div className="space-y-2">
+                  <div className="flex items-center gap-2">
+                    <Scroll size={13} className="text-[var(--color-accent)]" />
+                    <p className="text-xs font-medium text-[var(--color-secondary)]">SOUL.md</p>
+                  </div>
+                  <p className="text-xs text-[var(--color-muted)]">
+                    The agent's personality and system prompt.
+                  </p>
+                  <Textarea
+                    value={soul}
+                    onChange={(e) => { markDirty(); setSoul(e.target.value) }}
+                    placeholder={"# Soul\n\nDefine this agent's personality, expertise, and behavioral guidelines..."}
+                    rows={6}
+                    className="text-xs font-mono resize-none"
+                  />
+                  <SaveAllButton onUpload={setSoul} />
+                </div>
+
+                <Separator />
+
+                {/* Additional Instructions */}
+                <div className="space-y-2">
+                  <div className="flex items-center gap-2">
+                    <NotePencil size={13} className="text-[var(--color-accent)]" />
+                    <p className="text-xs font-medium text-[var(--color-secondary)]">Additional Instructions</p>
+                  </div>
+                  <p className="text-xs text-[var(--color-muted)]">
+                    Extra instructions appended to the agent's context.
+                  </p>
+                  <Textarea
+                    value={instructions}
+                    onChange={(e) => { markDirty(); setInstructions(e.target.value) }}
+                    placeholder="Add specific instructions, constraints, or domain knowledge..."
+                    rows={4}
+                    className="text-xs font-mono resize-none"
+                  />
+                  <SaveAllButton onUpload={setInstructions} />
+                </div>
+
+                <Separator />
+
+                {/* HEARTBEAT.md */}
+                <div className="space-y-2">
+                  <p className="text-xs font-medium text-[var(--color-secondary)]">HEARTBEAT.md</p>
+                  <p className="text-xs text-[var(--color-muted)]">
+                    The agent's persistent context — goals, preferences, and working memory.
+                  </p>
+                  <div className="rounded-lg border border-[var(--color-border)] bg-[var(--color-surface-1)] p-3 space-y-3">
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <p className="text-sm text-[var(--color-secondary)]">Enable heartbeat</p>
+                        <p className="text-xs text-[var(--color-muted)]">Run on a recurring schedule</p>
+                      </div>
+                      <Switch
+                        checked={heartbeatEnabled}
+                        onCheckedChange={(v) => { markDirty(); setHeartbeatEnabled(v) }}
+                      />
+                    </div>
+                    {heartbeatEnabled && (
+                      <div className="flex items-center gap-3 pt-1 border-t border-[var(--color-border)]">
+                        <label className="text-xs text-[var(--color-muted)] w-44 shrink-0">Interval (seconds)</label>
+                        <Input
+                          type="number"
+                          min={1}
+                          value={heartbeatInterval}
+                          onChange={(e) => { markDirty(); setHeartbeatInterval(Number(e.target.value)) }}
+                          className="text-xs h-8"
+                        />
+                      </div>
+                    )}
+                  </div>
+                  <Textarea
+                    value={heartbeat}
+                    onChange={(e) => { markDirty(); setHeartbeat(e.target.value) }}
+                    placeholder="# Heartbeat&#10;&#10;Write persistent context for this agent..."
+                    rows={4}
+                    className="text-xs font-mono resize-none"
+                  />
+                  <SaveAllButton onUpload={setHeartbeat} />
+                </div>
+
+                <Separator />
+
+                {/* Execution */}
+                {agent.type !== 'system' && (
+                  <div className="space-y-2">
+                    <p className="text-xs font-medium text-[var(--color-secondary)]">Execution</p>
+                    <div className="space-y-3 rounded-lg border border-[var(--color-border)] bg-[var(--color-surface-1)] p-4">
+                      <div className="flex items-center gap-3">
+                        <label className="text-xs text-[var(--color-muted)] w-44 shrink-0">
+                          Turn timeout (seconds)
+                          <span className="block text-[10px] text-[var(--color-muted)]/70">0 = no limit</span>
+                        </label>
+                        <Input
+                          type="number"
+                          min={0}
+                          value={timeoutSeconds}
+                          onChange={(e) => { markDirty(); setTimeoutSeconds(Number(e.target.value)) }}
+                          className="text-xs h-8"
+                        />
+                      </div>
+                      <div className="flex items-center gap-3">
+                        <label className="text-xs text-[var(--color-muted)] w-44 shrink-0">Max tool iterations</label>
+                        <Input
+                          type="number"
+                          min={1}
+                          value={maxToolIterations}
+                          onChange={(e) => { markDirty(); setMaxToolIterations(Number(e.target.value)) }}
+                          className="text-xs h-8"
+                        />
+                      </div>
+                      <div className="flex items-center gap-3">
+                        <label className="text-xs text-[var(--color-muted)] w-44 shrink-0">Message handling</label>
+                        <SmartSelect
+                          value={steeringMode}
+                          onValueChange={(v) => { markDirty(); setSteeringMode(v) }}
+                          triggerClassName="text-xs h-8"
+                          items={[
+                            { value: 'one-at-a-time', label: 'One at a time' },
+                            { value: 'parallel', label: 'Parallel' },
+                            { value: 'queue', label: 'Queue' },
+                          ]}
+                        />
+                      </div>
+                      <div className="flex items-center justify-between py-1">
+                        <div>
+                          <p className="text-sm text-[var(--color-secondary)]">Tool progress feedback</p>
+                          <p className="text-xs text-[var(--color-muted)]">Show tool call status while running</p>
+                        </div>
+                        <Switch
+                          checked={toolFeedback}
+                          onCheckedChange={(v) => { markDirty(); setToolFeedback(v) }}
+                        />
+                      </div>
+                    </div>
+                  </div>
+                )}
+              </div>
+            </AccordionContent>
+          </AccordionItem>
+        )}
+
+        {/* Tools & Permissions — default CLOSED */}
+        {agent.type !== 'system' && (
+          <AccordionItem value="tools" className="border-0">
+            <AccordionTrigger className="px-4 font-headline font-bold text-sm">
+              <span>Tools &amp; Permissions</span>
+              {toolsCfg.builtin.mode === 'explicit' && (
+                <span className="text-xs text-[var(--color-muted)] font-normal ml-2">
+                  {toolsCfg.builtin.visible?.length ?? 0} selected
+                </span>
+              )}
+            </AccordionTrigger>
+            <AccordionContent>
+              <div className="px-4">
+                <ToolsAndPermissions
+                  agentId={agentId}
+                  agentType={agent.type}
+                  tools={toolsCfg}
+                  onChange={setToolsCfg}
+                />
+              </div>
+            </AccordionContent>
+          </AccordionItem>
+        )}
+
+        {/* Sessions — default CLOSED */}
+        <AccordionItem value="sessions" className="border-0">
+          <AccordionTrigger className="px-4 font-headline font-bold text-sm">
+            Sessions
+          </AccordionTrigger>
+          <AccordionContent>
+            <div className="px-4">
+              {sessionsError ? (
+                <p className="text-sm text-[var(--color-error)]">Failed to load sessions</p>
+              ) : recentSessions.length > 0 ? (
+                <div className="space-y-1">
+                  {recentSessions.map((s) => (
+                    <SessionRow key={s.id} session={s} />
+                  ))}
+                </div>
+              ) : (
+                <p className="text-xs text-[var(--color-muted)]">No sessions yet.</p>
+              )}
+            </div>
+          </AccordionContent>
+        </AccordionItem>
+
+        {/* Activity — default CLOSED */}
+        <AccordionItem value="activity" className="border-0">
+          <AccordionTrigger className="px-4 font-headline font-bold text-sm">
+            Activity
+          </AccordionTrigger>
+          <AccordionContent>
+            <div className="px-4">
+              {agent.stats && (
+                <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-4">
+                  <StatCard label="Sessions" value={agent.stats.total_sessions.toString()} />
+                  <StatCard
+                    label="Tokens"
+                    value={
+                      agent.stats.total_tokens >= 1000
+                        ? `${(agent.stats.total_tokens / 1000).toFixed(1)}k`
+                        : agent.stats.total_tokens.toString()
+                    }
+                  />
+                  <StatCard label="Cost" value={`$${agent.stats.total_cost.toFixed(4)}`} />
+                  <StatCard
+                    label="Last active"
+                    value={
+                      agent.stats.last_active
+                        ? new Date(agent.stats.last_active).toLocaleDateString()
+                        : '—'
+                    }
+                  />
+                </div>
+              )}
+              {activityError ? (
+                <p className="text-sm text-[var(--color-error)]">Failed to load activity</p>
+              ) : recentActivity.length === 0 ? (
+                <p className="text-xs text-[var(--color-muted)]">No recent activity for this agent.</p>
+              ) : (
+                <div className="space-y-1">
+                  {recentActivity.map((event) => (
+                    <ActivityRow key={event.id} event={event} />
+                  ))}
+                </div>
+              )}
+            </div>
+          </AccordionContent>
+        </AccordionItem>
+      </Accordion>
     </div>
     </div>
   )

--- a/src/components/agents/CreateAgentModal.tsx
+++ b/src/components/agents/CreateAgentModal.tsx
@@ -19,11 +19,13 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { ModelSelector } from '@/components/ui/model-selector'
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
 import { useQuery } from '@tanstack/react-query'
 import { useUiStore } from '@/store/ui'
 import { createAgent, fetchProviders } from '@/lib/api'
-import type { Agent } from '@/lib/api'
+import type { Agent, AgentToolsCfg } from '@/lib/api'
 import { AVATAR_COLORS } from '@/lib/constants'
+import { ToolsAndPermissions } from './ToolsAndPermissions'
 
 const ICON_OPTIONS = [
   { name: 'Robot', component: Robot },
@@ -78,6 +80,9 @@ export function CreateAgentModal({ open: openProp, onClose: onCloseProp, onCreat
   const [temperature, setTemperature] = useState(1.0)
   const [advancedOpen, setAdvancedOpen] = useState(false)
   const [nameError, setNameError] = useState('')
+  const [toolsState, setToolsState] = useState<AgentToolsCfg>({
+    builtin: { mode: 'inherit' },
+  })
 
   const resetForm = () => {
     setName('')
@@ -88,6 +93,7 @@ export function CreateAgentModal({ open: openProp, onClose: onCloseProp, onCreat
     setTemperature(1.0)
     setAdvancedOpen(false)
     setNameError('')
+    setToolsState({ builtin: { mode: 'inherit' } })
   }
 
   // Reset form state whenever the modal opens so stale values are not shown
@@ -132,7 +138,8 @@ export function CreateAgentModal({ open: openProp, onClose: onCloseProp, onCreat
       icon,
       type: 'custom',
       model_params: { temperature },
-    })
+      tools_cfg: toolsState,
+    } as Partial<Agent> & { tools_cfg?: AgentToolsCfg })
   }
 
   return (
@@ -147,153 +154,165 @@ export function CreateAgentModal({ open: openProp, onClose: onCloseProp, onCreat
             Configure a new custom agent with a persona, model, and tools.
           </DialogPrimitive.Description>
 
-          <div className="space-y-4 overflow-y-auto flex-1 min-h-0 pr-1">
-            {/* Avatar preview + color + icon */}
-            <div>
-              <label className="text-xs font-medium text-[var(--color-muted)] mb-2 block">
-                Avatar
-              </label>
-              <div className="flex items-start gap-4">
-                {/* Preview */}
-                <div
-                  className="w-12 h-12 rounded-full flex items-center justify-center shrink-0"
-                  style={{ backgroundColor: color }}
-                >
-                  <AvatarIcon size={20} className="text-[var(--color-primary)]" />
-                </div>
+          <Tabs defaultValue="general" className="flex-1 min-h-0 flex flex-col">
+            <TabsList className="shrink-0 mb-3">
+              <TabsTrigger value="general">General</TabsTrigger>
+              <TabsTrigger value="tools">Tools &amp; Permissions</TabsTrigger>
+            </TabsList>
 
-                <div className="flex-1 space-y-3">
-                  {/* Color palette */}
-                  <div>
-                    <p className="text-[10px] text-[var(--color-muted)] mb-1.5">Color</p>
-                    <div className="flex gap-2 flex-wrap">
-                      {AVATAR_COLORS.map((c) => (
-                        <button
-                          key={c}
-                          type="button"
-                          onClick={() => setColor(c)}
-                          className={`w-6 h-6 rounded-full transition-transform ${color === c ? 'ring-2 ring-[var(--color-secondary)] ring-offset-2 ring-offset-[var(--color-surface-1)] scale-110' : 'hover:scale-110'}`}
-                          style={{ backgroundColor: c }}
-                          aria-label={`Select color ${c}`}
-                        />
-                      ))}
+            <TabsContent value="general" className="flex-1 overflow-y-auto min-h-0 mt-0">
+              <div className="space-y-4 pr-1">
+                {/* Avatar preview + color + icon */}
+                <div>
+                  <label className="text-xs font-medium text-[var(--color-muted)] mb-2 block">
+                    Avatar
+                  </label>
+                  <div className="flex items-start gap-4">
+                    <div
+                      className="w-12 h-12 rounded-full flex items-center justify-center shrink-0"
+                      style={{ backgroundColor: color }}
+                    >
+                      <AvatarIcon size={20} className="text-[var(--color-primary)]" />
+                    </div>
+                    <div className="flex-1 space-y-3">
+                      <div>
+                        <p className="text-[10px] text-[var(--color-muted)] mb-1.5">Color</p>
+                        <div className="flex gap-2 flex-wrap">
+                          {AVATAR_COLORS.map((c) => (
+                            <button
+                              key={c}
+                              type="button"
+                              onClick={() => setColor(c)}
+                              className={`w-6 h-6 rounded-full transition-transform ${color === c ? 'ring-2 ring-[var(--color-secondary)] ring-offset-2 ring-offset-[var(--color-surface-1)] scale-110' : 'hover:scale-110'}`}
+                              style={{ backgroundColor: c }}
+                              aria-label={`Select color ${c}`}
+                            />
+                          ))}
+                        </div>
+                      </div>
+                      <div>
+                        <p className="text-[10px] text-[var(--color-muted)] mb-1.5">Icon</p>
+                        <div className="grid grid-cols-5 gap-1.5">
+                          {ICON_OPTIONS.map(({ name: iconName, component: IconComp }) => (
+                            <button
+                              key={iconName}
+                              type="button"
+                              onClick={() => setIcon(iconName)}
+                              title={iconName}
+                              className={`flex items-center justify-center w-8 h-8 rounded-md transition-colors ${
+                                icon === iconName
+                                  ? 'bg-[var(--color-accent)] text-[var(--color-primary)]'
+                                  : 'bg-[var(--color-surface-2)] text-[var(--color-muted)] hover:text-[var(--color-secondary)]'
+                              }`}
+                            >
+                              <IconComp size={16} />
+                            </button>
+                          ))}
+                        </div>
+                      </div>
                     </div>
                   </div>
-
-                  {/* Icon grid */}
-                  <div>
-                    <p className="text-[10px] text-[var(--color-muted)] mb-1.5">Icon</p>
-                    <div className="grid grid-cols-5 gap-1.5">
-                      {ICON_OPTIONS.map(({ name: iconName, component: IconComp }) => (
-                        <button
-                          key={iconName}
-                          type="button"
-                          onClick={() => setIcon(iconName)}
-                          title={iconName}
-                          className={`flex items-center justify-center w-8 h-8 rounded-md transition-colors ${
-                            icon === iconName
-                              ? 'bg-[var(--color-accent)] text-[var(--color-primary)]'
-                              : 'bg-[var(--color-surface-2)] text-[var(--color-muted)] hover:text-[var(--color-secondary)]'
-                          }`}
-                        >
-                          <IconComp size={16} />
-                        </button>
-                      ))}
-                    </div>
-                  </div>
                 </div>
-              </div>
-            </div>
 
-            {/* Name */}
-            <div>
-              <label htmlFor="agent-name" className="text-xs font-medium text-[var(--color-muted)] mb-1.5 block">
-                Name <span className="text-[var(--color-error)]">*</span>
-              </label>
-              <Input
-                id="agent-name"
-                value={name}
-                onChange={(e) => {
-                  setName(e.target.value)
-                  if (e.target.value.trim()) setNameError('')
-                }}
-                placeholder="e.g. Research Assistant"
-                className={nameError ? 'border-[var(--color-error)]' : ''}
-                autoFocus
-              />
-              {nameError && (
-                <p className="mt-1 text-xs text-[var(--color-error)]">{nameError}</p>
-              )}
-            </div>
-
-            {/* Description */}
-            <div>
-              <label htmlFor="agent-description" className="text-xs font-medium text-[var(--color-muted)] mb-1.5 block">
-                Description
-              </label>
-              <Textarea
-                id="agent-description"
-                value={description}
-                onChange={(e) => setDescription(e.target.value)}
-                placeholder="What does this agent do?"
-                rows={2}
-              />
-            </div>
-
-            {/* Model */}
-            <div>
-              <label className="text-xs font-medium text-[var(--color-muted)] mb-1.5 block">
-                Model
-              </label>
-              {providersError && (
-                <div className="mb-2 rounded-md border border-[var(--color-error)]/40 bg-[var(--color-error)]/10 px-3 py-2">
-                  <p className="text-xs text-[var(--color-error)] font-medium">Provider list unavailable</p>
-                  <p className="text-xs text-[var(--color-error)]/80 mt-0.5">
-                    Could not load connected providers. The model list below may not reflect what is actually configured.
-                    Verify your provider settings before creating this agent.
-                  </p>
-                </div>
-              )}
-              <ModelSelector
-                models={availableModels}
-                value={model}
-                onChange={setModel}
-                placeholder="Use provider default"
-              />
-            </div>
-
-            {/* Advanced model params */}
-            <div className="rounded-md border border-[var(--color-border)] bg-[var(--color-surface-1)] overflow-hidden">
-              <button
-                type="button"
-                onClick={() => setAdvancedOpen((o) => !o)}
-                className="flex items-center justify-between w-full px-3 py-2.5 text-sm font-medium text-[var(--color-secondary)] hover:text-[var(--color-accent)] transition-colors"
-              >
-                <span>Advanced</span>
-                {advancedOpen ? <CaretUp size={13} /> : <CaretDown size={13} />}
-              </button>
-              {advancedOpen && (
-                <div className="px-3 pb-3 border-t border-[var(--color-border)] pt-3 space-y-1">
-                  <div className="flex items-center justify-between">
-                    <span className="text-xs text-[var(--color-muted)]">Temperature</span>
-                    <span className="text-xs font-mono text-[var(--color-secondary)]">{temperature.toFixed(2)}</span>
-                  </div>
-                  <input
-                    type="range"
-                    min={0}
-                    max={2}
-                    step={0.05}
-                    value={temperature}
-                    onChange={(e) => setTemperature(Number(e.target.value))}
-                    className="w-full h-1.5 rounded-full appearance-none cursor-pointer"
-                    style={{
-                      background: `linear-gradient(to right, var(--color-accent) 0%, var(--color-accent) ${(temperature / 2) * 100}%, var(--color-border) ${(temperature / 2) * 100}%, var(--color-border) 100%)`,
+                {/* Name */}
+                <div>
+                  <label htmlFor="agent-name" className="text-xs font-medium text-[var(--color-muted)] mb-1.5 block">
+                    Name <span className="text-[var(--color-error)]">*</span>
+                  </label>
+                  <Input
+                    id="agent-name"
+                    value={name}
+                    onChange={(e) => {
+                      setName(e.target.value)
+                      if (e.target.value.trim()) setNameError('')
                     }}
+                    placeholder="e.g. Research Assistant"
+                    className={nameError ? 'border-[var(--color-error)]' : ''}
+                    autoFocus
+                  />
+                  {nameError && (
+                    <p className="mt-1 text-xs text-[var(--color-error)]">{nameError}</p>
+                  )}
+                </div>
+
+                {/* Description */}
+                <div>
+                  <label htmlFor="agent-description" className="text-xs font-medium text-[var(--color-muted)] mb-1.5 block">
+                    Description
+                  </label>
+                  <Textarea
+                    id="agent-description"
+                    value={description}
+                    onChange={(e) => setDescription(e.target.value)}
+                    placeholder="What does this agent do?"
+                    rows={2}
                   />
                 </div>
-              )}
-            </div>
-          </div>
+
+                {/* Model */}
+                <div>
+                  <label className="text-xs font-medium text-[var(--color-muted)] mb-1.5 block">
+                    Model
+                  </label>
+                  {providersError && (
+                    <div className="mb-2 rounded-md border border-[var(--color-error)]/40 bg-[var(--color-error)]/10 px-3 py-2">
+                      <p className="text-xs text-[var(--color-error)] font-medium">Provider list unavailable</p>
+                      <p className="text-xs text-[var(--color-error)]/80 mt-0.5">
+                        Could not load connected providers. Verify your provider settings before creating this agent.
+                      </p>
+                    </div>
+                  )}
+                  <ModelSelector
+                    models={availableModels}
+                    value={model}
+                    onChange={setModel}
+                    placeholder="Use provider default"
+                  />
+                </div>
+
+                {/* Advanced model params */}
+                <div className="rounded-md border border-[var(--color-border)] bg-[var(--color-surface-1)] overflow-hidden">
+                  <button
+                    type="button"
+                    onClick={() => setAdvancedOpen((o) => !o)}
+                    className="flex items-center justify-between w-full px-3 py-2.5 text-sm font-medium text-[var(--color-secondary)] hover:text-[var(--color-accent)] transition-colors"
+                  >
+                    <span>Advanced</span>
+                    {advancedOpen ? <CaretUp size={13} /> : <CaretDown size={13} />}
+                  </button>
+                  {advancedOpen && (
+                    <div className="px-3 pb-3 border-t border-[var(--color-border)] pt-3 space-y-1">
+                      <div className="flex items-center justify-between">
+                        <span className="text-xs text-[var(--color-muted)]">Temperature</span>
+                        <span className="text-xs font-mono text-[var(--color-secondary)]">{temperature.toFixed(2)}</span>
+                      </div>
+                      <input
+                        type="range"
+                        min={0}
+                        max={2}
+                        step={0.05}
+                        value={temperature}
+                        onChange={(e) => setTemperature(Number(e.target.value))}
+                        className="w-full h-1.5 rounded-full appearance-none cursor-pointer"
+                        style={{
+                          background: `linear-gradient(to right, var(--color-accent) 0%, var(--color-accent) ${(temperature / 2) * 100}%, var(--color-border) ${(temperature / 2) * 100}%, var(--color-border) 100%)`,
+                        }}
+                      />
+                    </div>
+                  )}
+                </div>
+              </div>
+            </TabsContent>
+
+            <TabsContent value="tools" className="flex-1 overflow-y-auto min-h-0 mt-0 pr-1">
+              <ToolsAndPermissions
+                agentId={null}
+                agentType="custom"
+                tools={toolsState}
+                onChange={setToolsState}
+              />
+            </TabsContent>
+          </Tabs>
 
           {/* Actions */}
           <div className="flex justify-end gap-2 mt-6">

--- a/src/components/agents/MCPServerPicker.tsx
+++ b/src/components/agents/MCPServerPicker.tsx
@@ -1,0 +1,55 @@
+import { Switch } from '@/components/ui/switch'
+import type { McpServer, AgentToolsCfg } from '@/lib/api'
+
+interface MCPServerPickerProps {
+  servers: McpServer[]
+  mcpConfig: AgentToolsCfg['mcp']
+  onChange: (mcp: AgentToolsCfg['mcp']) => void
+}
+
+export function MCPServerPicker({ servers, mcpConfig, onChange }: MCPServerPickerProps) {
+  if (servers.length === 0) {
+    return (
+      <p className="text-xs text-[var(--color-muted)] py-2">
+        No MCP servers configured. Add servers in Settings.
+      </p>
+    )
+  }
+
+  const enabledIds = new Set(mcpConfig?.servers?.map((s) => s.id) ?? [])
+
+  function toggleServer(serverId: string, enabled: boolean) {
+    const current = mcpConfig?.servers ?? []
+    const next = enabled
+      ? [...current, { id: serverId }]
+      : current.filter((s) => s.id !== serverId)
+    onChange({ servers: next })
+  }
+
+  return (
+    <div className="space-y-1">
+      {servers.map((server) => {
+        const isEnabled = enabledIds.has(server.id)
+        return (
+          <div
+            key={server.id}
+            className="flex items-center justify-between px-3 py-2.5 rounded-md bg-[var(--color-surface-1)] border border-[var(--color-border)]"
+          >
+            <div className="min-w-0 flex-1 mr-4">
+              <p className="text-sm text-[var(--color-secondary)] font-medium truncate">
+                {server.name}
+              </p>
+              <p className="text-[10px] text-[var(--color-muted)]">
+                {server.tool_count} tool{server.tool_count !== 1 ? 's' : ''} — {server.transport}
+              </p>
+            </div>
+            <Switch
+              checked={isEnabled}
+              onCheckedChange={(checked) => toggleServer(server.id, checked)}
+            />
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/agents/ToolGroupList.tsx
+++ b/src/components/agents/ToolGroupList.tsx
@@ -1,0 +1,87 @@
+import { Warning } from '@phosphor-icons/react'
+import { Accordion, AccordionItem, AccordionTrigger, AccordionContent } from '@/components/ui/accordion'
+import { Checkbox } from '@/components/ui/checkbox'
+import type { BuiltinTool } from '@/lib/api'
+
+interface ToolGroupListProps {
+  tools: BuiltinTool[]
+  selected: string[]
+  agentType: 'system' | 'core' | 'custom'
+  onToggle: (toolName: string) => void
+}
+
+export function ToolGroupList({ tools, selected, agentType, onToggle }: ToolGroupListProps) {
+  // Hide system-scope tools for custom agents
+  const visible = tools.filter((t) => !(agentType === 'custom' && t.scope === 'system'))
+
+  // Group by category
+  const grouped = visible.reduce<Record<string, BuiltinTool[]>>((acc, tool) => {
+    const cat = tool.category || 'General'
+    if (!acc[cat]) acc[cat] = []
+    acc[cat].push(tool)
+    return acc
+  }, {})
+
+  const categories = Object.keys(grouped).sort()
+
+  if (categories.length === 0) {
+    return (
+      <p className="text-xs text-[var(--color-muted)] py-4 text-center">No tools available.</p>
+    )
+  }
+
+  return (
+    <Accordion type="multiple" defaultValue={categories}>
+      {categories.map((cat) => {
+        const catTools = grouped[cat]
+        const selectedCount = catTools.filter((t) => selected.includes(t.name)).length
+        return (
+          <AccordionItem key={cat} value={cat}>
+            <AccordionTrigger className="bg-[var(--color-surface-2)] px-3 rounded-t-md text-xs font-medium">
+              <span>{cat}</span>
+              <span className="text-[var(--color-muted)] font-normal ml-2 text-[10px]">
+                {selectedCount}/{catTools.length}
+              </span>
+            </AccordionTrigger>
+            <AccordionContent>
+              <div className="space-y-0.5">
+                {catTools.map((tool) => {
+                  const isSelected = selected.includes(tool.name)
+                  return (
+                    <div
+                      key={tool.name}
+                      className="flex items-center gap-3 px-3 py-2 rounded-md bg-[var(--color-surface-1)] hover:bg-[var(--color-surface-2)] transition-colors cursor-pointer"
+                      onClick={() => onToggle(tool.name)}
+                    >
+                      <Checkbox
+                        checked={isSelected}
+                        onCheckedChange={() => onToggle(tool.name)}
+                        onClick={(e) => e.stopPropagation()}
+                      />
+                      <div className="flex items-center gap-1.5 min-w-0 flex-1">
+                        {tool.scope === 'core' && (
+                          <Warning
+                            size={12}
+                            weight="fill"
+                            className="text-amber-500 shrink-0"
+                            aria-label="Core-scope tool — affects agent behavior"
+                          />
+                        )}
+                        <span className="font-mono text-xs text-[var(--color-secondary)] shrink-0">
+                          {tool.name}
+                        </span>
+                        <span className="text-xs text-[var(--color-muted)] truncate">
+                          {tool.description}
+                        </span>
+                      </div>
+                    </div>
+                  )
+                })}
+              </div>
+            </AccordionContent>
+          </AccordionItem>
+        )
+      })}
+    </Accordion>
+  )
+}

--- a/src/components/agents/ToolPickerPreset.tsx
+++ b/src/components/agents/ToolPickerPreset.tsx
@@ -1,0 +1,35 @@
+import { TOOL_PRESETS, type PresetKey } from '@/lib/agentToolPresets'
+
+interface ToolPickerPresetProps {
+  activePreset: PresetKey | null
+  onSelect: (preset: PresetKey) => void
+}
+
+export function ToolPickerPreset({ activePreset, onSelect }: ToolPickerPresetProps) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {(Object.entries(TOOL_PRESETS) as [PresetKey, typeof TOOL_PRESETS[PresetKey]][]).map(
+        ([key, preset]) => {
+          const Icon = preset.icon
+          const isActive = activePreset === key
+          return (
+            <button
+              key={key}
+              type="button"
+              onClick={() => onSelect(key)}
+              className={[
+                'flex items-center gap-1.5 px-3 py-1.5 rounded-md border text-xs font-medium transition-colors',
+                isActive
+                  ? 'border-[var(--color-accent)] bg-[var(--color-accent)]/10 text-[var(--color-accent)]'
+                  : 'border-[var(--color-border)] bg-[var(--color-surface-2)] text-[var(--color-muted)] hover:text-[var(--color-secondary)] hover:border-[var(--color-secondary)]',
+              ].join(' ')}
+            >
+              <Icon size={13} />
+              {preset.label}
+            </button>
+          )
+        }
+      )}
+    </div>
+  )
+}

--- a/src/components/agents/ToolsAndPermissions.tsx
+++ b/src/components/agents/ToolsAndPermissions.tsx
@@ -1,0 +1,197 @@
+import { useEffect, useMemo } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { FloppyDisk } from '@phosphor-icons/react'
+import { Button } from '@/components/ui/button'
+import { ToolPickerPreset } from './ToolPickerPreset'
+import { ToolGroupList } from './ToolGroupList'
+import { MCPServerPicker } from './MCPServerPicker'
+import {
+  fetchBuiltinTools,
+  fetchAgentTools,
+  fetchMcpServersForAgent,
+  updateAgentTools,
+  type AgentToolsCfg,
+  type BuiltinTool,
+} from '@/lib/api'
+import { useUiStore } from '@/store/ui'
+import { TOOL_PRESETS, type PresetKey } from '@/lib/agentToolPresets'
+
+interface ToolsAndPermissionsProps {
+  agentId: string | null
+  agentType: 'system' | 'core' | 'custom'
+  tools: AgentToolsCfg
+  onChange: (tools: AgentToolsCfg) => void
+}
+
+function detectPreset(visible: string[] | undefined, allTools: BuiltinTool[]): PresetKey {
+  if (!visible) return 'custom'
+  const sorted = [...visible].sort().join(',')
+
+  // Check "unrestricted" first — its tool set is derived from allTools at runtime.
+  const unrestrictedNames = allTools
+    .filter((t) => t.scope !== 'system')
+    .map((t) => t.name)
+    .sort()
+    .join(',')
+  if (sorted === unrestrictedNames) return 'unrestricted'
+
+  // Check named presets (skip unrestricted and custom which have no static list).
+  const namedPresets = (Object.keys(TOOL_PRESETS) as PresetKey[]).filter(
+    (k) => k !== 'unrestricted' && k !== 'custom',
+  )
+  for (const key of namedPresets) {
+    const presetSorted = [...(TOOL_PRESETS[key].tools as string[])].sort().join(',')
+    if (sorted === presetSorted) return key
+  }
+  return 'custom'
+}
+
+export function ToolsAndPermissions({ agentId, agentType, tools, onChange }: ToolsAndPermissionsProps) {
+  const { addToast } = useUiStore()
+  const queryClient = useQueryClient()
+
+  const { data: builtinTools = [], isLoading: toolsLoading, isError: toolsError } = useQuery({
+    queryKey: ['tools-builtin'],
+    queryFn: fetchBuiltinTools,
+  })
+
+  const { data: mcpServers = [], isError: mcpError } = useQuery({
+    queryKey: ['mcp-servers'],
+    queryFn: fetchMcpServersForAgent,
+  })
+
+  // When editing an existing agent, load its tool config from the server
+  const { data: agentToolsData } = useQuery({
+    queryKey: ['agent-tools', agentId],
+    queryFn: () => fetchAgentTools(agentId!),
+    enabled: !!agentId,
+  })
+
+  // Sync server-loaded config into parent state on first load
+  useEffect(() => {
+    if (agentToolsData && agentId) {
+      onChange(agentToolsData.config)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [agentToolsData, agentId])
+
+  const { mutate: doSave, isPending: isSaving } = useMutation({
+    mutationFn: (cfg: AgentToolsCfg) => updateAgentTools(agentId!, cfg),
+    onSuccess: (result) => {
+      onChange(result.config)
+      queryClient.invalidateQueries({ queryKey: ['agent-tools', agentId] })
+      addToast({ message: 'Tool permissions saved', variant: 'success' })
+    },
+    onError: (err: Error) => {
+      addToast({ message: `Failed to save tools: ${err.message}`, variant: 'error' })
+    },
+  })
+
+  const visibleTools = tools.builtin.visible ?? []
+
+  const activePreset = useMemo(
+    () => detectPreset(visibleTools, builtinTools),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [visibleTools.join(','), builtinTools]
+  )
+
+  function applyPreset(key: PresetKey) {
+    const preset = TOOL_PRESETS[key]
+    if (preset.tools === 'all') {
+      const allVisible = builtinTools
+        .filter((t) => t.scope !== 'system')
+        .map((t) => t.name)
+      onChange({ ...tools, builtin: { mode: 'explicit', visible: allVisible } })
+    } else if (key === 'custom') {
+      onChange({ ...tools, builtin: { mode: 'explicit', visible: visibleTools } })
+    } else {
+      onChange({
+        ...tools,
+        builtin: { mode: 'explicit', visible: [...(preset.tools as string[])] },
+      })
+    }
+  }
+
+  function toggleTool(toolName: string) {
+    const current = tools.builtin.visible ?? []
+    const next = current.includes(toolName)
+      ? current.filter((n) => n !== toolName)
+      : [...current, toolName]
+    onChange({ ...tools, builtin: { mode: 'explicit', visible: next } })
+  }
+
+  if (toolsLoading) {
+    return (
+      <div className="space-y-2 py-4">
+        {[1, 2, 3].map((i) => (
+          <div
+            key={i}
+            className="h-9 rounded-md bg-[var(--color-surface-2)] animate-pulse"
+          />
+        ))}
+      </div>
+    )
+  }
+
+  if (toolsError) {
+    return (
+      <p className="text-xs text-[var(--color-error)] py-4">
+        Failed to load tool list. Check that the backend is running.
+      </p>
+    )
+  }
+
+  return (
+    <div className="space-y-5">
+      {/* Preset row */}
+      <div className="space-y-2">
+        <p className="text-xs text-[var(--color-muted)]">Quick-select a preset</p>
+        <ToolPickerPreset activePreset={activePreset} onSelect={applyPreset} />
+      </div>
+
+      {/* Tool list */}
+      <div className="space-y-1.5">
+        <p className="text-xs text-[var(--color-muted)]">
+          Tools available to this agent
+          {mcpError && (
+            <span className="text-[var(--color-warning)] ml-2">(MCP servers unavailable)</span>
+          )}
+        </p>
+        <ToolGroupList
+          tools={builtinTools}
+          selected={visibleTools}
+          agentType={agentType}
+          onToggle={toggleTool}
+        />
+      </div>
+
+      {/* MCP section */}
+      <div className="space-y-2">
+        <p className="text-xs font-medium text-[var(--color-secondary)]">MCP Servers</p>
+        <MCPServerPicker
+          servers={mcpServers}
+          mcpConfig={tools.mcp}
+          onChange={(mcp) => onChange({ ...tools, mcp })}
+        />
+      </div>
+
+      {/* Save — only shown when editing an existing agent */}
+      {agentId && (
+        <div className="pt-2 flex items-center gap-3">
+          <Button
+            size="sm"
+            onClick={() => doSave(tools)}
+            disabled={isSaving}
+            className="gap-2"
+          >
+            <FloppyDisk size={13} weight="bold" />
+            {isSaving ? 'Saving...' : 'Save Tool Permissions'}
+          </Button>
+          <span className="text-[10px] text-[var(--color-muted)]">
+            Selected: {visibleTools.length} tool{visibleTools.length !== 1 ? 's' : ''}
+          </span>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react'
+import * as CheckboxPrimitive from '@radix-ui/react-checkbox'
+import { Check } from '@phosphor-icons/react'
+import { cn } from '@/lib/utils'
+
+const Checkbox = React.forwardRef<
+  React.ElementRef<typeof CheckboxPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <CheckboxPrimitive.Root
+    ref={ref}
+    className={cn(
+      'peer h-4 w-4 shrink-0 rounded-sm border border-[var(--color-border)] bg-[var(--color-surface-1)]',
+      'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-primary)]',
+      'disabled:cursor-not-allowed disabled:opacity-50',
+      'data-[state=checked]:bg-[var(--color-accent)] data-[state=checked]:border-[var(--color-accent)] data-[state=checked]:text-[var(--color-primary)]',
+      className
+    )}
+    {...props}
+  >
+    <CheckboxPrimitive.Indicator className="flex items-center justify-center text-current">
+      <Check size={10} weight="bold" />
+    </CheckboxPrimitive.Indicator>
+  </CheckboxPrimitive.Root>
+))
+Checkbox.displayName = CheckboxPrimitive.Root.displayName
+
+export { Checkbox }

--- a/src/lib/agentToolPresets.ts
+++ b/src/lib/agentToolPresets.ts
@@ -1,0 +1,61 @@
+import {
+  BookOpen,
+  Code,
+  ListChecks,
+  Lightning,
+  SlidersHorizontal,
+} from '@phosphor-icons/react'
+import type { Icon } from '@phosphor-icons/react'
+
+export interface ToolPreset {
+  label: string
+  icon: Icon
+  tools: string[] | 'all'
+}
+
+export const TOOL_PRESETS = {
+  researcher: {
+    label: 'Read-only Researcher',
+    icon: BookOpen,
+    tools: ['read_file', 'list_dir', 'web_search', 'web_fetch', 'message'],
+  },
+  developer: {
+    label: 'Developer',
+    icon: Code,
+    tools: [
+      'read_file',
+      'write_file',
+      'edit_file',
+      'list_dir',
+      'exec',
+      'web_search',
+      'web_fetch',
+      'message',
+      'send_file',
+    ],
+  },
+  task_manager: {
+    label: 'Task Manager',
+    icon: ListChecks,
+    tools: [
+      'read_file',
+      'list_dir',
+      'task_list',
+      'task_create',
+      'task_update',
+      'message',
+    ],
+  },
+  unrestricted: {
+    label: 'Unrestricted',
+    icon: Lightning,
+    tools: 'all' as const,
+  },
+  custom: {
+    label: 'Custom',
+    icon: SlidersHorizontal,
+    tools: [] as string[],
+  },
+} as const satisfies Record<string, ToolPreset>
+
+export type PresetKey = keyof typeof TOOL_PRESETS

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -859,6 +859,39 @@ export function fetchRateLimits(): Promise<RateLimitStatus> {
   return request<RateLimitStatus>('/security/rate-limits')
 }
 
+// ── Agent Tools ───────────────────────────────────────────────────────────────
+
+export interface BuiltinTool {
+  name: string
+  scope: 'system' | 'core' | 'general'
+  category: string
+  description: string
+}
+
+export interface AgentToolsCfg {
+  builtin: { mode: 'explicit' | 'inherit'; visible?: string[] }
+  mcp?: { servers: { id: string; tools?: string[] }[] }
+}
+
+export function fetchBuiltinTools(): Promise<BuiltinTool[]> {
+  return request<BuiltinTool[]>('/tools/builtin')
+}
+
+export function fetchMcpServersForAgent(): Promise<McpServer[]> {
+  return request<McpServer[]>('/mcp-servers')
+}
+
+export function fetchAgentTools(agentId: string): Promise<{ config: AgentToolsCfg; effective_tools: BuiltinTool[] }> {
+  return request<{ config: AgentToolsCfg; effective_tools: BuiltinTool[] }>(`/agents/${encodeURIComponent(agentId)}/tools`)
+}
+
+export function updateAgentTools(agentId: string, cfg: AgentToolsCfg): Promise<{ config: AgentToolsCfg; effective_tools: BuiltinTool[] }> {
+  return request<{ config: AgentToolsCfg; effective_tools: BuiltinTool[] }>(`/agents/${encodeURIComponent(agentId)}/tools`, {
+    method: 'PUT',
+    body: JSON.stringify(cfg),
+  })
+}
+
 // ── Sandbox Status ────────────────────────────────────────────────────────────
 
 export interface SandboxStatus {


### PR DESCRIPTION
## Summary

- Adds 3-layer tool visibility model: `ToolScope` (system/core/general) on every tool, `FilterToolsByVisibility` with scope gate + explicit mode, and per-agent `AgentToolsCfg` with inherit/explicit modes
- 4 new REST endpoints: `GET/PUT /agents/{id}/tools`, `GET /tools/builtin`, `GET /tools/mcp`
- Frontend: Tools & Permissions tab in Create Agent modal with 5 presets, grouped tool list with checkboxes and core-scope warning badges, MCP server picker
- AgentProfile refactored to 7 collapsible accordion sections; system agent profile hides editable sections
- 26 new tests, all 7 review agents passed, full E2E regression with real OpenRouter LLM chat

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./pkg/tools/ ./pkg/config/ ./pkg/gateway/ ./pkg/agent/ ./pkg/sysagent/...` — all pass
- [x] `tsc --noEmit` — clean
- [x] `npm run build` — clean
- [x] 7 review agents + architect — all findings resolved
- [x] E2E regression on embedded SPA: onboarding → OpenRouter + glm-5-turbo → real multi-turn chat → create agent with tools preset → agent profile accordion + tools panel → system agent profile (no tools section)
- [x] Regression report: `docs/regression/2026-04-12-per-agent-tool-visibility.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)