### PR TITLE
security: Sprint A — RBAC admin-only enforcement (#98)

### DIFF
--- a/pkg/gateway/auth.go
+++ b/pkg/gateway/auth.go
@@ -18,28 +18,30 @@ import (
 	"golang.org/x/crypto/bcrypt"
 
 	"github.com/dapicom-ai/omnipus/pkg/config"
+	"github.com/dapicom-ai/omnipus/pkg/gateway/ctxkey"
 )
 
 var warnUnauthOnce sync.Once
 
-// configContextKey is used to store a snapshotted *config.Config in the request
-// context. This ensures all handlers within a single request see a consistent
-// config even during hot-reload, preventing the race where the config pointer
-// is replaced mid-iteration (~5-10% auth failures under concurrent load).
-type configContextKey struct{}
-
 // configFromContext retrieves the config snapshot stored by configSnapshotMiddleware.
 // Returns nil if no snapshot was stored (caller should fall back to GetConfig()).
 func configFromContext(ctx context.Context) *config.Config {
-	cfg, _ := ctx.Value(configContextKey{}).(*config.Config)
+	cfg, _ := ctx.Value(ctxkey.ConfigContextKey{}).(*config.Config)
 	return cfg
 }
 
-// RoleContextKey is the context key for storing the authenticated user's role.
-type RoleContextKey struct{}
+// configContextKey is an unexported alias for ctxkey.ConfigContextKey.
+// It is kept for internal use and test compatibility. External packages must
+// use ctxkey.ConfigContextKey directly.
+type configContextKey = ctxkey.ConfigContextKey
 
-// UserContextKey is the context key for storing the authenticated user config.
-type UserContextKey struct{}
+// RoleContextKey is an alias for ctxkey.RoleContextKey kept for compatibility
+// with existing code in this package that uses the gateway-local type name.
+type RoleContextKey = ctxkey.RoleContextKey
+
+// UserContextKey is an alias for ctxkey.UserContextKey kept for compatibility
+// with existing code in this package that uses the gateway-local type name.
+type UserContextKey = ctxkey.UserContextKey
 
 // AuthResult holds the outcome of a bearer token check.
 type AuthResult struct {
@@ -118,7 +120,7 @@ func MapUserRoleToPrincipal(ur config.UserRole) string {
 func (a *restAPI) configSnapshotMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		cfg := a.agentLoop.GetConfig()
-		ctx := context.WithValue(r.Context(), configContextKey{}, cfg)
+		ctx := context.WithValue(r.Context(), ctxkey.ConfigContextKey{}, cfg)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }

--- a/pkg/gateway/ctxkey/ctxkey.go
+++ b/pkg/gateway/ctxkey/ctxkey.go
@@ -1,0 +1,23 @@
+//go:build !cgo
+
+// Omnipus - Ultra-lightweight personal AI agent
+// License: MIT
+// Copyright (c) 2026 Omnipus contributors
+
+// Package ctxkey defines typed context keys shared between the gateway package
+// and its sub-packages (e.g. middleware). Keeping them in a dedicated leaf
+// package avoids circular imports while guaranteeing key identity (context
+// lookup uses the exact concrete type, so the key type must be shared).
+package ctxkey
+
+// RoleContextKey is the context key for storing the authenticated user's role.
+// The value stored is a config.UserRole (string alias).
+type RoleContextKey struct{}
+
+// UserContextKey is the context key for storing the authenticated *config.UserConfig.
+type UserContextKey struct{}
+
+// ConfigContextKey stores a snapshotted *config.Config in the request context
+// so all handlers within a single request see a consistent config even during
+// hot-reload.
+type ConfigContextKey struct{}

--- a/pkg/gateway/middleware/rbac.go
+++ b/pkg/gateway/middleware/rbac.go
@@ -1,0 +1,52 @@
+//go:build !cgo
+
+// Omnipus - Ultra-lightweight personal AI agent
+// License: MIT
+// Copyright (c) 2026 Omnipus contributors
+
+// Package middleware provides HTTP middleware for the Omnipus gateway.
+package middleware
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/dapicom-ai/omnipus/pkg/config"
+	"github.com/dapicom-ai/omnipus/pkg/gateway/ctxkey"
+)
+
+// RequireAdmin returns a middleware that enforces admin-only access.
+//
+// Response matrix:
+//   - No role in context (auth middleware skipped or token unrecognised) → 401
+//   - Authenticated user with role != admin → 403 + {"error":"admin required"}
+//   - Authenticated admin → delegates to next handler unchanged
+//
+// This middleware must sit after withAuth, which is the layer that verifies the
+// bearer token and writes the role into the request context via RoleContextKey.
+func RequireAdmin(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		role, ok := r.Context().Value(ctxkey.RoleContextKey{}).(config.UserRole)
+		if !ok || role == "" {
+			// No role in context means the auth middleware did not run or did
+			// not recognise the token — treat as unauthenticated.
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
+			if err := json.NewEncoder(w).Encode(map[string]string{"error": "unauthorized"}); err != nil {
+				// Nothing useful to do after headers are sent; error is already
+				// logged by the http.Server at the transport level.
+				_ = err
+			}
+			return
+		}
+		if role != config.UserRoleAdmin {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusForbidden)
+			if err := json.NewEncoder(w).Encode(map[string]string{"error": "admin required"}); err != nil {
+				_ = err
+			}
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/pkg/gateway/middleware/rbac.go
+++ b/pkg/gateway/middleware/rbac.go
@@ -18,7 +18,7 @@ import (
 // RequireAdmin returns a middleware that enforces admin-only access.
 //
 // Response matrix:
-//   - No role in context (auth middleware skipped or token unrecognised) → 401
+//   - No role in context (auth middleware skipped or token unrecognized) → 401
 //   - Authenticated user with role != admin → 403 + {"error":"admin required"}
 //   - Authenticated admin → delegates to next handler unchanged
 //
@@ -29,7 +29,7 @@ func RequireAdmin(next http.Handler) http.Handler {
 		role, ok := r.Context().Value(ctxkey.RoleContextKey{}).(config.UserRole)
 		if !ok || role == "" {
 			// No role in context means the auth middleware did not run or did
-			// not recognise the token — treat as unauthenticated.
+			// not recognize the token — treat as unauthenticated.
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusUnauthorized)
 			if err := json.NewEncoder(w).Encode(map[string]string{"error": "unauthorized"}); err != nil {

--- a/pkg/gateway/middleware/rbac_test.go
+++ b/pkg/gateway/middleware/rbac_test.go
@@ -1,0 +1,94 @@
+//go:build !cgo
+
+// Omnipus - Ultra-lightweight personal AI agent
+// License: MIT
+// Copyright (c) 2026 Omnipus contributors
+
+package middleware_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapicom-ai/omnipus/pkg/config"
+	"github.com/dapicom-ai/omnipus/pkg/gateway/ctxkey"
+	"github.com/dapicom-ai/omnipus/pkg/gateway/middleware"
+)
+
+// sentinel handler that writes 200 so we know the next handler was called.
+var okHandler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusOK)
+})
+
+func requestWithRole(role config.UserRole) *http.Request {
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	if role != "" {
+		ctx := context.WithValue(r.Context(), ctxkey.RoleContextKey{}, role)
+		r = r.WithContext(ctx)
+	}
+	return r
+}
+
+// TestRequireAdmin_Anonymous verifies that requests with no role in context
+// (simulating a request that bypassed the auth middleware) receive 401.
+func TestRequireAdmin_Anonymous(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/", nil) // no role in context
+	w := httptest.NewRecorder()
+
+	middleware.RequireAdmin(okHandler).ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+
+	var body map[string]string
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&body))
+	assert.Equal(t, "unauthorized", body["error"])
+}
+
+// TestRequireAdmin_UserRole verifies that requests from a user-role principal
+// receive 403 with an "admin required" error body.
+func TestRequireAdmin_UserRole(t *testing.T) {
+	w := httptest.NewRecorder()
+
+	middleware.RequireAdmin(okHandler).ServeHTTP(w, requestWithRole(config.UserRoleUser))
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+
+	var body map[string]string
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&body))
+	assert.Equal(t, "admin required", body["error"])
+}
+
+// TestRequireAdmin_AdminRole verifies that admin-role requests pass through to
+// the wrapped handler unchanged.
+func TestRequireAdmin_AdminRole(t *testing.T) {
+	w := httptest.NewRecorder()
+
+	middleware.RequireAdmin(okHandler).ServeHTTP(w, requestWithRole(config.UserRoleAdmin))
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+// TestRequireAdmin_MissingRoleInContext simulates the defense-in-depth case
+// where a role key exists in context but holds a zero value (empty string),
+// which should be treated identically to no role at all (→ 401).
+func TestRequireAdmin_MissingRoleInContext(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	// Explicitly store an empty string — not the zero-value absence.
+	ctx := context.WithValue(r.Context(), ctxkey.RoleContextKey{}, config.UserRole(""))
+	r = r.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	middleware.RequireAdmin(okHandler).ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+
+	var body map[string]string
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&body))
+	assert.Equal(t, "unauthorized", body["error"])
+}

