### PR TITLE
fix(evals): write gateway.port + increase startup timeout to 60s

### DIFF
--- a/docs/architecture/library-refactor-impact-assessment.md
+++ b/docs/architecture/library-refactor-impact-assessment.md
@@ -1,0 +1,237 @@
+# Library Refactor — Impact Assessment
+
+**Status:** Assessment for architectural review
+**Base commit:** `da790c5` (origin/main at time of writing)
+**Prompted by:** *OmniPus — Three-Edition Architecture & Repo Strategy* (April 2026)
+**Purpose:** Ground-truth the strategy doc's claims against the current codebase and size the real work.
+
+> This is **not** a decision record. It is a sizing document intended to inform the architect's sign-off decision on §9 of the strategy doc. Line references are against `origin/main@da790c5`.
+
+---
+
+## 1. Executive summary
+
+Three things the reader needs up front:
+
+1. **The library refactor is smaller than the strategy doc implies.** Current library-readiness is ~**6–7/10**, not the implied "0/10" of a greenfield rewrite. The channel gateway pattern is already interface-driven, DI-shaped, and genuinely pluggable. The HTTP API is already a uniform `/api/v1/...` surface with no UI-only privileges. Config is already passed by value, not sourced from globals inside `pkg/`.
+
+2. **The real work is concentrated in three places, not spread across the codebase.** (a) `pkg/gateway/gateway.go` — a 1,186-line file that fuses library logic with application lifecycle (signal handling, banner printing, file-logger setup). (b) `pkg/logger/logger.go:274` — an unconditional `os.Exit(1)` on `FATAL` level that no library may contain. (c) The absence of swappable interfaces for `auth`, `policy`, `audit`, `credentials`, `storage` — these packages exist but expose concrete types, not contracts.
+
+3. **Revised effort estimate: 4–6 weeks for the backend, not 7–10.** The strategy doc's estimate is defensible for a generic refactor; it overshoots for this specific codebase because the hard architectural decisions (channel plugin model, uniform API, DI of config/bus/provider) have already been made. See §6.
+
+---
+
+## 2. What the strategy doc gets right
+
+These claims are accurate and should proceed to sign-off unchanged:
+
+| Strategy claim | Verdict | Evidence |
+|---|---|---|
+| Community code cannot contain `if enterprise` / `if desktop` conditionals (§3.2) | **Correct and currently upheld** | Zero hits for edition conditionals in `pkg/`. |
+| Extension interfaces must be versioned as first-class API (§4.4) | **Correct, and absent today** | No `pkg/ext` directory exists. No documented interface stability policy. |
+| OpenAPI as source of truth (§4.5) | **Correct, and absent today** | No `openapi.yaml` / `swagger.json` anywhere in repo. Contract exists only implicitly, encoded in `src/lib/api.ts` (1,075 LOC) and handler-by-handler in `pkg/gateway/rest*.go`. |
+| CLA on day one (§6.4) | **Correct and urgent** | No CLA mechanism currently in the repo. The moment any contribution lands in Community and is built into a closed Desktop/EE binary, this is a live legal exposure. Cheap to fix; blocks every downstream decision. |
+| "No private repo until the library boundary is validated" (§7.2) | **Correct** | The single highest-leverage rule in the whole doc. Worth enforcing. |
+| Contract tests in CI (§4.5) | **Correct, and absent today** | No contract-test job in CI; API/UI alignment is manual. |
+
+## 3. What the strategy doc overstates
+
+Claims that are directionally right but oversized for the actual code:
+
+### 3.1 "Today's shape is application-shaped" (§4.1)
+
+**Partially wrong.** The doc describes `main()` wiring hardcoded dependencies and the runtime "knowing it is OmniPus the app." Reality on `main@da790c5`:
+
+- `cmd/omnipus/main.go` is **63 lines**, a thin Cobra entrypoint that delegates to `cmd/omnipus/internal/gateway/command.go`.
+- `pkg/config/Config` is threaded through every subsystem via explicit arguments, not read from globals.
+- `pkg/bus/MessageBus`, `pkg/providers`, `pkg/agent.AgentLoop` are all constructor-injected.
+- The *actual* application-shaped code lives in `pkg/gateway/gateway.go` — not in `main.go` as the doc describes. The refactor target is different from what the doc names.
+
+### 3.2 "Library-shaped requires creating pkg/core.Runtime from scratch" (§4.2)
+
+**Wrong framing.** There is already a de-facto runtime entry point: `gateway.Run(debug, homePath, configPath, allowEmpty bool) error` at `pkg/gateway/gateway.go:231`. The work is not *creation*; it is **separation** — extracting application lifecycle out of this function so the residue is the library runtime.
+
+### 3.3 "7–10 weeks total" (§7.4)
+
+**Overstated for this codebase.** That budget assumes the channel plugin pattern, the LLM provider abstraction, the message bus, the session/state separation, and the single-entrypoint HTTP surface all need to be built. They already exist. Revised sizing in §6.
+
+### 3.4 "Three-layer UI monorepo requires extraction" (§5)
+
+**Partially done.** `pnpm-workspace.yaml` + `packages/ui` already exist. The split between top-level `src/` (the Community web app) and `packages/ui` is the beginning of the shell-vs-package model. What is missing is the middle layer (`@omnipus/client`, `@omnipus/hooks`, `@omnipus/feature-*`) and a proper DI pattern for the API client. See §5.
+
+---
+
+## 4. Current-state ground truth
+
+Verified on `main@da790c5`. Line numbers are stable unless noted.
+
+### 4.1 Backend prohibited-list audit (strategy doc §4.3)
+
+| Item | Present in `pkg/`? | Concrete evidence | Severity |
+|---|---|---|---|
+| `os.Exit` | **Yes, 2 production call sites** | `pkg/logger/logger.go:274` (FATAL level exits process); `pkg/logger/panic.go:33` (panic-trap exits after flush) | **Blocker.** Any subsystem logging at FATAL kills the host process. |
+| `log.Fatal` | No | — | Clean. |
+| `panic()` on recoverable errors | **Yes, 4 production call sites** of concern | `pkg/gateway/gateway.go:282` (file-logger setup); `pkg/policy/auditor.go:39` (nil Evaluator); `pkg/agent/audit_bridge.go:26` (nil Logger); `pkg/providers/fallback.go:43` (nil cooldown). Plus 6 "BUG: invalid hardcoded X" panics that are acceptable invariant checks. | **Medium.** Nil-constructor panics should become returned errors. |
+| `init()` with side effects | **25 files** | 15 channel `init.go` files register factories; `pkg/channels/base.go:26` seeds a random prefix; `pkg/logger/logger.go` initializes the global logger; `pkg/coreagent/core.go` compiles agent prompts. | **Medium.** The channel registry is acceptable *if documented as an opt-in import boundary*; the logger singleton is not. |
+| Global state / singletons | **Yes, confirmed** | `pkg/channels/registry.go:17–19` (global factories map); `pkg/logger/logger.go` (global `zerolog.Logger`, `fileLogger` under `sync.Once`); `pkg/channels/base.go:21–24` (global uniqueID counter). | **Medium.** Prevents two runtimes in one process (tests, multi-tenancy). |
+| Hardcoded file paths | **No absolute hardcoded paths** | `pkg/gateway/gateway.go:70–72` defines relative names (`"logs"`, `"gateway_panic.log"`, `"gateway.log"`) joined to a `homePath` argument. No `~/.omnipus/` literals in `pkg/`. | **Clean.** |
+| `os.Getenv` outside config helpers | **~30 occurrences, mostly OK** | Main concentration: `pkg/auth/oauth.go` reads OAuth client ID/secret from env. Should become `Config` fields. | **Low.** |
+| Flag parsing in `pkg/` | No | All flag parsing is in `cmd/omnipus/`. | **Clean.** |
+| Signal handling in `pkg/` | **Yes, 1 production site** | `pkg/gateway/gateway.go:245` (`signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)`) | **Blocker.** A library cannot own the host's signal strategy. |
+| Banner printing | **Yes** | Embedded in `gateway.Run()` status prints. | **Low.** Cosmetic; fix alongside signal extraction. |
+
+**Two hard blockers. Three medium-severity items. One low-severity.** The prohibited-list checklist is ~80% already satisfied.
+
+### 4.2 Channel gateway — the founder's "already library-shaped" claim
+
+**Substantively correct.** The channel subsystem is the strongest evidence that the architecture is already plugin-oriented:
+
+- `pkg/channels/base.go:47–56` defines the `Channel` interface with 8 required methods and a further 7 *optional* capability interfaces in `pkg/channels/interfaces.go` (TypingCapable, MessageEditor, StreamingCapable, etc.). This is the same pattern `pkg/ext` proposes.
+- `pkg/channels/registry.go` defines `ChannelFactory func(*config.Config, credentials.SecretBundle, *bus.MessageBus) (Channel, error)` — secrets arrive as a bundle, **not** from `os.Getenv`. This already solves the "no env var coupling" problem for the largest extension surface.
+- 15 channels (`dingtalk`, `discord`, `feishu`, `googlechat`, `irc`, `line`, `maixcam`, `onebot`, `qq`, `slack`, `telegram`, `wecom`, `weixin`, `whatsapp`, `whatsapp_native`) are registered via blank-imports at `pkg/gateway/gateway.go:31–45`. Dropping one = remove its import line. Adding a private EE channel = import it from the EE `cmd/`.
+
+**The one coupling issue:** because blank-imports live inside `pkg/gateway/gateway.go`, a third-party channel cannot be registered without the consumer modifying the library or manually calling `channels.RegisterFactory()` before `gateway.Run()`. This is fixable by moving the blank-imports out of `pkg/` and into `cmd/omnipus/`.
+
+### 4.3 UI as "just another client" — the founder's second claim
+
+**Correct.** Verified at `src/lib/api.ts:1–28`: the UI authenticates via Bearer token (same token path as any other HTTP client), calls `/api/v1/...` via `fetch`, and has no privileged "UI-only" endpoints. The same auth middleware that protects external calls protects UI calls. The UI is `go:embed`-ded (`pkg/gateway/embed.go`) as a convenience — the Go server does not *require* it; it is served alongside the API.
+
+**One nuance worth flagging:** `src/lib/api.ts` is 1,075 LOC of hand-maintained fetch wrappers. This is the single biggest *latent* risk when the UI splits across three editions — any drift between Go handlers and this file is silent. Generating it from OpenAPI (§4.5 of the strategy doc) is not optional once Desktop/EE exist.
+
+### 4.4 Gate-level coupling hotspots
+
+In order of extraction difficulty:
+
+1. **`pkg/gateway/gateway.go` (1,186 LOC).** The monolith. `Run()` (line 231) bootstraps credentials, config, provider, agent loop, HTTP server, reload loop, signal handling, banner, and file-logger. This is the *actual* refactor target — not `main.go`, not `pkg/core` (which does not exist).
+2. **`pkg/agent.AgentLoop`.** A large struct with many injected dependencies. Structurally DI-correct, but the number of fields means any change to a dependency's interface ripples through construction sites. Risk is refactor friction, not design failure.
+3. **`pkg/logger`.** Global singleton with `os.Exit` on FATAL. Must be either (a) made injectable as an `ext.Logger` interface, or (b) kept global but stripped of `os.Exit`. Option (b) is cheaper.
+4. **`pkg/auth`, `pkg/policy`, `pkg/audit`, `pkg/credentials`.** Each is a concrete package today. Extracting an interface is mechanical; the risk is that EE's needs (OIDC/SAML/SCIM, OPA, Splunk/SIEM, Vault/KMS) expose interface-design errors we cannot see yet. Defer full interface design until a paying EE partner's requirements are concrete (strategy doc §7.3 mitigation — correct).
+5. **Channel registry globalness.** Moving `factories` from a package-level `map` to a `*Registry` owned by the runtime is a 1-day refactor but touches 15 channel packages. Low risk, high surface area.
+
+---
+
+## 5. Gap analysis vs. the proposed `pkg/ext` interfaces
+
+Strategy doc §4.4 proposes nine interfaces. Current state, per interface:
+
+| Interface | Today | Extraction effort | Notes |
+|---|---|---|---|
+| `ConnectorRegistry` | **Done.** `pkg/channels` already matches this shape. | 2 days | Rename + document + move blank-imports to `cmd/`. |
+| `CredentialBroker` | **Partial.** `pkg/credentials.SecretBundle` already decouples channels from env. No broker interface for rotation/external vaults. | 3 days | Interface exists implicitly; formalize and add KMS/Vault seam. |
+| `Telemetry` | **Absent.** `pkg/health` provides a health server, not a metrics pipeline. | 2 days | Minimal surface (Counter/Gauge/Histogram/TraceSpan). Community defaults to stdout/Prometheus. |
+| `AuditSink` | **Concrete.** `pkg/audit` writes JSONL. No interface. | 3 days | Interface is small; `audit.Logger` already looks sink-shaped. Straightforward. |
+| `Storage` | **Absent.** Session/task/state persistence goes directly to filesystem via `pkg/session`, `pkg/taskstore`, `pkg/state`. | 5–8 days | Biggest hidden effort. Interface must cover multiple entity kinds without becoming leaky. Design carefully. |
+| `PolicyEngine` | **Concrete.** `pkg/policy` is a full implementation. | 3 days | Interface design is the hard part — OPA-style policy is much richer than allowlist. Defer rich design until EE is real. |
+| `AuthProvider` | **Concrete.** `pkg/auth` handles local + OAuth today. | 3 days | SSO/SAML/SCIM is EE-only work; Community interface is small. |
+| `WorkflowEngine` | **Absent.** No workflow abstraction today. | Defer | Strategy doc flags this as EE-durable-workflow territory. Don't build until Temporal/Inngest-equivalent is actually required by EE buyer. |
+| `TenantResolver` | **Absent.** Single-tenant everywhere. | Defer | Same logic. |
+
+**Realistic initial `pkg/ext` scope:** `ConnectorRegistry`, `CredentialBroker`, `Telemetry`, `AuditSink`, `AuthProvider`, `PolicyEngine`, `Storage`. Ship stubs/no-ops for `WorkflowEngine` and `TenantResolver`; implement them only when a paying partner's requirements exist. This matches strategy doc §7.3.
+
+---
+
+## 6. Revised effort estimate
+
+The strategy doc's Phase 2+3+4 estimate is **7–9 weeks**. Based on §4, the revised estimate:
+
+| Phase | Strategy doc | This assessment | Delta rationale |
+|---|---|---|---|
+| 1. API contract (OpenAPI + contract tests + CLA + generated TS client) | 1–2 wk | **1.5–2 wk** | No delta. Genuinely absent work. |
+| 2a. Extract `pkg/gateway/gateway.go` → `pkg/core.Runtime` + thin cmd | — | **1.5 wk** | The real Phase 2 entry. Split signal handling, banner, file-logger setup out. |
+| 2b. Remove `os.Exit` from logger; convert nil-constructor panics to errors | — | **2–3 days** | Mechanical. |
+| 2c. Move channel blank-imports from `pkg/gateway` to `cmd/omnipus` | — | **1 day** | Mechanical but touches 15 packages. |
+| 2d. Formalize 5 in-scope `pkg/ext` interfaces with defaults wired into the new `core.Runtime` (Connector, Credential, Telemetry, Audit, Auth — defer Policy/Storage until needed) | — | **1–1.5 wk** | Less than the doc implies because four of these already exist as concrete packages to wrap. |
+| 3. UI library refactor | 3–4 wk | **2–3 wk** | Less than the doc implies because `packages/ui` + pnpm workspace + `vite.lib.config.ts` already exist. Remaining: `@omnipus/client` (generated from OpenAPI), `@omnipus/hooks`, peel 1–2 features out as proof. |
+| 4. Validate boundary with `cmd/omnipus-minimal` | 1 wk | **3–5 days** | Same. |
+| 5. Private repos scaffolded | 1 wk | **3–5 days** | Same. |
+| **Total** | **7–10 wk** | **~5–6 wk** | Concentrated in items that are genuinely absent; existing structure saves ~2–4 weeks. |
+
+**One senior engineer, full-time, familiar with the codebase.** Add ~30% for code review cycles if the refactor lands via PRs with mandatory review (realistic).
+
+---
+
+## 7. Recommended sequencing (revised)
+
+Strategy doc Phase 1–5 remain correct in shape. Two adjustments:
+
+1. **Phase 1 should include the CLA and the "kill `os.Exit` in logger" chore.** Both are cheap, blocking, and do not require the big refactor. Do them first.
+
+2. **Phase 2 should explicitly target `pkg/gateway/gateway.go` as the lift site**, not create `pkg/core` from scratch. The work is to extract the library runtime *out of* the existing gateway file, not build a new one.
+
+Suggested branch/PR decomposition:
+
+| PR | Scope | Risk |
+|---|---|---|
+| 1 | Add CLA bot, add OpenAPI skeleton + CI contract test stub, remove `os.Exit(1)` from `pkg/logger` | Low |
+| 2 | Move channel blank-imports from `pkg/gateway/gateway.go` to `cmd/omnipus/main.go` | Low |
+| 3 | Extract `pkg/core.Runtime` from `gateway.Run()`; leave signal handling, banner, file-logger setup in `cmd/omnipus` | Medium — touches every caller of `gateway.Run` |
+| 4 | Introduce `pkg/ext` with `ConnectorRegistry`, `CredentialBroker`, `Telemetry`, `AuditSink`, `AuthProvider` interfaces + `pkg/ext/defaults` reference impls | Medium |
+| 5 | Generate `src/lib/api.ts` from OpenAPI; delete handwritten version | Medium — regression surface |
+| 6 | `cmd/omnipus-minimal` — 20-line proof-point consuming `pkg/core` | Low |
+| 7 | UI: extract `@omnipus/client` + `@omnipus/hooks`; keep existing SPA working | Medium |
+| 8 | UI: peel 1 feature (recommend `sessions`) into `@omnipus/feature-sessions` | Low — proves the pattern |
+
+Each PR is independently mergeable to `main` without Desktop or EE existing. The validation gate in strategy doc §7.2 (no private repo until boundary green) is satisfied after PR 6.
+
+---
+
+## 8. Risks
+
+### 8.1 Interface design errors hidden until EE is real (medium)
+
+`PolicyEngine`, `Storage`, `WorkflowEngine`, `TenantResolver` are all interfaces we cannot design correctly without a concrete EE requirement. If we design them speculatively, we will either (a) over-build and pay interface-maintenance cost for years, or (b) guess wrong and break every consumer when EE arrives. **Mitigation:** keep these out of v1 of `pkg/ext`. Ship only the five we already have concrete shape for.
+
+### 8.2 Hand-maintained `src/lib/api.ts` (medium, pre-existing)
+
+1,075 LOC of handwritten fetch wrappers. Already a drift risk today; becomes acute the moment a second consumer (Desktop's Tauri shell, EE's hosted UI) depends on it. **Mitigation:** PR 5 generates this file from OpenAPI. Non-optional if three editions exist.
+
+### 8.3 Logger globalness (low)
+
+Making the logger injectable is architecturally clean but would touch every log call site. **Mitigation:** keep the global, remove only `os.Exit(1)`. Acceptable compromise; revisit if multi-runtime-per-process becomes a real need.
+
+### 8.4 Channel blank-import coupling (low)
+
+Moving imports out of `pkg/gateway` into `cmd/omnipus` is mechanical but will surface any channel that reaches back into gateway internals. Expect 1–2 such discoveries. **Mitigation:** fix as found; none should be structural.
+
+### 8.5 "Refactor in flight, features keep shipping" (high, non-technical)
+
+The strategy doc assumes a clean Phase 1→5 sequence. In practice, feature work on channels, security, and agents is active (visible in concurrent feature branches: `channel-signal`, `channel-google-chat`, `channel-teams`, `sprint-c-test-first`). A 5-week refactor that freezes these branches will be rejected; one that merges incrementally without freezing will take longer in wall-clock time.
+
+**Mitigation:** design the PR sequence above to be independently mergeable and non-breaking. No single PR should block active feature work for more than ~2 days of rebase.
+
+---
+
+## 9. Recommendation
+
+### 9.1 To the architect
+
+Sign off on strategy doc §9 items **1, 2, 3, 4, 5, 6** — all six. They are correct in direction. However, adjust:
+
+- **§9.1 (three repos, dep-not-fork):** Sign off, but defer creation of the two private repos until after PR 6 lands. Strategy doc §7.2 already says this — enforce it.
+- **§9.2 (`pkg/core` + `pkg/ext`):** Sign off on the pattern, but scope initial `pkg/ext` to five interfaces, not nine. Defer `PolicyEngine` rich features, `Storage`, `WorkflowEngine`, `TenantResolver` until EE requirements are concrete.
+- **§9.4 (OpenAPI first-class):** Sign off, and **prioritize**. The handwritten `src/lib/api.ts` is the largest hidden debt in the current codebase relative to the three-edition plan.
+- **§9.5 (CLA day one):** Sign off, and do it **this week**. It is the cheapest, highest-leverage item in the entire strategy.
+- **§9.6 (no private repo until boundary validated):** Sign off. Single most important rule in the document.
+
+### 9.2 To Daniel
+
+The strategy doc is architecturally sound but oversized for the codebase you actually have. Your instinct that "much of this is already done" is correct:
+
+- The channel gateway is already `pkg/ext`-shaped in everything but name.
+- The HTTP API is already uniform and unprivileged.
+- `packages/ui` + pnpm workspace already exists.
+- Config is already DI'd through the stack.
+
+**What is genuinely missing** and worth starting now, regardless of whether Desktop/EE ever ship:
+
+1. A CLA (§9.5). 30 minutes of work. Unblocks every future licensing question.
+2. An OpenAPI spec, even imperfect. Even if the backend stays the sole consumer, it ends the drift risk on `src/lib/api.ts`.
+3. Removal of `os.Exit(1)` from `pkg/logger/logger.go:274` and the nil-constructor panics. These are library-hygiene improvements that are cheap and valuable regardless of edition plans.
+
+**What to defer** until a paying EE design partner commits: everything in §4 of the strategy doc beyond the five in-scope `pkg/ext` interfaces. Don't build `TenantResolver` for a product you haven't sold.
+
+**The actual go/no-go question** is not "library refactor yes or no." It is: **do we have signal that Desktop or EE will produce revenue within ~2 quarters of the refactor landing?** If yes, the 5–6 week investment pays back. If no, do only the three no-regret items above and revisit when signal changes.
+
+---
+
+*End of assessment.*

