### PR TITLE
Onboarding: non-persistent provider probe for plain-HTTP deployments

### DIFF
--- a/pkg/gateway/middleware/csrf.go
+++ b/pkg/gateway/middleware/csrf.go
@@ -83,6 +83,7 @@ const csrfTokenBytes = 32
 // Plan reference: temporal-puzzling-melody.md §1, PR-H.
 var defaultExemptPaths = []string{
 	"/api/v1/onboarding/complete",
+	"/api/v1/onboarding/probe-provider",
 	"/api/v1/auth/login",
 	"/api/v1/auth/register-admin",
 	"/health",

--- a/pkg/gateway/rest.go
+++ b/pkg/gateway/rest.go
@@ -1975,6 +1975,10 @@ func (a *restAPI) registerAdditionalEndpoints(cm httpHandlerRegistrar) {
 		"/api/v1/onboarding/complete",
 		a.withOptionalAuth(withRateLimit(onboardingCompleteLimiter, a.HandleCompleteOnboarding)),
 	)
+	cm.RegisterHTTPHandler(
+		"/api/v1/onboarding/probe-provider",
+		a.withOptionalAuth(withRateLimit(onboardingCompleteLimiter, a.HandleOnboardingProbeProvider)),
+	)
 	cm.RegisterHTTPHandler("/api/v1/auth/login", a.withOptionalAuth(a.HandleLogin))
 	cm.RegisterHTTPHandler(
 		"/api/v1/auth/register-admin",

--- a/pkg/gateway/rest_onboarding.go
+++ b/pkg/gateway/rest_onboarding.go
@@ -327,3 +327,88 @@ func (a *restAPI) HandleCompleteOnboarding(w http.ResponseWriter, r *http.Reques
 	}
 	jsonOK(w, resp)
 }
+
+// HandleOnboardingProbeProvider handles POST /api/v1/onboarding/probe-provider.
+//
+// Purpose: during onboarding the SPA needs to test an API key AND fetch the
+// available model list so the user can pick a model — BEFORE onboarding
+// completes and BEFORE a __Host-csrf cookie can be issued (the Secure cookie
+// cannot install over plain HTTP on non-localhost origins).
+//
+// The endpoint is CSRF-exempt (see defaultExemptPaths) and non-persistent:
+// it accepts the api_key in the request body, uses it to fetch the upstream
+// model list, and returns the result. Nothing is written to disk, credentials
+// store, or in-memory config. After onboarding completes, this endpoint
+// returns 409 — post-onboarding admins use the normal PUT /providers/{id}
+// + GET /providers flow (which works because their browser has the cookie
+// by then).
+//
+// Request body:
+//
+//	{"id":"openrouter","api_key":"sk-or-...","endpoint":"https://openrouter.ai/api/v1"}
+//
+// `endpoint` is optional; when omitted, the server uses
+// providers.GetDefaultAPIBase(id).
+//
+// Response shape:
+//
+//	{"success":true,"models":["gpt-4","gpt-4-turbo",...]}     on OK
+//	{"success":false,"error":"401 unauthorized"}               on upstream reject
+//	(HTTP 409)                                                 after onboarding complete
+//	(HTTP 400)                                                 on malformed body / unknown id
+func (a *restAPI) HandleOnboardingProbeProvider(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		jsonErr(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	// Gate: only usable during bootstrap. Once onboarding is complete the
+	// endpoint still exists (CSRF-exempt path can't be removed dynamically)
+	// but it refuses to serve — admins with a cookie use the standard
+	// /providers/{id} PUT + GET /providers flow instead.
+	if a.onboardingMgr != nil && a.onboardingMgr.IsComplete() {
+		jsonErr(w, http.StatusConflict,
+			"onboarding already complete — use PUT /api/v1/providers/{id} and GET /api/v1/providers to add providers")
+		return
+	}
+
+	var body struct {
+		ID       string `json:"id"`
+		APIKey   string `json:"api_key"`
+		Endpoint string `json:"endpoint"`
+	}
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 4096)).Decode(&body); err != nil {
+		jsonErr(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	if body.ID == "" {
+		jsonErr(w, http.StatusBadRequest, "id is required")
+		return
+	}
+	if body.APIKey == "" {
+		jsonErr(w, http.StatusBadRequest, "api_key is required")
+		return
+	}
+
+	baseURL := body.Endpoint
+	if baseURL == "" {
+		baseURL = providers.GetDefaultAPIBase(body.ID)
+	}
+	if baseURL == "" {
+		// Unknown provider and caller didn't supply an endpoint — the probe
+		// cannot proceed without one.
+		jsonErr(w, http.StatusBadRequest,
+			fmt.Sprintf("unknown provider %q and no endpoint override supplied", body.ID))
+		return
+	}
+
+	models, fetchErr := fetchUpstreamModels(baseURL, body.APIKey)
+	if fetchErr != nil {
+		// Upstream probe failure is a 200 with success=false — symmetrical
+		// with POST /providers/{id}/test, so the SPA's error-handling branch
+		// is identical for both flows.
+		jsonOK(w, map[string]any{"success": false, "error": fetchErr.Error()})
+		return
+	}
+
+	jsonOK(w, map[string]any{"success": true, "models": models})
+}

--- a/pkg/gateway/rest_onboarding_test.go
+++ b/pkg/gateway/rest_onboarding_test.go
@@ -687,3 +687,150 @@ func TestHandleCompleteOnboarding_ConcurrentDifferentUsers(t *testing.T) {
 	users := usersRaw.([]any)
 	assert.Len(t, users, 1, "config.json must have exactly 1 user after concurrent calls")
 }
+
+// --- HandleOnboardingProbeProvider tests ---
+
+// probeProviderWithUpstream points the probe at a stub httptest server that
+// mimics the OpenAI /v1/models shape. Used to avoid hitting real provider APIs.
+func probeProviderWithUpstream(t *testing.T, upstream string, body string, api *restAPI) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/onboarding/probe-provider",
+		strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	_ = upstream
+	api.HandleOnboardingProbeProvider(w, req)
+	return w
+}
+
+// TestHandleOnboardingProbeProvider_SuccessWithModels probes a stub upstream
+// and asserts the handler returns the model list without persisting anything.
+func TestHandleOnboardingProbeProvider_SuccessWithModels(t *testing.T) {
+	// Stub /v1/models endpoint.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/models") {
+			http.NotFound(w, r)
+			return
+		}
+		if auth := r.Header.Get("Authorization"); auth != "Bearer test-key" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":"gpt-4"},{"id":"gpt-3.5-turbo"}]}`))
+	}))
+	defer upstream.Close()
+
+	tmpDir := t.TempDir()
+	api := newOnboardingTestAPI(t, tmpDir, nil)
+	require.False(t, api.onboardingMgr.IsComplete(),
+		"onboarding must not be complete for the probe to work")
+
+	body := `{"id":"openai","api_key":"test-key","endpoint":"` + upstream.URL + `"}`
+	w := probeProviderWithUpstream(t, upstream.URL, body, api)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, true, resp["success"])
+	models, _ := resp["models"].([]any)
+	assert.ElementsMatch(t, []any{"gpt-3.5-turbo", "gpt-4"}, models,
+		"probe must return the upstream model list sorted alphabetically")
+
+	// Nothing persisted: config.json has no providers array entry, creds store is empty.
+	cfgData, err := os.ReadFile(tmpDir + "/config.json")
+	if err == nil {
+		assert.NotContains(t, string(cfgData), "test-key",
+			"probe must not persist the api_key to config.json")
+	}
+}
+
+// TestHandleOnboardingProbeProvider_UpstreamUnauthorized verifies that a 401
+// from the upstream is surfaced as success=false with an error message,
+// matching the existing POST /providers/{id}/test contract.
+func TestHandleOnboardingProbeProvider_UpstreamUnauthorized(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer upstream.Close()
+
+	tmpDir := t.TempDir()
+	api := newOnboardingTestAPI(t, tmpDir, nil)
+
+	body := `{"id":"openai","api_key":"bad-key","endpoint":"` + upstream.URL + `"}`
+	w := probeProviderWithUpstream(t, upstream.URL, body, api)
+
+	assert.Equal(t, http.StatusOK, w.Code,
+		"upstream failure still returns HTTP 200 with success=false (same shape as /providers/{id}/test)")
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, false, resp["success"])
+	assert.Contains(t, resp["error"].(string), "401")
+}
+
+// TestHandleOnboardingProbeProvider_AlreadyComplete verifies that once
+// onboarding is marked complete, the endpoint returns HTTP 409 to steer
+// admins to the normal provider-management flow.
+func TestHandleOnboardingProbeProvider_AlreadyComplete(t *testing.T) {
+	tmpDir := t.TempDir()
+	minimalCfg := []byte(`{"version":1,"agents":{"defaults":{},"list":[]},"providers":[]}`)
+	require.NoError(t, os.WriteFile(tmpDir+"/config.json", minimalCfg, 0o600))
+
+	api := newOnboardingTestAPI(t, tmpDir, nil)
+
+	// Complete onboarding by writing the state marker directly — avoids
+	// running the full /onboarding/complete handler in this narrow test.
+	commit, err := api.onboardingMgr.ReserveComplete()
+	require.NoError(t, err)
+	require.NoError(t, commit())
+	require.True(t, api.onboardingMgr.IsComplete())
+
+	body := `{"id":"openai","api_key":"any","endpoint":"http://127.0.0.1:1/"}`
+	w := probeProviderWithUpstream(t, "", body, api)
+
+	assert.Equal(t, http.StatusConflict, w.Code,
+		"probe-provider must return 409 once onboarding is complete")
+	assert.Contains(t, w.Body.String(), "onboarding already complete")
+}
+
+// TestHandleOnboardingProbeProvider_MissingFields exercises the request-body
+// validation branches — empty id, empty api_key, and an unknown provider
+// without endpoint override must all return 400.
+func TestHandleOnboardingProbeProvider_MissingFields(t *testing.T) {
+	tmpDir := t.TempDir()
+	api := newOnboardingTestAPI(t, tmpDir, nil)
+
+	cases := []struct {
+		name string
+		body string
+		want string // substring of error
+	}{
+		{"empty_id", `{"api_key":"k","endpoint":"http://x/"}`, "id is required"},
+		{"empty_api_key", `{"id":"openai","endpoint":"http://x/"}`, "api_key is required"},
+		{"unknown_provider_no_endpoint", `{"id":"notaprovider","api_key":"k"}`, "unknown provider"},
+		{"malformed_json", `{not-json`, "invalid JSON"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := probeProviderWithUpstream(t, "", tc.body, api)
+			assert.Equal(t, http.StatusBadRequest, w.Code)
+			assert.Contains(t, w.Body.String(), tc.want)
+		})
+	}
+}
+
+// TestHandleOnboardingProbeProvider_WrongMethod ensures non-POST verbs are rejected.
+func TestHandleOnboardingProbeProvider_WrongMethod(t *testing.T) {
+	tmpDir := t.TempDir()
+	api := newOnboardingTestAPI(t, tmpDir, nil)
+
+	for _, m := range []string{http.MethodGet, http.MethodPut, http.MethodDelete} {
+		req := httptest.NewRequest(m, "/api/v1/onboarding/probe-provider", nil)
+		w := httptest.NewRecorder()
+		api.HandleOnboardingProbeProvider(w, req)
+		assert.Equal(t, http.StatusMethodNotAllowed, w.Code,
+			"verb %s must be rejected", m)
+	}
+	// silence unused context import if minimized tests drop it
+	_ = context.Background
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -27,6 +27,7 @@ const STATE_CHANGING_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE'])
 //   - /api/v1/auth/register-admin — first-boot admin account creation.
 const CSRF_EXEMPT_PATHS = new Set<string>([
   '/api/v1/onboarding/complete',
+  '/api/v1/onboarding/probe-provider',
   '/api/v1/auth/login',
   '/api/v1/auth/register-admin',
 ])
@@ -676,6 +677,32 @@ export async function completeOnboardingTransaction(req: CompleteOnboardingReque
   return request<LoginResponse>('/onboarding/complete', {
     method: 'POST',
     body: JSON.stringify(req),
+  })
+}
+
+// probeProvider is a non-persistent "test + fetch model list" call used during
+// onboarding, before the __Host-csrf cookie can be issued. It accepts the
+// api_key in the request body, asks the server to hit the provider's /models
+// endpoint with that key, and returns both a success flag and the model list.
+// Nothing is written to disk or in-memory config.
+//
+// After onboarding completes, the server returns HTTP 409 from this endpoint.
+// Admins who want to add providers post-onboarding use configureProvider
+// (PUT /providers/{id}) + fetchProviders (GET /providers) — both work
+// because the browser has the __Host-csrf cookie at that point.
+export interface ProbeProviderResponse {
+  success: boolean
+  models?: string[]
+  error?: string
+}
+export async function probeProvider(
+  id: string,
+  apiKey: string,
+  endpoint?: string,
+): Promise<ProbeProviderResponse> {
+  return request<ProbeProviderResponse>('/onboarding/probe-provider', {
+    method: 'POST',
+    body: JSON.stringify({ id, api_key: apiKey, endpoint: endpoint ?? '' }),
   })
 }
 

--- a/src/routes/onboarding.tsx
+++ b/src/routes/onboarding.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { AnimatePresence, motion } from 'framer-motion'
 import {
@@ -18,7 +18,7 @@ import {
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { ModelSelector } from '@/components/ui/model-selector'
-import { configureProvider, testProvider, completeOnboardingTransaction, completeOnboarding, fetchProviders } from '@/lib/api'
+import { probeProvider, completeOnboardingTransaction, completeOnboarding } from '@/lib/api'
 import OmnipusAvatar from '@/assets/logo/omnipus-avatar.svg?url'
 import { PROVIDER_HINTS } from '@/lib/constants'
 import { useUiStore } from '@/store/ui'
@@ -125,15 +125,15 @@ function OnboardingWizard() {
     setTestStatus('testing')
     setTestError('')
     try {
-      await configureProvider(selectedProvider, apiKey.trim())
-      const result = await testProvider(selectedProvider)
+      // Non-persistent test + fetch: the server probes the provider with the
+      // supplied key and returns the model list in one response. Nothing is
+      // saved to disk until the user clicks "Complete" on step 4, which fires
+      // /onboarding/complete with the full payload atomically.
+      const result = await probeProvider(selectedProvider, apiKey.trim())
       if (result.success) {
         setTestStatus('success')
-        // Refetch provider list to get the updated model list for this provider.
-        const freshProviders = await fetchProviders()
-        const providerData = freshProviders.find((p) => p.id === selectedProvider)
-        if (providerData?.models && providerData.models.length > 0) {
-          setAvailableModels(providerData.models)
+        if (result.models && result.models.length > 0) {
+          setAvailableModels(result.models)
         }
       } else {
         setTestStatus('error')
@@ -145,22 +145,10 @@ function OnboardingWizard() {
     }
   }
 
-  // Save the selected model to the backend when it changes
-  useEffect(() => {
-    if (!selectedModel || testStatus !== 'success') return
-    const saveModel = async () => {
-      try {
-        await configureProvider(selectedProvider, undefined, undefined, selectedModel)
-      } catch (err) {
-        console.error('Failed to save model selection:', err)
-        addToast({
-          message: `Failed to save model selection: ${err instanceof Error ? err.message : 'Unknown error'}`,
-          variant: 'error',
-        })
-      }
-    }
-    saveModel()
-  }, [selectedModel, selectedProvider, testStatus])
+  // Model selection is kept purely in local state during onboarding. It gets
+  // persisted to the server as part of /onboarding/complete's payload, so we
+  // intentionally do NOT fire a PUT /providers/{id} here — that would require
+  // a __Host-csrf cookie the browser cannot install over plain HTTP.
 
   const handleFinish = async () => {
     setIsSaving(true)


### PR DESCRIPTION
## Problem
Onboarding on any deployment without TLS (public IPs, self-hosted HTTP) deadlocked: the SPA needed to persist + test a provider key and refetch the model list, but all three calls are CSRF-gated and the \`__Host-csrf\` cookie cannot install over plain HTTP on non-localhost origins (Secure flag required by the \`__Host-\` prefix).

## Fix
Add \`POST /api/v1/onboarding/probe-provider\` — a single non-persistent endpoint that accepts \`{id, api_key, endpoint?}\` in the body, calls \`fetchUpstreamModels()\` with the supplied key, and returns \`{success, models[], error?}\`. CSRF-exempt (same design as \`/onboarding/complete\`, \`/auth/login\`, \`/auth/register-admin\`). Returns 409 after onboarding completes.

## Flow comparison
**Before:** enter key → PUT /providers/{id} (save) → POST /providers/{id}/test → GET /providers (refetch w/ models) → model dropdown. Three state-changing requests, all CSRF-gated.
**After:** enter key → POST /onboarding/probe-provider → model dropdown. Zero persistent writes pre-onboarding; \`/onboarding/complete\` still does the atomic transaction at the end.

## Security posture
- The endpoint *path* is permanently CSRF-exempt (middleware exempt lists are static) but its *behavior* flips to 409 once onboarding completes, making the exemption moot post-bootstrap.
- Before onboarding: no admin exists → no session to CSRF-attack anyway.
- After onboarding: 409 regardless of caller — dead code path for admins; they use the normal \`PUT /providers/{id}\` which now works because their browser has \`__Host-csrf\`.
- Matches the pattern already used by \`/onboarding/complete\`.

## Test coverage
5 new Go tests in \`rest_onboarding_test.go\`:
- \`TestHandleOnboardingProbeProvider_SuccessWithModels\`
- \`TestHandleOnboardingProbeProvider_UpstreamUnauthorized\`
- \`TestHandleOnboardingProbeProvider_AlreadyComplete\`
- \`TestHandleOnboardingProbeProvider_MissingFields\` (4 sub-tests)
- \`TestHandleOnboardingProbeProvider_WrongMethod\`

## Verified live
Ran on \`http://146.190.89.151:3000\` with Sprint J binary + this change:
- \`probe-provider\` with no bearer, no CSRF, no cookie → 200 + model list
- \`/onboarding/complete\` still bootstraps the cookie + admin atomically

## Test plan
- [ ] CI: Linter, Tests, Security Check, matrix, Playwright E2E, Perf Smoke, Security Tests, build-and-test
- [ ] Manual: onboarding flow on a plain-HTTP deployment against a real provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)