--- a/pkg/gateway/rest.go
+++ b/pkg/gateway/rest.go
@@ -34,6 +34,7 @@ import (
 	"github.com/dapicom-ai/omnipus/pkg/coreagent"
 	"github.com/dapicom-ai/omnipus/pkg/credentials"
 	"github.com/dapicom-ai/omnipus/pkg/fileutil"
+	"github.com/dapicom-ai/omnipus/pkg/gateway/middleware"
 	"github.com/dapicom-ai/omnipus/pkg/media"
 	"github.com/dapicom-ai/omnipus/pkg/onboarding"
 	providers_pkg "github.com/dapicom-ai/omnipus/pkg/providers"
@@ -1351,12 +1352,20 @@ func (a *restAPI) updateAgent(w http.ResponseWriter, r *http.Request, id string)
 // --- Config ---
 
 // HandleConfig handles GET /api/v1/config and PUT /api/v1/config.
+// PUT is restricted to admin-role users (Issue #98): mutating gateway config
+// can change ports, dev_mode_bypass, and provider settings — a critical
+// privilege that must not be available to user-role accounts.
 func (a *restAPI) HandleConfig(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
 		a.getConfig(w)
 	case http.MethodPut:
-		a.updateConfig(w, r)
+		// Enforce admin-only for config mutations. withAuth has already run and
+		// written the role into the context; RequireAdmin reads it from there.
+		adminGuard := middleware.RequireAdmin(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			a.updateConfig(w, r)
+		}))
+		adminGuard.ServeHTTP(w, r)
 	default:
 		jsonErr(w, http.StatusMethodNotAllowed, "method not allowed")
 	}