--- a/docs/architecture/library-refactor-risk-analysis.md
+++ b/docs/architecture/library-refactor-risk-analysis.md
@@ -1,0 +1,207 @@
+# Library Refactor — Risk & Regression Analysis
+
+**Status:** Companion to `library-refactor-impact-assessment.md`
+**Audience:** Product owner, engineering lead, QA — anyone who needs to know what could break
+**Written in:** Plain English, not architect-ese
+**Base commit:** `origin/main@da790c5`
+
+> The impact assessment explained *what* needs to change. This document explains *what could break* while changing it, and how bad each break would be.
+
+---
+
+## The honest short answer
+
+**If the refactor is done carefully — 8 small PRs instead of 1 big-bang PR — the risk to existing features is low-to-moderate.** Most of the work is *moving code around*, not changing how things behave.
+
+The danger is concentrated in **two or three specific PRs**, not spread evenly across the whole refactor. If you know where to be careful, most of the code is safe.
+
+---
+
+## Risk by feature area
+
+### 🟢 Low risk
+
+**Channels (Slack, Telegram, Discord, Signal, and the other 12).**
+These already sit behind a clean interface. They're built from a factory, they receive config and secrets explicitly, they talk to the rest of the system only through the message bus. Moving the code around them doesn't change their behaviour.
+*One small gotcha:* moving the channel `_ "..."` imports out of `pkg/gateway/gateway.go:31–45` into `cmd/omnipus/` will silently break the build if any channel package quietly relies on being imported from gateway. I don't expect any to — but I'd find out on day one if they did. Hours to fix, not days.
+
+**The agent loop, LLM routing, tools, skills.**
+All already DI-shaped. They accept their dependencies as constructor arguments today. The refactor doesn't change that; it just means the constructor call site moves from `pkg/gateway` to `cmd/omnipus`.
+
+**Sessions, task store, state.**
+Self-contained subsystems. Nothing in the refactor touches their internals.
+
+**Adding `pkg/ext` interfaces around existing packages.**
+This is additive — the concrete types stay, interfaces wrap them. Community keeps using the concrete defaults; only a future Enterprise implementation would swap. Zero behaviour change for current users.
+
+---
+
+### 🟡 Medium risk
+
+**Startup sequence and shutdown — the single most dangerous area.**
+`pkg/gateway/gateway.go:231` (`Run()`) currently owns, in a very specific order:
+
+1. Credential unlock
+2. Config load
+3. Provider setup with env injection
+4. Agent loop construction
+5. HTTP server start
+6. Signal handling
+7. Banner + status output
+8. File logger setup
+9. Reload loop
+
+When you pull these apart into library vs. app code, it's easy to get the **order wrong**. Classic symptoms:
+
+- Credentials unlock before config is read → secrets resolve against an empty config → silent failure
+- HTTP server starts before the agent loop is ready → first request hits a nil pointer
+- Signal handler registered before the thing it's supposed to shut down exists → Ctrl+C does nothing
+
+**Why this is real, not theoretical:** the existing file is 1,186 lines because every line got added in an order that works. Moving them around without careful testing will re-introduce bugs someone already fixed, possibly months ago.
+
+**Mitigation:** the startup extraction PR needs **end-to-end tests** running against it. Start the gateway, log in, send a message, receive a reply, shut down cleanly. If those pass, you're probably fine.
+
+---
+
+**Logging behaviour — subtle, one-line change, widespread effect.**
+Removing `os.Exit(1)` from `pkg/logger/logger.go:274` changes one thing: today, logging at FATAL level kills the process immediately. After the change, the process logs FATAL and keeps running.
+
+**The risk:** some caller somewhere may be relying on FATAL-means-die. If it is, removing the exit means the process limps along in a broken state instead of dying cleanly — which is harder to debug than dying cleanly.
+
+**Mitigation:** grep every `.Fatal(` and `FATAL` call site (there are likely a handful). For each, ask: does this really mean "process must die right now"? If yes, the call site in `cmd/omnipus` should explicitly call `os.Exit` — libraries aren't allowed to, but apps are. If no, leave it logging and carrying on.
+
+---
+
+**Regenerating the API client from OpenAPI — highest surface area.**
+`src/lib/api.ts` is 1,075 lines of handwritten fetch wrappers. Every UI feature uses it. Replacing it with a generated-from-OpenAPI version means that every UI feature now depends on a slightly different client.
+
+**The risk:** subtle differences you don't notice until a user does.
+- Header shape differs → auth fails on some endpoints
+- Error parsing differs → errors become silent or become loud in the wrong places
+- Null vs. undefined handling differs → forms submit blank fields instead of not submitting them
+- Timeout behaviour differs → slow endpoints time out in the UI but succeed on the server
+
+These regressions scatter across the whole UI, which makes them hard to find with a targeted test.
+
+**Mitigation (important — don't skip):**
+- Do this PR **after** the gateway extraction, not during. Don't stack risks.
+- Keep the handwritten file present during the transition. Feature-flag which client is used so you can roll back in production.
+- Run a full UI smoke test manually: log in, chat, configure a channel, change a setting, log out. If any of those feel different, investigate before merging.
+
+Honestly, this is the PR I would be most conservative with. It's the one that can break things no test notices.
+
+---
+
+**Config reload — fragile today, needs to stay fragile-but-working.**
+The current reload loop inside `gateway.Run()` is intertwined with the gateway's own lifecycle. When the library extraction happens, the reload has to either stay inside the library (so that changes of config, provider, channels still work) or become a contract that the application layer honours. Getting this wrong means the next time you change a setting in the UI, it either doesn't take effect or takes effect in a way that breaks the session.
+
+**Mitigation:** treat "change a config value in the UI and see it applied without restart" as an acceptance test for the extraction PR. If it still works, the reload survived.
+
+---
+
+**UI feature extraction.**
+Peeling a feature (like sessions) out of `src/` into `@omnipus/feature-sessions` is mostly a move-and-rename operation. Low risk *if* the feature is self-contained.
+
+**The risk:** a feature you assumed was self-contained turns out to reach into shared state or context. When you extract it, it breaks — or worse, appears to work but behaves subtly differently.
+
+**Mitigation:** start with the most self-contained feature (sessions), not the most important one (chat). Chat probably has shared state with agents, messages, and streaming — save it for last.
+
+---
+
+### 🔴 Higher risk (but small scope)
+
+**Turning nil-constructor panics into returned errors.**
+Four places today (`pkg/policy/auditor.go:39`, `pkg/agent/audit_bridge.go:26`, `pkg/providers/fallback.go:43`, `pkg/gateway/gateway.go:282`) panic immediately if they're constructed with a nil dependency. The refactor wants them to return an error instead.
+
+Sounds mechanical. It isn't.
+
+**The risk:** if you return an error instead of panicking, every caller now has to handle it. Miss one caller and you've moved the panic from the constructor (which fails loudly and immediately) to some arbitrary later point when the nil field is first touched (which fails quietly, maybe minutes or hours later, in a totally unrelated-looking part of the code).
+
+**Mitigation:** do these one at a time, not in a batch. For each panic you remove, trace every call site of that constructor. Confirm the new error is handled. Don't just grep for the function name — use the compiler, because if the return signature changed, every caller fails to compile until handled. That's your safety net.
+
+---
+
+## Risk by user-visible feature
+
+A quick table for the product owner:
+
+| Feature | Risk | What would break it |
+|---|---|---|
+| Chat / sending messages | **Medium** | API client regeneration |
+| Streaming responses | **Medium** | SSE / WebSocket paths inside the gateway could be disturbed by extraction |
+| Channel integrations (all 15) | **Low** | Each channel is self-contained behind a clean interface |
+| Login / authentication | **Medium** | Touches `pkg/auth` (env var reads) and the UI client regen |
+| Skills and tools | **Low** | Already interface-driven |
+| Config changes / hot reload | **Medium–high** | Reload loop is tangled into gateway startup |
+| Credential unlock on boot | **Medium** | Boot order is fragile; order changes bite here first |
+| Graceful shutdown (Ctrl+C, SIGTERM) | **Medium** | Signal handling is moving out of the library |
+| UI responsiveness and layout | **Low–medium** | Depends on how clean each feature extraction is |
+| Observability / log output | **Low** | Log format doesn't change; only FATAL-means-exit behaviour changes |
+
+---
+
+## Risks that aren't about code breaking
+
+Two risks the strategy doc doesn't address, which matter more than people think.
+
+### Development velocity during the refactor
+
+You have **four active feature branches** today (`channel-signal`, `channel-google-chat`, `channel-teams`, `sprint-c-test-first`). Every one of them touches code in or near the refactor zone.
+
+**If the refactor lands as one big PR**, every one of those branches rebases through hell. Channel PRs re-do their blank-import wiring. Security PRs hunt for where their middleware registration moved to. Tests break in ways unrelated to the feature the branch was supposed to add.
+
+**If the refactor lands as 8 small PRs** (as recommended in the impact assessment), each is separately mergeable and the feature branches rebase cleanly most of the time.
+
+But the 8-small-PRs approach is **slower in wall-clock time** than the one-big-PR approach. Probably 30–40% longer. That's the trade-off. You buy lower regression risk with calendar weeks.
+
+### Risks that won't show up in any test suite
+
+Some behaviours only show up in production, under real conditions:
+
+- **Credential rotation under load.** If you're rotating a Slack token *while* the gateway is reloading config, and the refactor changed the order of credential unlock vs config reload, you'll discover the race condition the hard way — when a customer reports their bot went silent.
+- **Long agent sessions across a config reload.** Does an in-flight agent survive a reload? The current code does. Any refactor that touches the reload path needs to preserve this behaviour, but no unit test proves it.
+- **OAuth flows.** `pkg/auth/oauth.go` reads env vars directly today. If the refactor moves this to config-based reading, users whose environment setup relied on a specific load order might see failures.
+
+**Mitigation:** these get tested by running the refactored build against a staging instance for a week before release. No shortcut available.
+
+---
+
+## The biggest risk of all: not doing it
+
+This is worth saying plainly.
+
+The current code has **two real library-hygiene bugs** that exist today, regardless of whether Desktop or Enterprise ever ship:
+
+1. **`os.Exit(1)` in the logger** means any wrapper around OmniPus — including future Desktop, including test harnesses, including a hypothetical third-party embedder — gets killed by a single FATAL log call, possibly from a subsystem that shouldn't have that authority.
+2. **Hand-maintained `src/lib/api.ts`** is drifting from the Go backend today, silently, before a second UI even exists. You just don't have visibility into it yet because the UI and the backend ship as one binary, so small mismatches usually get fixed in the same PR. The moment they ship separately, drift becomes a user-facing bug.
+
+Deferring the refactor is not zero-risk. It's just **moving the risk to a place where you can't measure it**. The handwritten API client keeps growing. Every caller relying on `os.Exit`-on-FATAL becomes harder to unwind later.
+
+---
+
+## What I recommend to reduce risk
+
+1. **Do the three no-regret items first**, in this order, each as its own small PR:
+   - Add a CLA mechanism. No code risk at all.
+   - Remove `os.Exit(1)` from the logger. Medium risk, small scope, worth doing alone.
+   - Write the OpenAPI spec and add a CI contract test (but don't regenerate `src/lib/api.ts` yet). Low risk, high value.
+
+2. **Only then, decide whether to proceed with the full refactor.** If Desktop / Enterprise revenue signal is weak, stop here. You've already improved the code.
+
+3. **If you do proceed, follow the 8-PR sequence** from the impact assessment. Never bundle. Never do the startup extraction and the API regen in the same PR. Never do two medium-risk items together.
+
+4. **Treat the startup extraction (PR 3) as the riskiest PR.** Give it manual end-to-end testing, not just unit tests. If it passes a full "start → log in → chat → configure channel → shut down" flow, it's probably fine.
+
+5. **Treat the API regen (PR 5) as the second-riskiest PR.** Keep the handwritten client available as a feature-flag fallback for one release. Don't delete it on day one.
+
+6. **Don't freeze feature branches.** The refactor has to land incrementally alongside active work on channels, security, and agents. If it can't, it's too big — break it down more.
+
+---
+
+## One-sentence summary
+
+The refactor is genuinely risky in exactly three places — **gateway startup, API client regeneration, and turning panics into errors** — and genuinely safe everywhere else, which is why the discipline of small, separately-merged PRs matters more than the speed of any individual change.
+
+---
+
+*End of risk analysis.*

--- a/evals/cmd/eval-runner/main.go
+++ b/evals/cmd/eval-runner/main.go
@@ -305,7 +305,7 @@ func startGateway(ctx context.Context, omnipusBin, homeDir string) (*gatewayHand
 	// Poll for up to 30 seconds.
 	portFile := filepath.Join(homeDir, "gateway.port")
 	var port string
-	deadline := time.Now().Add(30 * time.Second)
+	deadline := time.Now().Add(60 * time.Second)
 	for time.Now().Before(deadline) {
 		data, err := os.ReadFile(portFile)
 		if err == nil && len(bytes.TrimSpace(data)) > 0 {
@@ -323,7 +323,7 @@ func startGateway(ctx context.Context, omnipusBin, homeDir string) (*gatewayHand
 
 	// Wait for /health.
 	healthURL := baseURL + "/health"
-	deadline = time.Now().Add(30 * time.Second)
+	deadline = time.Now().Add(60 * time.Second)
 	for time.Now().Before(deadline) {
 		resp, err := http.Get(healthURL) //nolint:noctx
 		if err == nil && resp.StatusCode == http.StatusOK {

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -834,6 +834,13 @@ func setupAndStartServices(
 		return nil, fmt.Errorf("error starting channels: %w", err)
 	}
 
+	// Write port file so external callers (e.g. eval-runner) can discover the bound port.
+	portFile := filepath.Join(cfg.WorkspacePath(), "gateway.port")
+	portData := strconv.Itoa(cfg.Gateway.Port)
+	if err := os.WriteFile(portFile, []byte(portData+"\n"), 0600); err != nil {
+		return nil, fmt.Errorf("write gateway.port: %w", err)
+	}
+
 	fmt.Printf(
 		"✓ Health endpoints available at http://%s:%d/health, /ready and /reload (POST)\n",
 		cfg.Gateway.Host,


### PR DESCRIPTION
## Summary
- Write `gateway.port` file after gateway starts so eval-runner can discover the bound port
- Increase port file poll and /health poll timeouts from 30s → 60s

## Root Cause
The eval-runner polls for `$OMNIPUS_HOME/gateway.port` but the gateway never wrote it — every scenario timed out waiting for a file that never appeared.

## Test plan
- [x] Local build succeeds (`CGO_ENABLED=0 go build`)
- [x] Run evals against local gateway and confirm port file is created
- [ ] Merge and verify nightly run completes without 30s timeout errors

🤖 Generated with [Claude Code](https://claude.ai/claude-code)