### PR TITLE
Security settings UX + plain-HTTP CSRF + UI-editable sandbox

### DIFF
--- a/pkg/gateway/middleware/csrf.go
+++ b/pkg/gateway/middleware/csrf.go
@@ -24,9 +24,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 )
 
-// CSRFCookieName is the name of the double-submit cookie.
+// CSRFCookieName is the name of the double-submit cookie under TLS.
 //
 // The __Host- prefix enforces three properties at the browser layer:
 //   - Secure must be set
@@ -36,6 +37,18 @@ import (
 // If any of those are violated the browser refuses to store the cookie.
 // This is defense-in-depth against a weaker cookie slipping out.
 const CSRFCookieName = "__Host-csrf"
+
+// CSRFCookieNameHTTP is the fallback cookie name used when the gateway is
+// reached over plain HTTP. The __Host- prefix requires Secure=true, which
+// browsers enforce by DROPPING the cookie on non-TLS origins (except
+// localhost). On plain-HTTP deployments (dev, self-hosted behind a
+// non-terminating proxy, public-IP test instances without a cert) the
+// __Host- cookie therefore never installs and every double-submit check
+// fails with "csrf cookie missing". Using an un-prefixed name plus
+// Secure=false lets the double-submit pattern still work on HTTP.
+// SameSite=Strict still blocks cross-origin sends — the protection the
+// middleware actually cares about survives the downgrade.
+const CSRFCookieNameHTTP = "csrf"
 
 // CSRFHeaderName is the header that clients must echo with the cookie value.
 //
@@ -298,8 +311,38 @@ func CSRFMiddleware(opts ...Option) func(http.Handler) http.Handler {
 				return
 			}
 
-			cookie, err := r.Cookie(CSRFCookieName)
-			if err != nil || cookie.Value == "" {
+			// Bearer-token requests are not a CSRF target.
+			//
+			// CSRF protection exists to defend AMBIENT credentials —
+			// cookies the browser auto-attaches to cross-origin requests.
+			// An Authorization: Bearer <token> header is NEVER auto-sent
+			// by a browser to a different origin, so a malicious site
+			// cannot cause a victim's browser to include it. Programmatic
+			// clients (curl, API SDKs, mobile apps) supply the header
+			// explicitly and are not susceptible to CSRF either.
+			//
+			// Skipping the cookie/header double-submit check for Bearer
+			// callers fixes the plain-HTTP deployment story: operators
+			// using `curl -H "Authorization: Bearer …"` no longer have
+			// to juggle an impossible-to-install __Host-csrf cookie, and
+			// admin tools that use Bearer tokens work identically on
+			// HTTP and HTTPS.
+			if authHeader := r.Header.Get("Authorization"); strings.HasPrefix(authHeader, "Bearer ") {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			// Accept either the TLS-only __Host-csrf cookie OR the
+			// plain-HTTP fallback `csrf` cookie. IssueCSRFCookie picks
+			// which one to issue based on the request that triggered
+			// issuance (TLS → __Host-; HTTP → fallback).
+			var cookieValue string
+			if c, err := r.Cookie(CSRFCookieName); err == nil && c.Value != "" {
+				cookieValue = c.Value
+			} else if c, err := r.Cookie(CSRFCookieNameHTTP); err == nil && c.Value != "" {
+				cookieValue = c.Value
+			}
+			if cookieValue == "" {
 				writeCSRFError(w, "csrf cookie missing")
 				return
 			}
@@ -310,7 +353,7 @@ func CSRFMiddleware(opts ...Option) func(http.Handler) http.Handler {
 				return
 			}
 
-			if subtle.ConstantTimeCompare([]byte(cookie.Value), []byte(header)) != 1 {
+			if subtle.ConstantTimeCompare([]byte(cookieValue), []byte(header)) != 1 {
 				if reporter != nil {
 					reporter(r, clientIP(r), r.URL.Path)
 				}
@@ -340,27 +383,67 @@ func CSRFMiddleware(opts ...Option) func(http.Handler) http.Handler {
 // On a dev-mode server bound to plain HTTP (no TLS) the browser will refuse
 // to store a Secure cookie. For localhost this is usually fine because
 // modern browsers treat 127.0.0.1/localhost as a "potentially trustworthy
-// origin" and honor Secure cookies over http. For arbitrary hosts, the
-// gateway must run on TLS.
-func IssueCSRFCookie(w http.ResponseWriter) error {
+// origin" and honor Secure cookies over http. For arbitrary hosts over
+// plain HTTP we fall back to an un-prefixed `csrf` cookie with Secure=false.
+//
+// The caller supplies the originating request so the issuer can see whether
+// the client is TLS-connected; this is best-effort — a reverse proxy that
+// terminates TLS must either forward via H2C/HTTPS or set
+// X-Forwarded-Proto=https so the middleware picks the secure variant.
+func IssueCSRFCookie(w http.ResponseWriter, r *http.Request) error {
 	buf := make([]byte, csrfTokenBytes)
 	if _, err := rand.Read(buf); err != nil {
 		return fmt.Errorf("csrf: rand.Read: %w", err)
 	}
 	token := base64.RawURLEncoding.EncodeToString(buf)
 
+	if requestIsSecure(r) {
+		http.SetCookie(w, &http.Cookie{
+			Name:     CSRFCookieName,
+			Value:    token,
+			Path:     "/",
+			HttpOnly: false,
+			Secure:   true,
+			SameSite: http.SameSiteStrictMode,
+			// No Domain — __Host- forbids it.
+			// No MaxAge — session cookie; lives until the browser closes.
+		})
+		return nil
+	}
+
+	// Plain-HTTP fallback. Same SameSite=Strict protection (the invariant
+	// CSRF cares about). HttpOnly=false so the SPA can read it, Path=/ so
+	// it attaches to every endpoint, no Domain / no MaxAge.
 	http.SetCookie(w, &http.Cookie{
-		Name:     CSRFCookieName,
+		Name:     CSRFCookieNameHTTP,
 		Value:    token,
 		Path:     "/",
 		HttpOnly: false,
-		Secure:   true,
+		Secure:   false,
 		SameSite: http.SameSiteStrictMode,
-		// No Domain — __Host- forbids it.
-		// No MaxAge — session cookie; lives until the browser closes. The
-		// SPA re-issues on every login/onboarding/refresh.
 	})
 	return nil
+}
+
+// requestIsSecure detects whether the request reached us over TLS, either
+// directly (r.TLS != nil) or via an ingress that forwards X-Forwarded-Proto.
+// Used by IssueCSRFCookie to pick the cookie flavor.
+func requestIsSecure(r *http.Request) bool {
+	if r == nil {
+		// Defensive: pre-refactor callers had no request handle. Assume
+		// TLS so an older call site still works in spec-compliant mode —
+		// if the cookie ends up Secure on a plain-HTTP origin, the only
+		// consequence is that the browser drops it (the exact pre-fix
+		// behavior).
+		return true
+	}
+	if r.TLS != nil {
+		return true
+	}
+	if strings.EqualFold(r.Header.Get("X-Forwarded-Proto"), "https") {
+		return true
+	}
+	return false
 }
 
 // writeCSRFError writes a 403 JSON error response. The response shape matches

--- a/pkg/gateway/middleware/csrf_test.go
+++ b/pkg/gateway/middleware/csrf_test.go
@@ -8,6 +8,7 @@ package middleware
 
 import (
 	"bytes"
+	"crypto/tls"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -278,7 +279,7 @@ func TestCSRF_NilOptionIgnored(t *testing.T) {
 
 func TestIssueCSRFCookie_Attributes(t *testing.T) {
 	rec := httptest.NewRecorder()
-	require.NoError(t, IssueCSRFCookie(rec))
+	require.NoError(t, IssueCSRFCookie(rec, nil))
 
 	cookies := rec.Result().Cookies()
 	require.Len(t, cookies, 1, "exactly one cookie must be set")
@@ -301,7 +302,7 @@ func TestIssueCSRFCookie_TokenIsUnique(t *testing.T) {
 	seen := map[string]bool{}
 	for i := 0; i < 16; i++ {
 		rec := httptest.NewRecorder()
-		require.NoError(t, IssueCSRFCookie(rec))
+		require.NoError(t, IssueCSRFCookie(rec, nil))
 		c := rec.Result().Cookies()[0]
 		assert.False(t, seen[c.Value], "token collision on iteration %d: %q", i, c.Value)
 		seen[c.Value] = true
@@ -310,7 +311,7 @@ func TestIssueCSRFCookie_TokenIsUnique(t *testing.T) {
 
 func TestIssueCSRFCookie_HeaderIsParseable(t *testing.T) {
 	rec := httptest.NewRecorder()
-	require.NoError(t, IssueCSRFCookie(rec))
+	require.NoError(t, IssueCSRFCookie(rec, nil))
 	setCookie := rec.Header().Get("Set-Cookie")
 	require.NotEmpty(t, setCookie)
 
@@ -341,4 +342,127 @@ func TestCSRF_ErrorBody_JSONEncoded(t *testing.T) {
 	var body map[string]string
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
 	assert.Equal(t, "csrf cookie missing", body["error"])
+}
+
+// --- Bug 3 coverage: Bearer bypass + plain-HTTP cookie downgrade ---
+
+// TestCSRFMiddleware_BearerBypass verifies that a state-changing request
+// carrying an Authorization: Bearer header skips the double-submit check
+// entirely. Browsers cannot auto-send an Authorization header cross-origin,
+// so Bearer-authenticated callers are not a CSRF target — requiring them
+// to juggle the cookie is pure friction and breaks plain-HTTP deployments
+// where the Secure __Host-csrf cookie cannot install.
+func TestCSRFMiddleware_BearerBypass(t *testing.T) {
+	reached := false
+	h := CSRFMiddleware()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/doctor", nil)
+	req.Header.Set("Authorization", "Bearer sk-test-token")
+	// Intentionally no cookie, no X-Csrf-Token header — the whole point is
+	// that Bearer callers don't need them.
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code,
+		"Bearer-authenticated state-changing request must pass through without a CSRF cookie")
+	assert.True(t, reached, "the inner handler must actually run")
+}
+
+// TestCSRFMiddleware_BearerMustHavePrefix confirms that only the "Bearer "
+// prefix triggers the bypass — a stray Authorization: Basic or malformed
+// header still goes through the normal CSRF check.
+func TestCSRFMiddleware_BearerMustHavePrefix(t *testing.T) {
+	h := CSRFMiddleware()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("handler must NOT run when Bearer prefix is absent")
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/doctor", nil)
+	req.Header.Set("Authorization", "Basic dXNlcjpwYXNz")
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusForbidden, rec.Code,
+		"non-Bearer Authorization must fall through to the cookie check and 403 without one")
+}
+
+// TestCSRFMiddleware_PlainHTTPCookieAccepted verifies that the middleware
+// accepts the un-prefixed `csrf` cookie issued over plain HTTP, not only
+// the TLS-only __Host-csrf cookie. The two flavors are interchangeable
+// as far as the gate is concerned — the gate cares about "cookie value
+// matches header value", not which name carries the value.
+func TestCSRFMiddleware_PlainHTTPCookieAccepted(t *testing.T) {
+	reached := false
+	h := CSRFMiddleware()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	const token = "plain-http-token-value"
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/doctor", nil)
+	req.AddCookie(&http.Cookie{Name: CSRFCookieNameHTTP, Value: token})
+	req.Header.Set(CSRFHeaderName, token)
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code,
+		"middleware must accept the plain-HTTP `csrf` cookie when it matches the header")
+	assert.True(t, reached, "the inner handler must actually run")
+}
+
+// TestIssueCSRFCookie_PlainHTTPUsesFallbackName verifies that when the
+// request arrives without TLS (r.TLS == nil and no X-Forwarded-Proto=https),
+// IssueCSRFCookie emits the un-prefixed `csrf` cookie with Secure=false so
+// the browser will actually store it on an HTTP origin.
+func TestIssueCSRFCookie_PlainHTTPUsesFallbackName(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "http://example.com/api/v1/onboarding/complete", nil)
+	// req.TLS is nil because it's an http:// URL.
+	rec := httptest.NewRecorder()
+	require.NoError(t, IssueCSRFCookie(rec, req))
+
+	cookies := rec.Result().Cookies()
+	require.Len(t, cookies, 1)
+	c := cookies[0]
+	assert.Equal(t, CSRFCookieNameHTTP, c.Name,
+		"on plain HTTP the fallback `csrf` cookie must be issued instead of __Host-csrf")
+	assert.False(t, c.Secure,
+		"fallback cookie must have Secure=false so the browser actually stores it on HTTP")
+	assert.Equal(t, http.SameSiteStrictMode, c.SameSite,
+		"SameSite=Strict must survive the HTTP downgrade — it's the real CSRF defense")
+	assert.Equal(t, "/", c.Path)
+}
+
+// TestIssueCSRFCookie_HTTPSUsesHostPrefix verifies the secure branch still
+// emits the __Host-csrf cookie with Secure=true when r.TLS is non-nil.
+func TestIssueCSRFCookie_HTTPSUsesHostPrefix(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "https://example.com/api/v1/onboarding/complete", nil)
+	req.TLS = &tls.ConnectionState{} // simulate TLS-connected request
+	rec := httptest.NewRecorder()
+	require.NoError(t, IssueCSRFCookie(rec, req))
+
+	cookies := rec.Result().Cookies()
+	require.Len(t, cookies, 1)
+	c := cookies[0]
+	assert.Equal(t, CSRFCookieName, c.Name, "HTTPS branch must still emit __Host-csrf")
+	assert.True(t, c.Secure, "__Host- prefix requires Secure=true")
+}
+
+// TestIssueCSRFCookie_ForwardedProtoHonored — a reverse proxy terminating
+// TLS and forwarding X-Forwarded-Proto=https must route to the secure
+// branch, so the cookie survives the Strict-Transport-Security dance.
+func TestIssueCSRFCookie_ForwardedProtoHonored(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "http://example.com/api/v1/onboarding/complete", nil)
+	req.Header.Set("X-Forwarded-Proto", "https")
+	rec := httptest.NewRecorder()
+	require.NoError(t, IssueCSRFCookie(rec, req))
+
+	cookies := rec.Result().Cookies()
+	require.Len(t, cookies, 1)
+	assert.Equal(t, CSRFCookieName, cookies[0].Name,
+		"X-Forwarded-Proto=https from a terminating proxy must pick the __Host- branch")
 }

--- a/pkg/gateway/rest.go
+++ b/pkg/gateway/rest.go
@@ -1952,6 +1952,11 @@ func (a *restAPI) registerAdditionalEndpoints(cm httpHandlerRegistrar) {
 	cm.RegisterHTTPHandler("/api/v1/security/rate-limits", a.withAuth(a.HandleRateLimits))
 	// Wave 5 security endpoints (SEC-01/02/03).
 	cm.RegisterHTTPHandler("/api/v1/security/sandbox-status", a.withAuth(a.HandleSandboxStatus))
+	// Sandbox config editing is admin-only — blocking the "sandbox" key in
+	// the generic PUT /api/v1/config (line ~1622) pushes UI edits to this
+	// dedicated endpoint which surfaces the restart-required UX signal.
+	cm.RegisterHTTPHandler("/api/v1/security/sandbox-config",
+		a.withAuth(middleware.RequireAdmin(http.HandlerFunc(a.HandleSandboxConfig)).ServeHTTP))
 	// GET /api/v1/security/tool-policies — read available to all authenticated
 	// users; PUT is admin-only (enforced inside HandleToolPolicies, Issue #98).
 	cm.RegisterHTTPHandler("/api/v1/security/tool-policies", a.withAuth(a.HandleToolPolicies))

--- a/pkg/gateway/rest_auth.go
+++ b/pkg/gateway/rest_auth.go
@@ -368,7 +368,7 @@ func (a *restAPI) HandleLogin(w http.ResponseWriter, r *http.Request) {
 	// Cookie mint failure means the OS RNG is broken — refuse to return the
 	// bearer token to avoid issuing a session that cannot make CSRF-protected
 	// requests.
-	if err := middleware.IssueCSRFCookie(w); err != nil {
+	if err := middleware.IssueCSRFCookie(w, r); err != nil {
 		slog.Error("auth: issue CSRF cookie failed", "error", err)
 		jsonErr(w, http.StatusInternalServerError, "session init failed")
 		return
@@ -503,7 +503,7 @@ func (a *restAPI) HandleRegisterAdmin(w http.ResponseWriter, r *http.Request) {
 	// immediately make state-changing requests without being blocked by the
 	// CSRF middleware (issue #97). Cookie mint failure means the OS RNG is
 	// broken — refuse to return the bearer token to prevent an unusable session.
-	if err := middleware.IssueCSRFCookie(w); err != nil {
+	if err := middleware.IssueCSRFCookie(w, r); err != nil {
 		slog.Error("auth: issue CSRF cookie failed", "error", err)
 		jsonErr(w, http.StatusInternalServerError, "session init failed")
 		return

--- a/pkg/gateway/rest_onboarding.go
+++ b/pkg/gateway/rest_onboarding.go
@@ -310,7 +310,7 @@ func (a *restAPI) HandleCompleteOnboarding(w http.ResponseWriter, r *http.Reques
 	// point had no cookie — /api/v1/onboarding/complete is exempt from the
 	// CSRF gate for exactly that reason, see pkg/gateway/middleware/csrf.go)
 	// can make subsequent state-changing requests without a 403. Issue #97.
-	if err := middleware.IssueCSRFCookie(w); err != nil {
+	if err := middleware.IssueCSRFCookie(w, r); err != nil {
 		slog.Error("onboarding: issue CSRF cookie failed", "error", err)
 		jsonErr(w, http.StatusInternalServerError, "session init failed")
 		return

--- a/pkg/gateway/rest_security_wave5.go
+++ b/pkg/gateway/rest_security_wave5.go
@@ -7,7 +7,10 @@
 package gateway
 
 import (
+	"encoding/json"
+	"log/slog"
 	"net/http"
+	"strings"
 
 	"github.com/dapicom-ai/omnipus/pkg/sandbox"
 )
@@ -49,4 +52,185 @@ func (a *restAPI) HandleSandboxStatus(w http.ResponseWriter, r *http.Request) {
 	}
 	status := sandbox.DescribeBackendWithState(backend, state)
 	jsonOK(w, status)
+}
+
+// sandboxConfigResponse is the JSON shape surfaced on GET/PUT
+// /api/v1/security/sandbox-config. It mirrors the subset of
+// config.OmnipusSandboxConfig that operators are allowed to edit through the
+// UI. Other sandbox-adjacent fields (prompt-injection tier, rate limits,
+// tool policies) have their own editors elsewhere in Settings → Security
+// and are intentionally NOT exposed here — this endpoint is scoped to the
+// sandbox/SSRF surface the Settings → Security → Process Sandbox panel
+// renders.
+type sandboxConfigResponse struct {
+	// Current sandbox config as persisted in config.json.
+	Mode                 string   `json:"mode"`
+	AllowNetworkOutbound bool     `json:"allow_network_outbound"`
+	AllowedPaths         []string `json:"allowed_paths"`
+	SSRFEnabled          bool     `json:"ssrf_enabled"`
+	SSRFAllowInternal    []string `json:"ssrf_allow_internal"`
+
+	// AppliedMode reflects what the gateway is ACTUALLY running with. It can
+	// differ from Mode above when the operator saved a new mode but hasn't
+	// restarted yet (Sprint J FR-J-015 locks out hot-reload for sandbox).
+	AppliedMode string `json:"applied_mode"`
+
+	// RequiresRestart is true after a successful PUT — the UI renders a
+	// persistent banner telling the operator to restart the gateway for
+	// the change to take effect.
+	RequiresRestart bool `json:"requires_restart,omitempty"`
+}
+
+// sandboxConfigUpdate is the JSON shape accepted on PUT. Every field is a
+// pointer so the handler can distinguish "operator left this unset" from
+// "operator explicitly set it to zero/empty". Fields that are nil on the
+// wire are left untouched on disk.
+type sandboxConfigUpdate struct {
+	Mode                 *string   `json:"mode,omitempty"`
+	AllowNetworkOutbound *bool     `json:"allow_network_outbound,omitempty"`
+	AllowedPaths         *[]string `json:"allowed_paths,omitempty"`
+	SSRFEnabled          *bool     `json:"ssrf_enabled,omitempty"`
+	SSRFAllowInternal    *[]string `json:"ssrf_allow_internal,omitempty"`
+}
+
+// validSandboxModes is the canonical set the UI radio group maps to. The
+// string values match what sandbox.ParseMode expects (case-insensitive).
+var validSandboxModes = map[string]struct{}{
+	"enforce":    {},
+	"permissive": {},
+	"off":        {},
+}
+
+// HandleSandboxConfig handles GET/PUT /api/v1/security/sandbox-config.
+//
+// PUT is the sanctioned path for UI-driven sandbox edits — the generic
+// PUT /api/v1/config blocks the "sandbox" top-level key on purpose (see
+// rest.go:1622) because sandbox edits require process restart (FR-J-015,
+// no hot-reload), and the operator needs an unambiguous UX signal that
+// a restart is coming. Mixing sandbox writes into the generic config PUT
+// would silently save the change and leave the operator thinking it took
+// effect.
+//
+// Admin-only: enforced by middleware.RequireAdmin at route-mount time.
+// CSRF: state-changing PUT passes through the normal double-submit gate;
+// admins have the __Host-csrf (TLS) or csrf (HTTP) cookie by this point.
+func (a *restAPI) HandleSandboxConfig(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		a.getSandboxConfig(w)
+	case http.MethodPut:
+		a.putSandboxConfig(w, r)
+	default:
+		jsonErr(w, http.StatusMethodNotAllowed, "method not allowed")
+	}
+}
+
+func (a *restAPI) getSandboxConfig(w http.ResponseWriter) {
+	if a.agentLoop == nil {
+		jsonErr(w, http.StatusServiceUnavailable, "sandbox: agent loop not initialized")
+		return
+	}
+	cfg := a.agentLoop.GetConfig()
+	applied := ""
+	if a.sandboxResult != nil {
+		applied = string(a.sandboxResult.ApplyState.Mode)
+	}
+	resp := sandboxConfigResponse{
+		Mode:                 cfg.Sandbox.ResolvedMode(),
+		AllowNetworkOutbound: cfg.Sandbox.AllowNetworkOutbound,
+		AllowedPaths:         append([]string(nil), cfg.Sandbox.AllowedPaths...),
+		SSRFEnabled:          cfg.Sandbox.SSRF.Enabled,
+		SSRFAllowInternal:    append([]string(nil), cfg.Sandbox.SSRF.AllowInternal...),
+		AppliedMode:          applied,
+	}
+	jsonOK(w, resp)
+}
+
+func (a *restAPI) putSandboxConfig(w http.ResponseWriter, r *http.Request) {
+	var upd sandboxConfigUpdate
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 16<<10)).Decode(&upd); err != nil {
+		jsonErr(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+
+	// Validate mode before touching disk so a malformed value is rejected
+	// atomically rather than caught halfway through the merge.
+	var normalizedMode string
+	if upd.Mode != nil {
+		normalizedMode = strings.ToLower(strings.TrimSpace(*upd.Mode))
+		if _, ok := validSandboxModes[normalizedMode]; !ok {
+			jsonErr(w, http.StatusBadRequest,
+				"invalid sandbox mode; must be one of: enforce, permissive, off")
+			return
+		}
+	}
+
+	// Merge the supplied fields into the sandbox sub-map of config.json.
+	// Fields not present in the request body are left untouched — pointer-
+	// null semantics gives us partial updates without the operator having
+	// to resend the whole sandbox block.
+	err := a.safeUpdateConfigJSON(func(m map[string]any) error {
+		sb, _ := m["sandbox"].(map[string]any)
+		if sb == nil {
+			sb = make(map[string]any)
+			m["sandbox"] = sb
+		}
+		if upd.Mode != nil {
+			sb["mode"] = normalizedMode
+			// Clear the legacy Enabled bool when an explicit mode is set, so
+			// the two fields don't disagree after the write. ResolvedMode
+			// prefers Mode when present, but mismatched persisted state
+			// confuses humans reading config.json.
+			delete(sb, "enabled")
+		}
+		if upd.AllowNetworkOutbound != nil {
+			sb["allow_network_outbound"] = *upd.AllowNetworkOutbound
+		}
+		if upd.AllowedPaths != nil {
+			sb["allowed_paths"] = *upd.AllowedPaths
+		}
+		if upd.SSRFEnabled != nil || upd.SSRFAllowInternal != nil {
+			ssrf, _ := sb["ssrf"].(map[string]any)
+			if ssrf == nil {
+				ssrf = make(map[string]any)
+				sb["ssrf"] = ssrf
+			}
+			if upd.SSRFEnabled != nil {
+				ssrf["enabled"] = *upd.SSRFEnabled
+			}
+			if upd.SSRFAllowInternal != nil {
+				ssrf["allow_internal"] = *upd.SSRFAllowInternal
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		slog.Error("sandbox-config: write failed", "error", err)
+		jsonErr(w, http.StatusInternalServerError, "could not save sandbox config")
+		return
+	}
+
+	// Hot-reload is locked out for sandbox config by FR-J-015 — the change
+	// lives on disk but won't take effect until restart. Return the state
+	// that's actually running so the UI can display "saved 'enforce',
+	// currently running 'off' — restart to apply".
+	cfg := a.agentLoop.GetConfig()
+	applied := ""
+	if a.sandboxResult != nil {
+		applied = string(a.sandboxResult.ApplyState.Mode)
+	}
+	jsonOK(w, sandboxConfigResponse{
+		Mode:                 cfg.Sandbox.ResolvedMode(),
+		AllowNetworkOutbound: cfg.Sandbox.AllowNetworkOutbound,
+		AllowedPaths:         append([]string(nil), cfg.Sandbox.AllowedPaths...),
+		SSRFEnabled:          cfg.Sandbox.SSRF.Enabled,
+		SSRFAllowInternal:    append([]string(nil), cfg.Sandbox.SSRF.AllowInternal...),
+		AppliedMode:          applied,
+		RequiresRestart:      true,
+	})
+
+	// Ensure sandbox reference stays in scope; prevents goimports from
+	// dropping the import since this file historically only used sandbox
+	// for DescribeBackendWithState. HandleSandboxStatus still uses it.
+	_ = sandbox.Status{}
 }

--- a/pkg/gateway/rest_security_wave5_test.go
+++ b/pkg/gateway/rest_security_wave5_test.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -80,5 +81,131 @@ func TestHandleSandboxStatus_MethodNotAllowed(t *testing.T) {
 			api.HandleSandboxStatus(w, r)
 			assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
 		})
+	}
+}
+
+// --- HandleSandboxConfig tests (bug 4) ---
+
+// TestHandleSandboxConfig_GETReturnsCurrentConfig verifies the GET path
+// returns the persisted sandbox configuration in the expected JSON shape.
+func TestHandleSandboxConfig_GETReturnsCurrentConfig(t *testing.T) {
+	api := newTestRestAPIWithHome(t)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/security/sandbox-config", nil)
+	api.HandleSandboxConfig(w, r)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	// Must contain all the editable fields even when config.json lacks them
+	// (the response uses zero values / empty arrays for unset fields).
+	for _, key := range []string{
+		"mode", "allow_network_outbound", "allowed_paths",
+		"ssrf_enabled", "ssrf_allow_internal", "applied_mode",
+	} {
+		_, ok := body[key]
+		assert.True(t, ok, "GET /sandbox-config response must include %q", key)
+	}
+}
+
+// TestHandleSandboxConfig_PUTPersistsMode verifies that writing a new mode
+// via PUT is reflected in a subsequent GET and in config.json on disk.
+func TestHandleSandboxConfig_PUTPersistsMode(t *testing.T) {
+	api := newTestRestAPIWithHome(t)
+
+	body := `{"mode":"permissive"}`
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPut, "/api/v1/security/sandbox-config",
+		strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+	api.HandleSandboxConfig(w, r)
+
+	require.Equal(t, http.StatusOK, w.Code,
+		"valid PUT must return 200; got body=%s", w.Body.String())
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "permissive", resp["mode"],
+		"response must echo the new mode")
+	assert.Equal(t, true, resp["requires_restart"],
+		"response must flag restart-required (FR-J-015 no hot-reload)")
+
+	// GET should now return the new mode too.
+	w2 := httptest.NewRecorder()
+	r2 := httptest.NewRequest(http.MethodGet, "/api/v1/security/sandbox-config", nil)
+	api.HandleSandboxConfig(w2, r2)
+	var readBack map[string]any
+	require.NoError(t, json.Unmarshal(w2.Body.Bytes(), &readBack))
+	assert.Equal(t, "permissive", readBack["mode"],
+		"GET must reflect the value just persisted")
+}
+
+// TestHandleSandboxConfig_PUTRejectsInvalidMode verifies that a garbage
+// mode value is rejected with 400 BEFORE any disk write happens.
+func TestHandleSandboxConfig_PUTRejectsInvalidMode(t *testing.T) {
+	api := newTestRestAPIWithHome(t)
+
+	body := `{"mode":"bananas"}`
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPut, "/api/v1/security/sandbox-config",
+		strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+	api.HandleSandboxConfig(w, r)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "invalid sandbox mode")
+
+	// Verify no disk write happened: GET still returns the default.
+	w2 := httptest.NewRecorder()
+	r2 := httptest.NewRequest(http.MethodGet, "/api/v1/security/sandbox-config", nil)
+	api.HandleSandboxConfig(w2, r2)
+	var readBack map[string]any
+	require.NoError(t, json.Unmarshal(w2.Body.Bytes(), &readBack))
+	assert.NotEqual(t, "bananas", readBack["mode"],
+		"a rejected mode must not leak into persisted config")
+}
+
+// TestHandleSandboxConfig_PUTPartialUpdate verifies that omitting a field
+// in the request body leaves that field unchanged on disk (pointer-null
+// semantics).
+func TestHandleSandboxConfig_PUTPartialUpdate(t *testing.T) {
+	api := newTestRestAPIWithHome(t)
+
+	// First PUT: set both mode and ssrf_enabled.
+	body1 := `{"mode":"enforce","ssrf_enabled":true}`
+	r1 := httptest.NewRequest(http.MethodPut, "/api/v1/security/sandbox-config",
+		strings.NewReader(body1))
+	r1.Header.Set("Content-Type", "application/json")
+	w1 := httptest.NewRecorder()
+	api.HandleSandboxConfig(w1, r1)
+	require.Equal(t, http.StatusOK, w1.Code)
+
+	// Second PUT: only mode — ssrf_enabled must survive.
+	body2 := `{"mode":"off"}`
+	r2 := httptest.NewRequest(http.MethodPut, "/api/v1/security/sandbox-config",
+		strings.NewReader(body2))
+	r2.Header.Set("Content-Type", "application/json")
+	w2 := httptest.NewRecorder()
+	api.HandleSandboxConfig(w2, r2)
+	require.Equal(t, http.StatusOK, w2.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w2.Body.Bytes(), &resp))
+	assert.Equal(t, "off", resp["mode"])
+	assert.Equal(t, true, resp["ssrf_enabled"],
+		"omitting ssrf_enabled in the second PUT must not wipe the earlier value")
+}
+
+// TestHandleSandboxConfig_UnsupportedMethod verifies that verbs other than
+// GET/PUT return 405. DELETE/POST/PATCH are not valid on this endpoint.
+func TestHandleSandboxConfig_UnsupportedMethod(t *testing.T) {
+	api := newTestRestAPIWithHome(t)
+
+	for _, m := range []string{http.MethodPost, http.MethodDelete, http.MethodPatch} {
+		r := httptest.NewRequest(m, "/api/v1/security/sandbox-config", nil)
+		w := httptest.NewRecorder()
+		api.HandleSandboxConfig(w, r)
+		assert.Equal(t, http.StatusMethodNotAllowed, w.Code, "verb %s must 405", m)
 	}
 }

--- a/pkg/sandbox/sandbox.go
+++ b/pkg/sandbox/sandbox.go
@@ -687,17 +687,31 @@ func DescribeBackendWithState(backend SandboxBackend, state ApplyState) Status {
 	} else {
 		status.PolicyApplied = false
 		status.SeccompEnabled = false
-		// Surface the "Apply has not been called" note regardless of
-		// Mode. The note's semantics are "kernel-level sandbox is not
-		// active on this process" — that is equally true when Apply
-		// failed, when Sprint-J wiring is pending, or when mode=off
-		// was explicitly requested. The DisabledBy field lets clients
-		// distinguish the three cases while the Notes array remains
-		// informationally complete for operators scanning status.
-		status.Notes = append(
-			status.Notes,
-			"sandbox backend is capable of kernel-level enforcement but Apply() has not been called on the Omnipus process; child processes are not currently restricted by Landlock or seccomp",
-		)
+		// Phrase the note differently depending on WHY the kernel sandbox
+		// isn't active. An operator who passed --sandbox=off is deliberately
+		// disabling enforcement; surfacing the scary "Apply has not been
+		// called" warning in that case implies the gateway is misconfigured
+		// when the operator explicitly chose this state. Reserve the gap
+		// warning for the unexpected-disabled case (DisabledBy empty), which
+		// really does mean Apply failed or wasn't wired.
+		switch state.DisabledBy {
+		case "cli_flag":
+			status.Notes = append(
+				status.Notes,
+				"Sandbox disabled via --sandbox CLI flag (operator choice). Pass --sandbox=enforce or set gateway.sandbox.mode to re-enable.",
+			)
+		case "config":
+			status.Notes = append(status.Notes,
+				"Sandbox disabled via gateway.sandbox.mode=off in config.json (operator choice).")
+		default:
+			// Unexpected: capable kernel, no DisabledBy marker, but Apply
+			// didn't succeed. That's the original failure mode — keep the
+			// loud warning.
+			status.Notes = append(
+				status.Notes,
+				"sandbox backend is capable of kernel-level enforcement but Apply() has not been called on the Omnipus process; child processes are not currently restricted by Landlock or seccomp",
+			)
+		}
 	}
 
 	if len(state.ExtraNotes) > 0 {

--- a/pkg/sandbox/status_test.go
+++ b/pkg/sandbox/status_test.go
@@ -134,3 +134,63 @@ func TestDescribeBackend_ABI2Features(t *testing.T) {
 	assert.Contains(t, status.LandlockFeatures, "TRUNCATE", "ABI v2 must include TRUNCATE")
 	assert.NotContains(t, status.LandlockFeatures, "IOCTL_DEV", "ABI v2 must not include IOCTL_DEV")
 }
+
+// TestDescribeBackendWithState_DisabledByCliFlag verifies that when the
+// operator explicitly disabled the sandbox via --sandbox=off, the status
+// note describes an operator choice rather than the scary "Apply() has
+// not been called" warning. Bug 2 from public-IP test findings.
+func TestDescribeBackendWithState_DisabledByCliFlag(t *testing.T) {
+	mock := &mockABIBackend{abiVersion: 3, applied: false}
+	status := DescribeBackendWithState(mock, ApplyState{
+		Mode:       ModeOff,
+		DisabledBy: "cli_flag",
+	})
+
+	assert.True(t, status.KernelLevel,
+		"backend is still kernel-capable even when disabled")
+	assert.False(t, status.PolicyApplied, "off mode must NOT report PolicyApplied=true")
+	require.Len(t, status.Notes, 1, "expect exactly one note for this branch")
+	note := status.Notes[0]
+	assert.Contains(t, note, "--sandbox CLI flag",
+		"note must reference the CLI flag as the reason")
+	assert.Contains(t, note, "operator choice",
+		"note must frame the state as a deliberate operator choice")
+	assert.NotContains(t, note, "Apply() has not been called",
+		"must not use the gap-warning wording when operator disabled explicitly")
+}
+
+// TestDescribeBackendWithState_DisabledByConfig verifies the equivalent
+// informational note when the operator set gateway.sandbox.mode=off in
+// config.json. Bug 2 from public-IP test findings.
+func TestDescribeBackendWithState_DisabledByConfig(t *testing.T) {
+	mock := &mockABIBackend{abiVersion: 3, applied: false}
+	status := DescribeBackendWithState(mock, ApplyState{
+		Mode:       ModeOff,
+		DisabledBy: "config",
+	})
+
+	assert.False(t, status.PolicyApplied)
+	require.Len(t, status.Notes, 1)
+	note := status.Notes[0]
+	assert.Contains(t, note, "gateway.sandbox.mode=off",
+		"note must name the config key")
+	assert.Contains(t, note, "operator choice")
+	assert.NotContains(t, note, "Apply() has not been called")
+}
+
+// TestDescribeBackendWithState_UnexpectedGapKeepsWarning verifies that when
+// the kernel is capable, the backend reports not-applied, and there is NO
+// DisabledBy marker, the original "Apply() has not been called" warning
+// still fires — that's a real gap operators need to see.
+func TestDescribeBackendWithState_UnexpectedGapKeepsWarning(t *testing.T) {
+	mock := &mockABIBackend{abiVersion: 3, applied: false}
+	status := DescribeBackendWithState(mock, ApplyState{
+		Mode:       "", // no explicit mode
+		DisabledBy: "",
+	})
+
+	assert.False(t, status.PolicyApplied)
+	require.Len(t, status.Notes, 1)
+	assert.Contains(t, status.Notes[0], "Apply() has not been called",
+		"unexpected-disabled case (no DisabledBy) must still surface the original gap warning")
+}

--- a/src/components/settings/DiagnosticsSection.test.tsx
+++ b/src/components/settings/DiagnosticsSection.test.tsx
@@ -111,16 +111,33 @@ describe('DiagnosticsSection — results display', () => {
     ],
   }
 
-  it('renders risk score when results are loaded', async () => {
-    // Traces to: wave5b-system-agent-spec.md — Scenario: Risk score gauge displayed (US-10 AC2)
-    // BDD: Given doctor result with score=42, Then score "42" is shown
+  it('renders security score (100 − risk) when results are loaded', async () => {
+    // Traces to: wave5b-system-agent-spec.md — Scenario: Score gauge displayed (US-10 AC2)
+    // BDD: Given doctor result with risk score=42, Then security score "58" is shown
+    // (bug 1 fix: UI flips the backend risk score so higher = better)
     vi.mocked(fetchDoctorResults).mockResolvedValue(fullResult)
 
     renderSection()
 
     await waitFor(() => {
-      expect(screen.getByText('42')).toBeInTheDocument()
+      expect(screen.getByText('58')).toBeInTheDocument()
     })
+    // The raw backend risk number (42) must NOT be shown to the user, so
+    // this assertion guards against a regression that would bring the
+    // confusing "Risk Score 42 — Medium" labeling back.
+    expect(screen.queryByText('42')).not.toBeInTheDocument()
+  })
+
+  it('uses the "Security Score" label (not "Risk Score")', async () => {
+    // Traces to: bug 1 from public-IP test findings — users mis-read
+    // "Risk Score: 90" as a high grade when it's actually 90/100 risk.
+    vi.mocked(fetchDoctorResults).mockResolvedValue(fullResult)
+    renderSection()
+    await waitFor(() => {
+      expect(screen.getByText(/security score/i)).toBeInTheDocument()
+    })
+    // The old label must be gone to prevent confusing operators.
+    expect(screen.queryByText(/^\s*risk score\s*$/i)).not.toBeInTheDocument()
   })
 
   it('displays the last run timestamp', async () => {
@@ -161,20 +178,23 @@ describe('DiagnosticsSection — results display', () => {
     })
   })
 
-  it('shows risk score label based on score value', async () => {
-    // Traces to: wave5b-system-agent-spec.md — Scenario: Risk label changes with score (US-10 AC2)
-    // Dataset from spec: score≤10 → Excellent, ≤33 → Low, ≤66 → Medium, ≤85 → High, >85 → Critical
-    const cases: Array<{ score: number; label: string }> = [
-      { score: 5, label: 'Excellent' },
-      { score: 20, label: 'Low risk' },
-      { score: 50, label: 'Medium risk' },
-      { score: 75, label: 'High risk' },
-      { score: 95, label: 'Critical' },
+  it('shows security label derived from (100 − risk)', async () => {
+    // Traces to: bug 1 fix — thresholds operate on security score, not risk.
+    //   security >= 90 → "Excellent"
+    //   security >= 67 → "Good"
+    //   security >= 34 → "At risk"
+    //   security  < 34 → "Critical"
+    const cases: Array<{ risk: number; label: string }> = [
+      { risk: 5, label: 'Excellent' }, // security 95
+      { risk: 20, label: 'Good' }, // security 80
+      { risk: 50, label: 'At risk' }, // security 50
+      { risk: 75, label: 'Critical' }, // security 25
+      { risk: 95, label: 'Critical' }, // security 5
     ]
 
-    for (const { score, label } of cases) {
+    for (const { risk, label } of cases) {
       const client = makeClient()
-      vi.mocked(fetchDoctorResults).mockResolvedValue({ score, issues: [], checked_at: '2026-01-01T00:00:00Z' })
+      vi.mocked(fetchDoctorResults).mockResolvedValue({ score: risk, issues: [], checked_at: '2026-01-01T00:00:00Z' })
       const { unmount } = render(
         <QueryClientProvider client={client}>
           <DiagnosticsSection />
@@ -308,8 +328,8 @@ describe('DiagnosticsSection — run diagnostics', () => {
     })
   })
 
-  it('shows toast with risk score after successful run', async () => {
-    // Traces to: wave5b-system-agent-spec.md — Scenario: Doctor run shows toast on completion
+  it('shows toast with security score after successful run', async () => {
+    // Traces to: bug 1 fix — toast says "security score: 75/100" (not raw risk 25).
     vi.mocked(fetchDoctorResults).mockResolvedValue(null)
     vi.mocked(runDoctor).mockResolvedValue({
       score: 25,
@@ -324,13 +344,15 @@ describe('DiagnosticsSection — run diagnostics', () => {
 
     await waitFor(() => {
       expect(mockAddToast).toHaveBeenCalledWith(
-        expect.objectContaining({ message: expect.stringContaining('25') })
+        expect.objectContaining({
+          message: expect.stringMatching(/security score:\s*75\/100/i),
+        })
       )
     })
   })
 
-  it('updates displayed results after run completes', async () => {
-    // Traces to: wave5b-system-agent-spec.md — Scenario: Results update after run (US-10 AC5)
+  it('updates displayed security score after run completes', async () => {
+    // Traces to: bug 1 fix — displayed number is 100 − risk (85 for risk=15).
     const newResult: DoctorResult = {
       score: 15,
       issues: [],
@@ -346,8 +368,8 @@ describe('DiagnosticsSection — run diagnostics', () => {
     fireEvent.click(screen.getByRole('button', { name: /run diagnostics/i }))
 
     await waitFor(() => {
-      // Score from the new result is shown
-      expect(screen.getByText('15')).toBeInTheDocument()
+      // Security score 85 (= 100 − 15) is shown
+      expect(screen.getByText('85')).toBeInTheDocument()
     })
   })
 

--- a/src/components/settings/DiagnosticsSection.tsx
+++ b/src/components/settings/DiagnosticsSection.tsx
@@ -17,18 +17,27 @@ import type { DoctorResult, DoctorIssue } from '@/lib/api'
 import { useUiStore } from '@/store/ui'
 
 // US-10: Doctor results diagnostics panel for Settings → Security
+//
+// The doctor API returns a numeric `score` field that semantically counts
+// RISK (deductions of -5/-10/-20 from an initial 100 per severity tier) —
+// higher on the wire means worse. The UI flips it to a conventional
+// "Security Score" where higher = better, because users consistently
+// misread a "Risk Score" of 90 as an A-grade. Backend contract unchanged;
+// the inversion lives entirely here.
+function toSecurityScore(risk: number): number {
+  return Math.max(0, Math.min(100, 100 - risk))
+}
 
-function getRiskLabel(score: number): string {
-  if (score <= 10) return 'Excellent'
-  if (score <= 33) return 'Low risk'
-  if (score <= 66) return 'Medium risk'
-  if (score <= 85) return 'High risk'
+function getSecurityLabel(securityScore: number): string {
+  if (securityScore >= 90) return 'Excellent'
+  if (securityScore >= 67) return 'Good'
+  if (securityScore >= 34) return 'At risk'
   return 'Critical'
 }
 
-function getRiskColor(score: number): string {
-  if (score <= 33) return 'var(--color-success)'
-  if (score <= 66) return 'var(--color-warning)'
+function getSecurityColor(securityScore: number): string {
+  if (securityScore >= 67) return 'var(--color-success)'
+  if (securityScore >= 34) return 'var(--color-warning)'
   return 'var(--color-error)'
 }
 
@@ -71,9 +80,10 @@ export function DiagnosticsSection() {
     mutationFn: runDoctor,
     onSuccess: (result) => {
       queryClient.setQueryData(['doctor'], result)
+      const securityScore = toSecurityScore(result.score)
       addToast({
-        message: `Diagnostics complete — risk score: ${result.score}/100`,
-        variant: result.score <= 33 ? 'success' : 'error',
+        message: `Diagnostics complete — security score: ${securityScore}/100`,
+        variant: securityScore >= 67 ? 'success' : 'error',
       })
     },
     onError: (err: Error) => addToast({ message: err.message, variant: 'error' }),
@@ -89,7 +99,8 @@ export function DiagnosticsSection() {
       } as const)
     : null
 
-  const riskColor = result ? getRiskColor(result.score) : undefined
+  const securityScore = result ? toSecurityScore(result.score) : 0
+  const scoreColor = result ? getSecurityColor(securityScore) : undefined
 
   return (
     <section className="space-y-4">
@@ -155,7 +166,7 @@ export function DiagnosticsSection() {
         </div>
       ) : result ? (
         <div className="space-y-4">
-          {/* Risk score card */}
+          {/* Security score card */}
           <div
             className="rounded-lg border p-4 space-y-3"
             style={{
@@ -165,27 +176,28 @@ export function DiagnosticsSection() {
           >
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-2">
-                {result.score <= 33 ? (
-                  <ShieldCheck size={15} weight="fill" style={{ color: riskColor }} />
+                {securityScore >= 67 ? (
+                  <ShieldCheck size={15} weight="fill" style={{ color: scoreColor }} />
                 ) : (
-                  <ShieldWarning size={15} weight="fill" style={{ color: riskColor }} />
+                  <ShieldWarning size={15} weight="fill" style={{ color: scoreColor }} />
                 )}
                 <span className="text-sm font-medium" style={{ color: 'var(--color-secondary)' }}>
-                  Risk Score
+                  Security Score
                 </span>
               </div>
               <div className="flex items-baseline gap-1">
-                <span className="text-2xl font-headline font-bold" style={{ color: riskColor }}>
-                  {result.score}
+                <span className="text-2xl font-headline font-bold" style={{ color: scoreColor }}>
+                  {securityScore}
                 </span>
                 <span className="text-xs" style={{ color: 'var(--color-muted)' }}>/100</span>
-                <span className="text-xs font-semibold ml-1.5" style={{ color: riskColor }}>
-                  {getRiskLabel(result.score)}
+                <span className="text-xs font-semibold ml-1.5" style={{ color: scoreColor }}>
+                  {getSecurityLabel(securityScore)}
                 </span>
               </div>
             </div>
 
-            {/* Custom-colored progress bar */}
+            {/* Custom-colored progress bar — width scales with security, so
+                a green fill grows as the posture improves. */}
             <div>
               <div
                 className="w-full h-2 rounded-full overflow-hidden"
@@ -194,17 +206,17 @@ export function DiagnosticsSection() {
                 <div
                   className="h-full rounded-full transition-all duration-700"
                   style={{
-                    width: `${result.score}%`,
-                    backgroundColor: riskColor,
+                    width: `${securityScore}%`,
+                    backgroundColor: scoreColor,
                   }}
                 />
               </div>
               <div className="flex justify-between mt-1">
                 <span className="text-[10px]" style={{ color: 'var(--color-muted)' }}>
-                  No issues
+                  Critical
                 </span>
                 <span className="text-[10px]" style={{ color: 'var(--color-muted)' }}>
-                  Critical
+                  Excellent
                 </span>
               </div>
             </div>

--- a/src/components/settings/SandboxSection.tsx
+++ b/src/components/settings/SandboxSection.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import {
   ShieldCheck,
   ShieldWarning,
@@ -9,10 +9,20 @@ import {
   CaretUp,
   XCircle,
   Cpu,
+  PencilSimple,
+  CheckCircle,
+  ArrowCounterClockwise,
+  Warning,
 } from '@phosphor-icons/react'
 import { Button } from '@/components/ui/button'
-import { fetchSandboxStatus } from '@/lib/api'
-import type { SandboxStatus } from '@/lib/api'
+import {
+  fetchSandboxStatus,
+  fetchSandboxConfig,
+  updateSandboxConfig,
+} from '@/lib/api'
+import type { SandboxStatus, SandboxConfig, SandboxConfigUpdate } from '@/lib/api'
+import { useAuthStore } from '@/store/auth'
+import { useUiStore } from '@/store/ui'
 
 // ── Status dot ────────────────────────────────────────────────────────────────
 
@@ -125,11 +135,57 @@ function CapabilitiesPanel({ data }: { data: SandboxStatus }) {
 
 export function SandboxSection(): React.ReactElement {
   const [expanded, setExpanded] = useState(false)
+  const [editing, setEditing] = useState(false)
+  const role = useAuthStore((s) => s.role)
+  const isAdmin = role === 'admin'
+  const { addToast } = useUiStore()
+  const queryClient = useQueryClient()
 
   const { data, isLoading, isError, error, refetch, isFetching } = useQuery({
     queryKey: ['sandbox-status'],
     queryFn: fetchSandboxStatus,
   })
+
+  // Editable sandbox config — only fetched when the operator is an admin
+  // AND has opened the editor. Keeps the read-only path unaffected.
+  const {
+    data: config,
+    isLoading: configLoading,
+    refetch: refetchConfig,
+  } = useQuery<SandboxConfig>({
+    queryKey: ['sandbox-config'],
+    queryFn: fetchSandboxConfig,
+    enabled: isAdmin && editing,
+  })
+
+  // Local draft — diverges from `config` once the operator touches a
+  // control. On Save we send only the changed fields (pointer-null
+  // semantics on the server side).
+  const [draftMode, setDraftMode] = useState<SandboxConfigUpdate['mode']>()
+
+  const { mutate: doSave, isPending: saving } = useMutation({
+    mutationFn: updateSandboxConfig,
+    onSuccess: (saved) => {
+      queryClient.setQueryData(['sandbox-config'], saved)
+      addToast({
+        message: saved.requires_restart
+          ? 'Sandbox config saved — restart the gateway to apply.'
+          : 'Sandbox config saved.',
+        variant: saved.requires_restart ? 'default' : 'success',
+      })
+      setDraftMode(undefined)
+    },
+    onError: (err: Error) =>
+      addToast({ message: err.message, variant: 'error' }),
+  })
+
+  const savedMode = config?.mode
+  const effectiveDraftMode = draftMode ?? savedMode
+  const restartPending = !!(
+    config &&
+    config.applied_mode !== '' &&
+    config.mode !== config.applied_mode
+  )
 
   // Derived display values — computed with explicit branches rather than
   // nested ternaries for readability.
@@ -265,6 +321,111 @@ export function SandboxSection(): React.ReactElement {
     )
   }
 
+  // ── Editor body ─────────────────────────────────────────────────────
+  function renderEditor(): React.ReactNode {
+    if (configLoading || !config) {
+      return <SandboxSkeleton />
+    }
+    const modes: Array<{ value: 'enforce' | 'permissive' | 'off'; label: string; desc: string }> = [
+      { value: 'enforce', label: 'Enforce', desc: 'Kernel-level Landlock + seccomp denies violating syscalls.' },
+      { value: 'permissive', label: 'Permissive', desc: 'Policy computed and logged; violations not blocked (audit-only).' },
+      { value: 'off', label: 'Off', desc: 'Sandbox disabled. Development only; production banner will fire.' },
+    ]
+    return (
+      <div className="rounded-lg border border-[var(--color-border)] bg-[var(--color-surface-1)] p-4 space-y-4">
+        {/* Restart banner — fires when a saved change hasn't taken effect yet. */}
+        {restartPending && (
+          <div
+            className="flex items-start gap-2 rounded-md border p-2.5"
+            style={{
+              borderColor: 'rgba(234,179,8,0.35)',
+              backgroundColor: 'rgba(234,179,8,0.08)',
+            }}
+            role="status"
+          >
+            <Warning size={14} weight="fill" style={{ color: 'var(--color-warning)' }} className="mt-0.5 shrink-0" />
+            <p className="text-xs leading-relaxed text-[var(--color-secondary)]">
+              <span className="font-semibold" style={{ color: 'var(--color-warning)' }}>
+                Restart required.
+              </span>{' '}
+              Saved mode is <code className="font-mono">{config.mode}</code> but the
+              gateway is currently running with{' '}
+              <code className="font-mono">{config.applied_mode || 'none'}</code>.
+              Restart the gateway for the change to take effect.
+            </p>
+          </div>
+        )}
+
+        {/* Mode radio group */}
+        <fieldset className="space-y-2">
+          <legend className="text-xs font-semibold uppercase tracking-wider text-[var(--color-muted)]">
+            Sandbox mode
+          </legend>
+          {modes.map((m) => (
+            <label
+              key={m.value}
+              className={`flex items-start gap-2 p-2 rounded-md border cursor-pointer transition-colors ${
+                effectiveDraftMode === m.value
+                  ? 'border-[var(--color-accent)]/50 bg-[var(--color-accent)]/5'
+                  : 'border-[var(--color-border)] hover:bg-[var(--color-surface-2)]'
+              }`}
+            >
+              <input
+                type="radio"
+                name="sandbox-mode"
+                value={m.value}
+                checked={effectiveDraftMode === m.value}
+                onChange={() => setDraftMode(m.value)}
+                className="mt-0.5 accent-[var(--color-accent)]"
+                aria-label={`Sandbox mode: ${m.label}`}
+              />
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium text-[var(--color-secondary)]">{m.label}</p>
+                <p className="text-xs text-[var(--color-muted)] leading-snug">{m.desc}</p>
+              </div>
+            </label>
+          ))}
+        </fieldset>
+
+        {/* Save / Cancel */}
+        <div className="flex items-center justify-end gap-2">
+          <Button
+            size="sm"
+            variant="outline"
+            className="h-7 px-3 text-xs"
+            onClick={() => {
+              setDraftMode(undefined)
+              setEditing(false)
+            }}
+            disabled={saving}
+          >
+            Cancel
+          </Button>
+          <Button
+            size="sm"
+            className="h-7 px-3 text-xs gap-1"
+            disabled={saving || !draftMode || draftMode === savedMode}
+            onClick={() => {
+              if (draftMode) doSave({ mode: draftMode })
+            }}
+          >
+            {saving ? (
+              <>
+                <ArrowCounterClockwise size={11} className="animate-spin" />
+                Saving
+              </>
+            ) : (
+              <>
+                <CheckCircle size={11} />
+                Save
+              </>
+            )}
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
   return (
     <section className="space-y-3">
       <div className="flex items-center justify-between">
@@ -272,22 +433,41 @@ export function SandboxSection(): React.ReactElement {
           <Cpu size={14} className="text-[var(--color-muted)]" />
           Process Sandbox
         </h3>
-        <Button
-          size="sm"
-          variant="outline"
-          className="h-7 px-2 gap-1 text-xs"
-          aria-label="Refresh sandbox status"
-          onClick={() => { void refetch() }}
-          disabled={isFetching}
-        >
-          <ArrowsClockwise
-            size={11}
-            className={isFetching ? 'animate-spin' : undefined}
-          />
-        </Button>
+        <div className="flex items-center gap-2">
+          {/* Edit button — admin-only. Opens the editor beneath the status card. */}
+          {isAdmin && !editing && (
+            <Button
+              size="sm"
+              variant="outline"
+              className="h-7 px-2 gap-1 text-xs"
+              aria-label="Edit sandbox configuration"
+              onClick={() => setEditing(true)}
+            >
+              <PencilSimple size={11} />
+              Edit
+            </Button>
+          )}
+          <Button
+            size="sm"
+            variant="outline"
+            className="h-7 px-2 gap-1 text-xs"
+            aria-label="Refresh sandbox status"
+            onClick={() => {
+              void refetch()
+              if (editing) void refetchConfig()
+            }}
+            disabled={isFetching}
+          >
+            <ArrowsClockwise
+              size={11}
+              className={isFetching ? 'animate-spin' : undefined}
+            />
+          </Button>
+        </div>
       </div>
 
       {renderBody()}
+      {isAdmin && editing && renderEditor()}
     </section>
   )
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -10,7 +10,13 @@
 const BASE_URL = import.meta.env.VITE_API_URL ?? ''
 
 // CSRF_COOKIE_NAME must match pkg/gateway/middleware/csrf.go CSRFCookieName.
+// On HTTPS origins the server issues `__Host-csrf` (Secure, prefix-enforced).
+// On plain-HTTP origins (dev, self-hosted without TLS) the __Host- cookie
+// can't install, so the server falls back to `csrf` (Secure=false) —
+// CSRF_COOKIE_NAME_HTTP below. readCSRFCookie() prefers __Host-csrf and
+// falls back to csrf, matching whatever the server actually set.
 const CSRF_COOKIE_NAME = '__Host-csrf'
+const CSRF_COOKIE_NAME_HTTP = 'csrf'
 const CSRF_HEADER_NAME = 'X-CSRF-Token'
 const STATE_CHANGING_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE'])
 
@@ -32,29 +38,34 @@ const CSRF_EXEMPT_PATHS = new Set<string>([
   '/api/v1/auth/register-admin',
 ])
 
-// readCSRFCookie parses document.cookie and returns the __Host-csrf value,
-// or null if the cookie is absent. We intentionally do not cache — cookies
-// can change after login/logout/onboarding and caching would cause stale
-// tokens on the next state-changing call.
+// readCSRFCookie parses document.cookie and returns the CSRF token value,
+// or null if neither the TLS nor the HTTP variant is present. We prefer
+// __Host-csrf when both are somehow present (shouldn't happen in practice)
+// because that's the stronger cookie. We intentionally do not cache —
+// cookies can change after login/logout/onboarding and caching would cause
+// stale tokens on the next state-changing call.
 function readCSRFCookie(): string | null {
   if (typeof document === 'undefined') return null
-  const prefix = `${CSRF_COOKIE_NAME}=`
-  // document.cookie is a single string of "a=b; c=d" pairs. We walk the
-  // pairs manually rather than split on ";" because cookie values can
-  // contain "=" (and base64 tokens certainly can).
-  for (const part of document.cookie.split(';')) {
-    const trimmed = part.trim()
-    if (trimmed.startsWith(prefix)) {
-      const raw = trimmed.slice(prefix.length)
-      // Apply decodeURIComponent defensively: if the browser percent-encoded
-      // the cookie value (e.g. standard base64 "=", "+", "/"), we decode it
-      // so the header value matches what the server originally set. If
-      // decoding fails (malformed sequence such as a lone "%"), fall back to
-      // the raw string and let the server compare verbatim.
-      try {
-        return decodeURIComponent(raw)
-      } catch {
-        return raw
+  // Try the TLS name first, then the plain-HTTP fallback.
+  for (const name of [CSRF_COOKIE_NAME, CSRF_COOKIE_NAME_HTTP]) {
+    const prefix = `${name}=`
+    // document.cookie is a single string of "a=b; c=d" pairs. We walk the
+    // pairs manually rather than split on ";" because cookie values can
+    // contain "=" (and base64 tokens certainly can).
+    for (const part of document.cookie.split(';')) {
+      const trimmed = part.trim()
+      if (trimmed.startsWith(prefix)) {
+        const raw = trimmed.slice(prefix.length)
+        // Apply decodeURIComponent defensively: if the browser percent-encoded
+        // the cookie value (e.g. standard base64 "=", "+", "/"), we decode it
+        // so the header value matches what the server originally set. If
+        // decoding fails (malformed sequence such as a lone "%"), fall back to
+        // the raw string and let the server compare verbatim.
+        try {
+          return decodeURIComponent(raw)
+        } catch {
+          return raw
+        }
       }
     }
   }
@@ -93,15 +104,23 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
   // instead of a cryptic "403 csrf cookie missing" from the network tab
   // and also prevents a cascade of dependent requests firing during a
   // broken auth state.
+  //
+  // Bearer-authenticated requests are not subject to the double-submit check
+  // server-side (browsers cannot auto-send an Authorization header cross-
+  // origin), so they must not be blocked here either — otherwise a logged-in
+  // SPA on plain HTTP where the Secure cookie couldn't install would hit an
+  // eager false-positive.
   const method = (init?.method ?? 'GET').toUpperCase()
+  const hasBearer = 'Authorization' in getAuthHeaders()
   if (
     STATE_CHANGING_METHODS.has(method) &&
     !isPathCSRFExempt(path) &&
+    !hasBearer &&
     readCSRFCookie() === null
   ) {
     throw new Error(
       `CSRF cookie missing — cannot ${method} ${path}. ` +
-        `Log in or complete onboarding first so the server can issue the __Host-csrf cookie.`,
+        `Log in or complete onboarding first so the server can issue the CSRF cookie.`,
     )
   }
 
@@ -1099,4 +1118,39 @@ export interface SandboxStatus {
 
 export function fetchSandboxStatus(): Promise<SandboxStatus> {
   return request<SandboxStatus>('/security/sandbox-status')
+}
+
+// SandboxConfig mirrors the editable subset of config.OmnipusSandboxConfig
+// exposed by GET/PUT /api/v1/security/sandbox-config. applied_mode reflects
+// what the gateway is CURRENTLY running; it differs from mode when the
+// operator saved a change that won't take effect until the gateway restarts.
+export interface SandboxConfig {
+  mode: 'enforce' | 'permissive' | 'off' | string
+  allow_network_outbound: boolean
+  allowed_paths: string[]
+  ssrf_enabled: boolean
+  ssrf_allow_internal: string[]
+  applied_mode: string
+  requires_restart?: boolean
+}
+
+// SandboxConfigUpdate is the partial-update shape accepted by PUT. Fields
+// not present are left untouched on disk.
+export interface SandboxConfigUpdate {
+  mode?: 'enforce' | 'permissive' | 'off'
+  allow_network_outbound?: boolean
+  allowed_paths?: string[]
+  ssrf_enabled?: boolean
+  ssrf_allow_internal?: string[]
+}
+
+export function fetchSandboxConfig(): Promise<SandboxConfig> {
+  return request<SandboxConfig>('/security/sandbox-config')
+}
+
+export function updateSandboxConfig(update: SandboxConfigUpdate): Promise<SandboxConfig> {
+  return request<SandboxConfig>('/security/sandbox-config', {
+    method: 'PUT',
+    body: JSON.stringify(update),
+  })
 }

--- a/tests/security/csrf_test.go
+++ b/tests/security/csrf_test.go
@@ -98,6 +98,12 @@ func csrfTargets() []csrfTarget {
 // TestCSRFProtection hard-asserts the double-submit cookie gate on every
 // state-changing endpoint in csrfTargets. The three sub-tests match the
 // failure modes of pkg/gateway/middleware/csrf.go.
+//
+// Note (bug 3 fix): Authorization: Bearer callers are EXEMPT from the CSRF
+// gate — browsers cannot auto-send the Authorization header cross-origin,
+// so Bearer traffic is not a CSRF target. These tests therefore omit the
+// Bearer token from the attack-scenario sub-tests to exercise the
+// cookie-auth code path, which is what the CSRF gate actually guards.
 func TestCSRFProtection(t *testing.T) {
 	gw := testutil.StartTestGateway(t, testutil.WithBearerAuth())
 
@@ -109,7 +115,8 @@ func TestCSRFProtection(t *testing.T) {
 		name := strings.NewReplacer("/", "_", " ", "_").Replace(tgt.path)
 
 		// ------------------------------------------------------------
-		// 1. Cross-origin + NO X-CSRF-Token header → hard-expect 403.
+		// 1. Cross-origin + NO X-CSRF-Token header + NO Bearer →
+		//    hard-expect 403 (the realistic browser-CSRF attacker scenario).
 		// ------------------------------------------------------------
 		t.Run(name+"_no_csrf_header_rejected", func(t *testing.T) {
 			body := bytes.NewReader([]byte(tgt.body))
@@ -119,15 +126,18 @@ func TestCSRFProtection(t *testing.T) {
 			if tgt.needsJSONBody {
 				req.Header.Set("Content-Type", "application/json")
 			}
-			if gw.Token() != "" {
-				req.Header.Set("Authorization", "Bearer "+gw.Token())
-			}
-			// Deliberately omit the X-CSRF-Token header AND the cookie.
+			// Intentionally omit Authorization header. In a real CSRF attack
+			// the victim's browser cannot auto-send Authorization cross-origin,
+			// only auto-send cookies — that's the scenario we're modelling.
+			// Also deliberately omit the X-CSRF-Token header AND the cookie.
 			resp, err := gw.HTTPClient.Do(req)
 			require.NoError(t, err)
 			defer resp.Body.Close()
 
-			// Hard expectation: 403 Forbidden.
+			// Hard expectation: 403 Forbidden from the CSRF gate. Without
+			// Bearer auth the request would 401 at the auth layer — but the
+			// CSRF middleware runs BEFORE auth in the middleware chain, so a
+			// state-changing request with no cookie short-circuits to 403.
 			require.Equal(t, http.StatusForbidden, resp.StatusCode,
 				"CSRF gate must reject %s %s with no cookie/header as 403",
 				tgt.method, tgt.path)
@@ -152,9 +162,7 @@ func TestCSRFProtection(t *testing.T) {
 			if tgt.needsJSONBody {
 				req.Header.Set("Content-Type", "application/json")
 			}
-			if gw.Token() != "" {
-				req.Header.Set("Authorization", "Bearer "+gw.Token())
-			}
+			// Same as above — no Bearer; the attack is cross-origin browser CSRF.
 			// Cookie and header disagree — the classic "forged header"
 			// attack shape. Attacker can set arbitrary headers but cannot
 			// write __Host- cookies from a different origin.

--- a/tests/security/csrf_test.go
+++ b/tests/security/csrf_test.go
@@ -128,7 +128,7 @@ func TestCSRFProtection(t *testing.T) {
 			}
 			// Intentionally omit Authorization header. In a real CSRF attack
 			// the victim's browser cannot auto-send Authorization cross-origin,
-			// only auto-send cookies — that's the scenario we're modelling.
+			// only auto-send cookies — that's the scenario we're modeling.
 			// Also deliberately omit the X-CSRF-Token header AND the cookie.
 			resp, err := gw.HTTPClient.Do(req)
 			require.NoError(t, err)

--- a/tests/security/helpers_test.go
+++ b/tests/security/helpers_test.go
@@ -152,16 +152,20 @@ func gatewayWithRBAC(t *testing.T) (gw *testutil.TestGateway, adminToken, userTo
 	require.NotEmpty(t, onboardResp.Token)
 	adminToken = onboardResp.Token
 
-	// Capture the __Host-csrf cookie issued by the onboarding handler
-	// (see pkg/gateway/rest_onboarding.go). All authenticated callers in the
-	// test harness reuse this value to pass the CSRF middleware (issue #97).
+	// Capture whichever CSRF cookie the onboarding handler issued. Bug 3
+	// made the cookie flavor request-aware: __Host-csrf when the request
+	// arrived over TLS (Secure:true, __Host- prefix), otherwise the
+	// un-prefixed `csrf` fallback (Secure:false) so the browser will
+	// accept it on plain HTTP. httptest.NewServer binds plain HTTP so the
+	// fallback is what the handler emits in this harness.
 	for _, c := range resp.Cookies() {
-		if c.Name == "__Host-csrf" {
+		if c.Name == "__Host-csrf" || c.Name == "csrf" {
 			csrfToken = c.Value
 			break
 		}
 	}
-	require.NotEmpty(t, csrfToken, "onboarding response must set __Host-csrf cookie")
+	require.NotEmpty(t, csrfToken,
+		"onboarding response must set either __Host-csrf (TLS) or csrf (plain HTTP) cookie")
 
 	// Add a second (non-admin) user via gw.SeedUser — this writes the user via
 	// the same read-modify-write + /reload path the gateway uses, eliminating

--- a/tests/security/sandbox_apply_test.go
+++ b/tests/security/sandbox_apply_test.go
@@ -194,30 +194,44 @@ func TestSandboxApply_NotesAbsentWhenApplied(t *testing.T) {
 	var status sandboxStatusResponse
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&status))
 
-	// BDD: The "not applied" warning is only acceptable when policy_applied=false.
-	// If policy_applied=true (enforce mode landed), no warning note must be present.
+	// BDD: When policy_applied=true (enforce mode), no warning/informational
+	// note about the sandbox being inactive must be present.
+	// When policy_applied=false, the note phrasing depends on DisabledBy
+	// (Bug 2 fix): operator choice vs genuine gap get distinct messages.
 	const notAppliedMsg = "Apply() has not been called"
+	const operatorChoice = "operator choice"
 	if status.PolicyApplied {
 		// After issue #76 is merged: enforce mode active — notes must be clean.
 		for _, note := range status.Notes {
 			assert.NotContains(t, note, notAppliedMsg,
 				"When policy_applied=true, notes must not contain the 'not applied' warning")
+			assert.NotContains(t, note, operatorChoice,
+				"When policy_applied=true, notes must not describe an operator-disabled state")
 		}
 		t.Logf("PASS: sandbox applied (backend=%s), notes clean", status.Backend)
 	} else {
-		// Before issue #76 merges OR on fallback: the gap note should be present
-		// IF the backend is kernel-capable. FallbackBackend has no notes.
+		// Before issue #76 merged OR on fallback OR when the harness disables
+		// the sandbox: the status MUST explain why it isn't active.
+		// FallbackBackend has no notes (nothing to explain).
 		if status.KernelLevel {
 			found := false
 			for _, note := range status.Notes {
-				if strings.Contains(note, notAppliedMsg) || strings.Contains(note, "not applied") {
+				// Either the genuine-gap warning (DisabledBy empty) OR the
+				// operator-disabled informational message (Bug 2) counts as
+				// an adequate explanation — both tell the operator what's
+				// happening. The test harness typically runs with
+				// --sandbox=off, which produces the operator-choice note.
+				if strings.Contains(note, notAppliedMsg) ||
+					strings.Contains(note, "not applied") ||
+					strings.Contains(note, operatorChoice) {
 					found = true
 					break
 				}
 			}
 			assert.True(t, found,
-				"When kernel-capable but Apply() not called (policy_applied=false), "+
-					"notes must explain the gap via 'not applied' message")
+				"When kernel-capable but policy_applied=false, notes must explain "+
+					"either the gap ('Apply() has not been called') or the "+
+					"operator choice ('operator choice')")
 			t.Logf(
 				"Test harness runs with sandbox=off (security-lead scope #1); kernel-level backend %q correctly reports policy_applied=false",
 				status.Backend,


### PR DESCRIPTION
## Summary

Fixes four issues surfaced by live testing on the public-IP gateway at \`http://146.190.89.151:3000/\`:

1. **Security Score (UI flip)** — \`DiagnosticsSection\` now shows \`Security Score: X/100\` (computed as \`100 − risk\`) with conventional higher=better semantics. Users no longer misread "Risk Score: 90" as an A-grade.

2. **Stale sandbox banner** — \`pkg/sandbox/sandbox.go\` surfaces different notes depending on \`DisabledBy\`:
   - \`cli_flag\` → "Sandbox disabled via --sandbox CLI flag (operator choice)"
   - \`config\` → "Sandbox disabled via gateway.sandbox.mode=off (operator choice)"
   - (genuine gap) → keeps the original "Apply() has not been called…" warning
   The loud warning no longer fires when the operator deliberately disabled sandbox.

3. **CSRF on plain HTTP** — two complementary policy changes:
   - **Bearer bypass**: CSRF middleware skips the double-submit check when \`Authorization: Bearer …\` is present. Browsers can't auto-send the Authorization header cross-origin, so Bearer traffic is not a CSRF target. Standard practice.
   - **HTTP cookie downgrade**: over plain HTTP the server emits an un-prefixed \`csrf\` cookie with \`Secure: false\` (instead of the \`__Host-csrf\` / \`Secure: true\` variant) so the browser will actually store it. Gate accepts either name. SameSite=Strict still blocks cross-origin sends.
   Plain-HTTP deployments (dev, self-hosted without a cert) now work end-to-end.

4. **UI-editable sandbox config** — \`PUT /api/v1/config\` intentionally blocks \`sandbox\` mutations ("use the dedicated security endpoints"). That endpoint didn't exist until now. New \`GET/PUT /api/v1/security/sandbox-config\` (admin-only) handles partial updates; SandboxSection gains an admin-only editor with a radio group for enforce/permissive/off and a "Restart required" banner (FR-J-015 locks out hot-reload for sandbox).

## Test coverage added

| Area | New tests |
|---|---|
| \`pkg/sandbox/status_test.go\` | 3 — DisabledBy branches + unexpected-gap retention |
| \`pkg/gateway/middleware/csrf_test.go\` | 6 — Bearer bypass, non-Bearer fallthrough, HTTP cookie downgrade, __Host- on HTTPS, X-Forwarded-Proto honoring |
| \`pkg/gateway/rest_security_wave5_test.go\` | 5 — GET/PUT/invalid mode/partial update/unsupported method |
| \`src/components/settings/DiagnosticsSection.test.tsx\` | 2 new + updated thresholds for flipped semantics |
| \`tests/security/csrf_test.go\` | Updated attack-scenario tests to reflect Bearer bypass policy |
| \`tests/security/helpers_test.go\` | Harness accepts either cookie flavor |

## Local CI

- \`CGO_ENABLED=0 go build ./...\` — clean
- \`CGO_ENABLED=0 go test ./pkg/gateway/... ./pkg/gateway/middleware/... ./pkg/sandbox/... ./pkg/audit/... ./pkg/policy/... ./pkg/security/... ./tests/security/...\` — all green
- \`CGO_ENABLED=0 golangci-lint run --build-tags=goolm,stdjson ./pkg/... ./tests/...\` — 0 issues
- \`npm run build\` — succeeds
- \`npx vitest run src/components/settings/\` — 28/28 passing

## Verified live

On \`http://146.190.89.151:3000/\` with a rebuilt binary carrying these fixes:
- Settings → Security → Diagnostics → Run: completes, shows "Security Score: X/100"
- Settings → Security → Process Sandbox: note reads "Sandbox disabled via --sandbox CLI flag (operator choice)" rather than "Apply() has not been called"
- Admin can edit sandbox mode → saves → banner reads "Restart required"
- \`curl -H "Authorization: Bearer \$TOKEN" -X POST /api/v1/doctor\` — 200 (Bearer bypass)
- SPA state-changing calls succeed over HTTP post-onboarding (plain-HTTP \`csrf\` cookie installs successfully)

🤖 Generated with [Claude Code](https://claude.com/claude-code)