@@ -1886,7 +1895,12 @@ func (a *restAPI) registerAdditionalEndpoints(cm httpHandlerRegistrar) {
 	cm.RegisterHTTPHandler("/api/v1/activity", a.withAuth(a.HandleActivity))
 
 	// Settings endpoints (Wave 4).
-	cm.RegisterHTTPHandler("/api/v1/audit-log", a.withAuth(a.HandleAuditLog))
+	// GET /api/v1/audit-log — admin-only: audit log contains every admin
+	// action, tool-use trace, and LLM request. A user-role leak here exposes
+	// the full activity history to non-privileged accounts (Issue #98).
+	// Chain: withAuth (verifies token, writes role into ctx) → RequireAdmin (checks role).
+	cm.RegisterHTTPHandler("/api/v1/audit-log",
+		a.withAuth(middleware.RequireAdmin(http.HandlerFunc(a.HandleAuditLog)).ServeHTTP))
 	cm.RegisterHTTPHandler("/api/v1/security/exec-allowlist", a.withAuth(a.HandleExecAllowlist))
 	// Wave 3 security endpoints (SEC-25, SEC-28).
 	cm.RegisterHTTPHandler("/api/v1/security/exec-proxy-status", a.withAuth(a.HandleExecProxyStatus))
@@ -1895,10 +1909,17 @@ func (a *restAPI) registerAdditionalEndpoints(cm httpHandlerRegistrar) {
 	cm.RegisterHTTPHandler("/api/v1/security/rate-limits", a.withAuth(a.HandleRateLimits))
 	// Wave 5 security endpoints (SEC-01/02/03).
 	cm.RegisterHTTPHandler("/api/v1/security/sandbox-status", a.withAuth(a.HandleSandboxStatus))
-	// Global tool policies endpoint.
+	// GET /api/v1/security/tool-policies — read available to all authenticated
+	// users; PUT is admin-only (enforced inside HandleToolPolicies, Issue #98).
 	cm.RegisterHTTPHandler("/api/v1/security/tool-policies", a.withAuth(a.HandleToolPolicies))
-	cm.RegisterHTTPHandler("/api/v1/credentials", a.withAuth(a.HandleCredentials))
-	cm.RegisterHTTPHandler("/api/v1/credentials/", a.withAuth(a.HandleCredentials))
+	// GET /api/v1/credentials — admin-only: even though plaintext is not
+	// returned, the credential ref names reveal what integrations exist
+	// (Issue #98).
+	// Chain: withAuth (verifies token, writes role into ctx) → RequireAdmin (checks role).
+	cm.RegisterHTTPHandler("/api/v1/credentials",
+		a.withAuth(middleware.RequireAdmin(http.HandlerFunc(a.HandleCredentials)).ServeHTTP))
+	cm.RegisterHTTPHandler("/api/v1/credentials/",
+		a.withAuth(middleware.RequireAdmin(http.HandlerFunc(a.HandleCredentials)).ServeHTTP))
 	cm.RegisterHTTPHandler("/api/v1/media/", a.withOptionalAuth(a.HandleMedia))
 	cm.RegisterHTTPHandler("/api/v1/backup", a.withAuth(a.HandleCreateBackup))
 	cm.RegisterHTTPHandler("/api/v1/backups", a.withAuth(a.HandleListBackups))

--- a/pkg/gateway/rest_tool_policies.go
+++ b/pkg/gateway/rest_tool_policies.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 
 	"github.com/dapicom-ai/omnipus/pkg/audit"
+	"github.com/dapicom-ai/omnipus/pkg/gateway/middleware"
 )
 
 // HandleToolPolicies handles GET/PUT /api/v1/security/tool-policies.
@@ -50,91 +51,102 @@ func (a *restAPI) HandleToolPolicies(w http.ResponseWriter, r *http.Request) {
 		})
 
 	case http.MethodPut:
-		r.Body = http.MaxBytesReader(w, r.Body, 1<<20) // 1 MB limit
-		var body struct {
-			DefaultPolicy string            `json:"default_policy"`
-			Policies      map[string]string `json:"policies"`
-		}
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			jsonErr(w, http.StatusBadRequest, "invalid JSON body")
-			return
-		}
-
-		// Validate default_policy.
-		switch body.DefaultPolicy {
-		case "", "allow", "ask", "deny":
-			// valid; empty string is treated as "allow"
-		default:
-			jsonErr(w, http.StatusBadRequest, "default_policy must be 'allow', 'ask', or 'deny'")
-			return
-		}
-		if body.DefaultPolicy == "" {
-			body.DefaultPolicy = "allow"
-		}
-
-		// Validate per-tool policies.
-		for toolName, p := range body.Policies {
-			switch p {
-			case "allow", "ask", "deny":
-				// valid
-			default:
-				jsonErr(w, http.StatusBadRequest,
-					"policies["+toolName+"]: value must be 'allow', 'ask', or 'deny'")
-				return
-			}
-		}
-
-		// Persist to config.json under the sandbox key, preserving all other fields.
-		if err := a.safeUpdateConfigJSON(func(m map[string]any) error {
-			sandbox, _ := m["sandbox"].(map[string]any)
-			if sandbox == nil {
-				sandbox = map[string]any{}
-				m["sandbox"] = sandbox
-			}
-			sandbox["default_tool_policy"] = body.DefaultPolicy
-			if body.Policies != nil {
-				sandbox["tool_policies"] = body.Policies
-			} else {
-				// Explicit null from the client clears the map.
-				sandbox["tool_policies"] = map[string]any{}
-			}
-			return nil
-		}); err != nil {
-			slog.Error("rest: update tool policies", "error", err)
-			jsonErr(w, http.StatusInternalServerError, "could not save config")
-			return
-		}
-
-		// SEC-15: audit-log the policy change.
-		if a.agentLoop != nil {
-			if auditLogger := a.agentLoop.AuditLogger(); auditLogger != nil {
-				if err := auditLogger.Log(&audit.Entry{
-					Event:    audit.EventPolicyEval,
-					Decision: audit.DecisionAllow,
-					Details: map[string]any{
-						"action":         "tool_policies_update",
-						"default_policy": body.DefaultPolicy,
-						"policy_count":   len(body.Policies),
-					},
-				}); err != nil {
-					slog.Warn("rest: audit log tool policies update", "error", err)
-				}
-			}
-		}
-
-		slog.Info("rest: global tool policies updated",
-			"default_policy", body.DefaultPolicy,
-			"policy_count", len(body.Policies),
-		)
-
-		// Return the persisted state. Changes take effect immediately because
-		// safeUpdateConfigJSON hot-reloads the in-memory config after the write.
-		jsonOK(w, map[string]any{
-			"default_policy": body.DefaultPolicy,
-			"policies":       body.Policies,
-		})
+		// PUT mutates tool policies — admin-only (Issue #98). GET remains
+		// readable by all authenticated users.
+		adminGuard := middleware.RequireAdmin(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			a.putToolPolicies(w, r)
+		}))
+		adminGuard.ServeHTTP(w, r)
 
 	default:
 		jsonErr(w, http.StatusMethodNotAllowed, "method not allowed")
 	}
+}
+
+// putToolPolicies is the admin-only body of PUT /api/v1/security/tool-policies.
+// It is called only after RequireAdmin has confirmed the caller holds admin role.
+func (a *restAPI) putToolPolicies(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20) // 1 MB limit
+	var body struct {
+		DefaultPolicy string            `json:"default_policy"`
+		Policies      map[string]string `json:"policies"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		jsonErr(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+
+	// Validate default_policy.
+	switch body.DefaultPolicy {
+	case "", "allow", "ask", "deny":
+		// valid; empty string is treated as "allow"
+	default:
+		jsonErr(w, http.StatusBadRequest, "default_policy must be 'allow', 'ask', or 'deny'")
+		return
+	}
+	if body.DefaultPolicy == "" {
+		body.DefaultPolicy = "allow"
+	}
+
+	// Validate per-tool policies.
+	for toolName, p := range body.Policies {
+		switch p {
+		case "allow", "ask", "deny":
+			// valid
+		default:
+			jsonErr(w, http.StatusBadRequest,
+				"policies["+toolName+"]: value must be 'allow', 'ask', or 'deny'")
+			return
+		}
+	}
+
+	// Persist to config.json under the sandbox key, preserving all other fields.
+	if err := a.safeUpdateConfigJSON(func(m map[string]any) error {
+		sandbox, _ := m["sandbox"].(map[string]any)
+		if sandbox == nil {
+			sandbox = map[string]any{}
+			m["sandbox"] = sandbox
+		}
+		sandbox["default_tool_policy"] = body.DefaultPolicy
+		if body.Policies != nil {
+			sandbox["tool_policies"] = body.Policies
+		} else {
+			// Explicit null from the client clears the map.
+			sandbox["tool_policies"] = map[string]any{}
+		}
+		return nil
+	}); err != nil {
+		slog.Error("rest: update tool policies", "error", err)
+		jsonErr(w, http.StatusInternalServerError, "could not save config")
+		return
+	}
+
+	// SEC-15: audit-log the policy change.
+	if a.agentLoop != nil {
+		if auditLogger := a.agentLoop.AuditLogger(); auditLogger != nil {
+			if err := auditLogger.Log(&audit.Entry{
+				Event:    audit.EventPolicyEval,
+				Decision: audit.DecisionAllow,
+				Details: map[string]any{
+					"action":         "tool_policies_update",
+					"default_policy": body.DefaultPolicy,
+					"policy_count":   len(body.Policies),
+				},
+			}); err != nil {
+				slog.Warn("rest: audit log tool policies update", "error", err)
+			}
+		}
+	}
+
+	slog.Info("rest: global tool policies updated",
+		"default_policy", body.DefaultPolicy,
+		"policy_count", len(body.Policies),
+	)
+
+	// Return the persisted state. Changes take effect immediately because
+	// safeUpdateConfigJSON hot-reloads the in-memory config after the write.
+	jsonOK(w, map[string]any{
+		"default_policy": body.DefaultPolicy,
+		"policies":       body.Policies,
+	})
 }

--- a/pkg/gateway/rest_tool_policies_test.go
+++ b/pkg/gateway/rest_tool_policies_test.go
@@ -7,6 +7,7 @@
 package gateway
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -15,7 +16,18 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/dapicom-ai/omnipus/pkg/config"
 )
+
+// withAdminRole injects config.UserRoleAdmin into the request context so that
+// RequireAdmin middleware allows the request through. Unit tests that call
+// handlers directly (bypassing withAuth) must use this helper for PUT/admin
+// endpoints.
+func withAdminRole(r *http.Request) *http.Request {
+	ctx := context.WithValue(r.Context(), RoleContextKey{}, config.UserRoleAdmin)
+	return r.WithContext(ctx)
+}
 
 // TestHandleToolPolicies_GET_EmptyState verifies that GET returns the default
 // shape when no tool policies have been configured.
@@ -44,6 +56,7 @@ func TestHandleToolPolicies_PUT_ReturnsPersistedValues(t *testing.T) {
 	body := `{"default_policy":"ask","policies":{"exec":"deny","web_search":"allow"}}`
 	r := httptest.NewRequest(http.MethodPut, "/api/v1/security/tool-policies", strings.NewReader(body))
 	r.Header.Set("Content-Type", "application/json")
+	r = withAdminRole(r) // RequireAdmin requires admin role in context
 	w := httptest.NewRecorder()
 	api.HandleToolPolicies(w, r)
 
@@ -67,6 +80,7 @@ func TestHandleToolPolicies_PUT_ReadBack(t *testing.T) {
 	putBody := `{"default_policy":"deny","policies":{"browser.evaluate":"ask"}}`
 	putReq := httptest.NewRequest(http.MethodPut, "/api/v1/security/tool-policies", strings.NewReader(putBody))
 	putReq.Header.Set("Content-Type", "application/json")
+	putReq = withAdminRole(putReq) // RequireAdmin requires admin role in context
 	putW := httptest.NewRecorder()
 	api.HandleToolPolicies(putW, putReq)
 	require.Equal(t, http.StatusOK, putW.Code, "PUT must succeed: %s", putW.Body)
@@ -91,6 +105,7 @@ func TestHandleToolPolicies_PUT_InvalidDefaultPolicy(t *testing.T) {
 	body := `{"default_policy":"invalid"}`
 	r := httptest.NewRequest(http.MethodPut, "/api/v1/security/tool-policies", strings.NewReader(body))
 	r.Header.Set("Content-Type", "application/json")
+	r = withAdminRole(r) // RequireAdmin requires admin role in context
 	w := httptest.NewRecorder()
 	api.HandleToolPolicies(w, r)
 
@@ -104,6 +119,7 @@ func TestHandleToolPolicies_PUT_InvalidPerToolPolicy(t *testing.T) {
 	body := `{"default_policy":"allow","policies":{"exec":"maybe"}}`
 	r := httptest.NewRequest(http.MethodPut, "/api/v1/security/tool-policies", strings.NewReader(body))
 	r.Header.Set("Content-Type", "application/json")
+	r = withAdminRole(r) // RequireAdmin requires admin role in context
 	w := httptest.NewRecorder()
 	api.HandleToolPolicies(w, r)
 
@@ -115,6 +131,7 @@ func TestHandleToolPolicies_PUT_BadJSON(t *testing.T) {
 	api := newTestRestAPIWithHome(t)
 	r := httptest.NewRequest(http.MethodPut, "/api/v1/security/tool-policies",
 		strings.NewReader(`not-json`))
+	r = withAdminRole(r) // RequireAdmin requires admin role in context
 	w := httptest.NewRecorder()
 	api.HandleToolPolicies(w, r)
 

--- a/tests/security/authz_matrix_test.go
+++ b/tests/security/authz_matrix_test.go
@@ -101,7 +101,14 @@ func authzMatrix() []matrixCase {
 		{roleAdmin, http.MethodGet, "/api/v1/security/rate-limits", "", []int{200}, "", ""},
 
 		{role: roleAnon, method: http.MethodGet, path: "/api/v1/audit-log", expectStatus: []int{401}},
-		{role: roleUser, method: http.MethodGet, path: "/api/v1/audit-log", expectStatus: []int{403}, note: "admin-only: user must receive 403 (Issue #98)", wantBodyContains: "admin required"},
+		{
+			role:             roleUser,
+			method:           http.MethodGet,
+			path:             "/api/v1/audit-log",
+			expectStatus:     []int{403},
+			note:             "admin-only: user must receive 403 (Issue #98)",
+			wantBodyContains: "admin required",
+		},
 		{role: roleAdmin, method: http.MethodGet, path: "/api/v1/audit-log", expectStatus: []int{200}},
 
 		// ---- Write surface: createAgent (POST) ----

--- a/tests/security/authz_matrix_test.go
+++ b/tests/security/authz_matrix_test.go
@@ -53,6 +53,9 @@ type matrixCase struct {
 	expectStatus []int
 	// note describes expected behavior for debugging.
 	note string
+	// wantBodyContains, if non-empty, asserts the response body contains the
+	// given substring. Checked only after status assertion passes.
+	wantBodyContains string
 }
 
 // authzMatrix returns the full ≥30 row matrix. The cases below reflect TODAY'S
@@ -61,64 +64,64 @@ type matrixCase struct {
 func authzMatrix() []matrixCase {
 	return []matrixCase{
 		// ---- Read surface: all three roles ----
-		{roleAnon, http.MethodGet, "/api/v1/agents", "", []int{401}, "anon must be rejected"},
-		{roleUser, http.MethodGet, "/api/v1/agents", "", []int{200}, "user may read agent list"},
-		{roleAdmin, http.MethodGet, "/api/v1/agents", "", []int{200}, "admin may read agent list"},
+		{roleAnon, http.MethodGet, "/api/v1/agents", "", []int{401}, "anon must be rejected", ""},
+		{roleUser, http.MethodGet, "/api/v1/agents", "", []int{200}, "user may read agent list", ""},
+		{roleAdmin, http.MethodGet, "/api/v1/agents", "", []int{200}, "admin may read agent list", ""},
 
-		{roleAnon, http.MethodGet, "/api/v1/config", "", []int{401}, ""},
-		{roleUser, http.MethodGet, "/api/v1/config", "", []int{200}, ""},
-		{roleAdmin, http.MethodGet, "/api/v1/config", "", []int{200}, ""},
+		{roleAnon, http.MethodGet, "/api/v1/config", "", []int{401}, "", ""},
+		{roleUser, http.MethodGet, "/api/v1/config", "", []int{200}, "", ""},
+		{roleAdmin, http.MethodGet, "/api/v1/config", "", []int{200}, "", ""},
 
-		{roleAnon, http.MethodGet, "/api/v1/status", "", []int{401}, ""},
-		{roleUser, http.MethodGet, "/api/v1/status", "", []int{200}, ""},
-		{roleAdmin, http.MethodGet, "/api/v1/status", "", []int{200}, ""},
+		{roleAnon, http.MethodGet, "/api/v1/status", "", []int{401}, "", ""},
+		{roleUser, http.MethodGet, "/api/v1/status", "", []int{200}, "", ""},
+		{roleAdmin, http.MethodGet, "/api/v1/status", "", []int{200}, "", ""},
 
-		{roleAnon, http.MethodGet, "/api/v1/tasks", "", []int{401}, ""},
-		{roleUser, http.MethodGet, "/api/v1/tasks", "", []int{200}, ""},
-		{roleAdmin, http.MethodGet, "/api/v1/tasks", "", []int{200}, ""},
+		{roleAnon, http.MethodGet, "/api/v1/tasks", "", []int{401}, "", ""},
+		{roleUser, http.MethodGet, "/api/v1/tasks", "", []int{200}, "", ""},
+		{roleAdmin, http.MethodGet, "/api/v1/tasks", "", []int{200}, "", ""},
 
-		{roleAnon, http.MethodGet, "/api/v1/tools", "", []int{401}, ""},
-		{roleUser, http.MethodGet, "/api/v1/tools", "", []int{200}, ""},
-		{roleAdmin, http.MethodGet, "/api/v1/tools", "", []int{200}, ""},
+		{roleAnon, http.MethodGet, "/api/v1/tools", "", []int{401}, "", ""},
+		{roleUser, http.MethodGet, "/api/v1/tools", "", []int{200}, "", ""},
+		{roleAdmin, http.MethodGet, "/api/v1/tools", "", []int{200}, "", ""},
 
-		{roleAnon, http.MethodGet, "/api/v1/sessions", "", []int{401}, ""},
-		{roleUser, http.MethodGet, "/api/v1/sessions", "", []int{200}, ""},
-		{roleAdmin, http.MethodGet, "/api/v1/sessions", "", []int{200}, ""},
+		{roleAnon, http.MethodGet, "/api/v1/sessions", "", []int{401}, "", ""},
+		{roleUser, http.MethodGet, "/api/v1/sessions", "", []int{200}, "", ""},
+		{roleAdmin, http.MethodGet, "/api/v1/sessions", "", []int{200}, "", ""},
 
-		{roleAnon, http.MethodGet, "/api/v1/security/sandbox-status", "", []int{401}, ""},
-		{roleUser, http.MethodGet, "/api/v1/security/sandbox-status", "", []int{200}, ""},
-		{roleAdmin, http.MethodGet, "/api/v1/security/sandbox-status", "", []int{200}, ""},
+		{roleAnon, http.MethodGet, "/api/v1/security/sandbox-status", "", []int{401}, "", ""},
+		{roleUser, http.MethodGet, "/api/v1/security/sandbox-status", "", []int{200}, "", ""},
+		{roleAdmin, http.MethodGet, "/api/v1/security/sandbox-status", "", []int{200}, "", ""},
 
-		{roleAnon, http.MethodGet, "/api/v1/security/tool-policies", "", []int{401}, ""},
-		{roleUser, http.MethodGet, "/api/v1/security/tool-policies", "", []int{200}, ""},
-		{roleAdmin, http.MethodGet, "/api/v1/security/tool-policies", "", []int{200}, ""},
+		{roleAnon, http.MethodGet, "/api/v1/security/tool-policies", "", []int{401}, "", ""},
+		{roleUser, http.MethodGet, "/api/v1/security/tool-policies", "", []int{200}, "", ""},
+		{roleAdmin, http.MethodGet, "/api/v1/security/tool-policies", "", []int{200}, "", ""},
 
-		{roleAnon, http.MethodGet, "/api/v1/security/rate-limits", "", []int{401}, ""},
-		{roleUser, http.MethodGet, "/api/v1/security/rate-limits", "", []int{200}, ""},
-		{roleAdmin, http.MethodGet, "/api/v1/security/rate-limits", "", []int{200}, ""},
+		{roleAnon, http.MethodGet, "/api/v1/security/rate-limits", "", []int{401}, "", ""},
+		{roleUser, http.MethodGet, "/api/v1/security/rate-limits", "", []int{200}, "", ""},
+		{roleAdmin, http.MethodGet, "/api/v1/security/rate-limits", "", []int{200}, "", ""},
 
-		{roleAnon, http.MethodGet, "/api/v1/audit-log", "", []int{401}, ""},
-		{roleUser, http.MethodGet, "/api/v1/audit-log", "", []int{200}, "GAP: user can read audit log (admin-only?)"},
-		{roleAdmin, http.MethodGet, "/api/v1/audit-log", "", []int{200}, ""},
+		{role: roleAnon, method: http.MethodGet, path: "/api/v1/audit-log", expectStatus: []int{401}},
+		{role: roleUser, method: http.MethodGet, path: "/api/v1/audit-log", expectStatus: []int{403}, note: "admin-only: user must receive 403 (Issue #98)", wantBodyContains: "admin required"},
+		{role: roleAdmin, method: http.MethodGet, path: "/api/v1/audit-log", expectStatus: []int{200}},
 
 		// ---- Write surface: createAgent (POST) ----
 		{
 			roleAnon, http.MethodPost, "/api/v1/agents",
 			`{"name":"a1","model":"scripted-model"}`,
 			[]int{401},
-			"",
+			"", "",
 		},
 		{
 			roleUser, http.MethodPost, "/api/v1/agents",
 			`{"name":"authz-user-a","model":"scripted-model"}`,
 			[]int{200, 201},
-			"GAP: user can create agents (admin-only?)",
+			"GAP: user can create agents (admin-only?)", "",
 		},
 		{
 			roleAdmin, http.MethodPost, "/api/v1/agents",
 			`{"name":"authz-admin-a","model":"scripted-model"}`,
 			[]int{200, 201},
-			"",
+			"", "",
 		},
 
 		// ---- Write surface: sessions POST ----
@@ -126,19 +129,19 @@ func authzMatrix() []matrixCase {
 			roleAnon, http.MethodPost, "/api/v1/sessions",
 			`{"agent_id":"omnipus-system","type":"chat"}`,
 			[]int{401},
-			"",
+			"", "",
 		},
 		{
 			roleUser, http.MethodPost, "/api/v1/sessions",
 			`{"agent_id":"omnipus-system","type":"chat"}`,
 			[]int{201, 400},
-			"agent existence depends on seed",
+			"agent existence depends on seed", "",
 		},
 		{
 			roleAdmin, http.MethodPost, "/api/v1/sessions",
 			`{"agent_id":"omnipus-system","type":"chat"}`,
 			[]int{201, 400},
-			"agent existence depends on seed",
+			"agent existence depends on seed", "",
 		},
 
 		// ---- Config PUT (admin-only in any reasonable model) ----
@@ -146,19 +149,20 @@ func authzMatrix() []matrixCase {
 			roleAnon, http.MethodPut, "/api/v1/config",
 			`{"agents":{"defaults":{}}}`,
 			[]int{401},
-			"",
+			"", "",
 		},
 		{
-			roleUser, http.MethodPut, "/api/v1/config",
-			`{"agents":{"defaults":{}}}`,
-			[]int{200, 400, 403},
-			"GAP-CANDIDATE: user-role PUT /config — may or may not be restricted",
+			role: roleUser, method: http.MethodPut, path: "/api/v1/config",
+			body:             `{"agents":{"defaults":{}}}`,
+			expectStatus:     []int{403},
+			note:             "admin-only: user must be rejected with 403 (Issue #98)",
+			wantBodyContains: "admin required",
 		},
 		{
 			roleAdmin, http.MethodPut, "/api/v1/config",
 			`{"agents":{"defaults":{}}}`,
 			[]int{200, 400},
-			"",
+			"", "",
 		},
 
 		// ---- tool-policies PUT (admin-only in any reasonable model) ----
@@ -166,29 +170,31 @@ func authzMatrix() []matrixCase {
 			roleAnon, http.MethodPut, "/api/v1/security/tool-policies",
 			`{"tool_policies":{}}`,
 			[]int{401},
-			"",
+			"", "",
 		},
 		{
-			roleUser, http.MethodPut, "/api/v1/security/tool-policies",
-			`{"tool_policies":{}}`,
-			[]int{200, 400, 403},
-			"GAP-CANDIDATE: user-role PUT tool-policies",
+			role: roleUser, method: http.MethodPut, path: "/api/v1/security/tool-policies",
+			body:             `{"tool_policies":{}}`,
+			expectStatus:     []int{403},
+			note:             "admin-only: user must be rejected with 403 (Issue #98)",
+			wantBodyContains: "admin required",
 		},
 		{
 			roleAdmin, http.MethodPut, "/api/v1/security/tool-policies",
 			`{"tool_policies":{}}`,
 			[]int{200, 400},
-			"",
+			"", "",
 		},
 
 		// ---- Credentials (admin-only even in simple models) ----
-		{roleAnon, http.MethodGet, "/api/v1/credentials", "", []int{401}, ""},
+		{roleAnon, http.MethodGet, "/api/v1/credentials", "", []int{401}, "", ""},
 		{
-			roleUser, http.MethodGet, "/api/v1/credentials", "",
-			[]int{200, 403},
-			"GAP-CANDIDATE: user reading credentials list",
+			role: roleUser, method: http.MethodGet, path: "/api/v1/credentials",
+			expectStatus:     []int{403},
+			note:             "admin-only: user must be rejected with 403 (Issue #98)",
+			wantBodyContains: "admin required",
 		},
-		{roleAdmin, http.MethodGet, "/api/v1/credentials", "", []int{200}, ""},
+		{roleAdmin, http.MethodGet, "/api/v1/credentials", "", []int{200}, "", ""},
 	}
 }
 
@@ -238,6 +244,9 @@ func TestAuthorizationMatrix(t *testing.T) {
 			}
 			defer resp.Body.Close()
 
+			raw, _ := io.ReadAll(resp.Body)
+			rawStr := string(raw)
+
 			ok := false
 			for _, want := range tc.expectStatus {
 				if resp.StatusCode == want {
@@ -246,18 +255,23 @@ func TestAuthorizationMatrix(t *testing.T) {
 				}
 			}
 			if !ok {
-				raw, _ := io.ReadAll(resp.Body)
 				note := tc.note
 				if note == "" {
 					note = "(no note)"
 				}
 				t.Fatalf("role=%s %s %s: got status %d, want one of %v. Body: %s. Note: %s",
 					tc.role, tc.method, tc.path, resp.StatusCode,
-					tc.expectStatus, truncate(string(raw), 200), note)
+					tc.expectStatus, truncate(rawStr, 200), note)
 			}
 			if tc.note != "" {
 				t.Logf("note: %s (role=%s %s %s -> %d)",
 					tc.note, tc.role, tc.method, tc.path, resp.StatusCode)
+			}
+			// Body substring assertion for admin-enforced 403 responses (Issue #98).
+			if tc.wantBodyContains != "" {
+				assert.Contains(t, rawStr, tc.wantBodyContains,
+					"role=%s %s %s: response body must contain %q",
+					tc.role, tc.method, tc.path, tc.wantBodyContains)
 			}
 			assert.Less(t, resp.StatusCode, 500,
 				"server must not 5xx for any matrix row (role=%s %s %s)",

--- a/tests/security/helpers_test.go
+++ b/tests/security/helpers_test.go
@@ -119,17 +119,53 @@ func gatewayWithRBAC(t *testing.T) (gw *testutil.TestGateway, adminToken, userTo
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(cfgPath, out, 0o600))
 
-	// Trigger reload by hitting the config endpoint — or wait ~400 ms for the
-	// periodic reload if enabled. The test gateway has HotReload=false, so the
-	// cleanest path is to use the configured SIGHUP-equivalent: /reload.
+	// Trigger reload by hitting the /reload endpoint. This is asynchronous —
+	// the endpoint queues the reload and returns immediately; the actual config
+	// swap happens in the RunContext goroutine. We must NOT rely on a fixed
+	// sleep here because the reload duration is unpredictable in CI. Instead
+	// we use a probe loop (Option A): poll GET /api/v1/agents with the user
+	// token until we receive a non-401 response, confirming the new config
+	// has been picked up by the auth middleware.
 	reloadReq, err := gw.NewRequest(http.MethodPost, "/reload", nil)
-	if err == nil {
-		if reloadResp, err := gw.Do(reloadReq); err == nil {
-			_ = reloadResp.Body.Close()
+	require.NoError(t, err, "failed to build /reload request")
+	reloadResp, err := gw.Do(reloadReq)
+	require.NoError(t, err, "failed to POST /reload")
+	_ = reloadResp.Body.Close()
+	require.Equal(t, http.StatusOK, reloadResp.StatusCode,
+		"POST /reload must return 200 (got %d)", reloadResp.StatusCode)
+
+	// Wait for the non-admin user to be recognized by polling with their token.
+	// A 401 means the reload has not propagated yet. A 200 or 403 means the
+	// gateway's auth layer is aware of the new user list.
+	//
+	// Timeout: 5 s with 100 ms poll interval = 50 attempts. In CI, the reload
+	// typically completes within 200-400 ms; 5 s is a safe ceiling.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		probeReq, probeErr := http.NewRequest(http.MethodGet, gw.URL+"/api/v1/agents", nil)
+		require.NoError(t, probeErr, "failed to build probe request")
+		probeReq.Header.Set("Origin", gw.URL)
+		probeReq.Header.Set("Authorization", "Bearer "+userPlain)
+
+		probeResp, probeErr := gw.HTTPClient.Do(probeReq)
+		if probeErr == nil {
+			status := probeResp.StatusCode
+			_ = probeResp.Body.Close()
+			// 200 or any non-401 means the user was recognized.
+			if status != http.StatusUnauthorized {
+				break
+			}
 		}
+
+		if time.Now().After(deadline) {
+			t.Fatalf(
+				"gatewayWithRBAC: non-admin user token was not recognized within 5s after /reload; "+
+					"last probe status: %d — reload may have failed or taken too long",
+				http.StatusUnauthorized,
+			)
+		}
+		time.Sleep(100 * time.Millisecond)
 	}
-	// Give the agent loop a beat to pick up the new config.
-	time.Sleep(500 * time.Millisecond)
 
 	return gw, adminToken, userPlain
 }


### PR DESCRIPTION
## Summary

Closes #98 — four endpoints that accepted `role=user` now hard-enforce `role=admin`.

| Endpoint | Before (role=user) | After (role=user) |
|---|---|---|
| `GET /api/v1/audit-log` | 200 | **403** |
| `PUT /api/v1/config` | 200 | **403** |
| `PUT /api/v1/security/tool-policies` | 200 | **403** |
| `GET /api/v1/credentials` | 200 | **403** |

Anonymous (no token) continues to receive 401 for all four. Admin role continues to receive 200/400 as before.

## Architecture

- New `pkg/gateway/ctxkey` leaf package holds exported context key types (`RoleContextKey`, `UserContextKey`, `ConfigContextKey`) so both `gateway` and the new `middleware` sub-package can import them without circular dependency.
- New `pkg/gateway/middleware.RequireAdmin` reads the role written by `withAuth` and returns 403 `{"error":"admin required"}` for non-admin roles, 401 for missing role.
- Chain order: `configSnapshot → withAuth (verifies token, writes role) → RequireAdmin (checks role) → handler`.
- `GET /api/v1/config` and `GET /api/v1/security/tool-policies` are **not** gated — the admin check is applied only to the mutating PUT branch inside the handler, preserving read access for user-role accounts per the authz matrix spec.

## Attacker model (from Issue #98)

A valid `role=user` bearer token previously allowed:
- Reading the complete audit log (admin actions, LLM traces, tool calls)
- Mutating gateway config (`dev_mode_bypass`, ports, providers)
- Flipping tool policies from `ask` to `allow` — disabling approval gates for exec/browser
- Enumerating encrypted credential ref names (integration list disclosure)

All four surfaces now return 403 before any handler logic executes.

## Test plan

- [x] `pkg/gateway/middleware` — 4 unit tests cover all cases: anon→401, user→403+body, admin→200, empty-role-in-ctx→401
- [x] `TestAuthorizationMatrix` — 45 rows, all pass; 4 rows flipped from soft to hard 403 assertion with `wantBodyContains: "admin required"`
- [x] Existing `TestHandleToolPolicies_PUT_*` tests updated to inject admin role into context (correct enforcement, not overreach — those tests bypassed auth by calling the handler directly)
- [x] Full `pkg/gateway/...` test suite passes with zero regressions

🤖 Generated with [Claude Code](https://claude.ai/claude-code)