### PR TITLE
ci(release-drafter): land config + workflow on main

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,117 @@
+# Release-drafter configuration.
+# Builds the next release's changelog from PR titles + labels.
+# https://github.com/release-drafter/release-drafter
+
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+
+# Map PR labels to changelog sections. PRs without a label land in "Other changes".
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'enhancement'
+      - 'type:performance'
+  - title: '🐛 Bug fixes'
+    labels:
+      - 'bug'
+  - title: '🔐 Security'
+    labels:
+      - 'security'
+  - title: '⚠️ Breaking changes'
+    labels:
+      - 'type:breaking-change'
+  - title: '📚 Documentation'
+    labels:
+      - 'documentation'
+      - 'area:docs'
+  - title: '🧹 Refactoring & tech debt'
+    labels:
+      - 'type:refactor'
+      - 'tech-debt'
+  - title: '🤖 Dependencies'
+    labels:
+      - 'dependencies'
+      - 'github_actions'
+  - title: '🧪 Testing'
+    labels:
+      - 'test-coverage'
+
+# Semver bump rules driven by labels.
+version-resolver:
+  major:
+    labels:
+      - 'type:breaking-change'
+  minor:
+    labels:
+      - 'enhancement'
+      - 'security'
+  patch:
+    labels:
+      - 'bug'
+      - 'documentation'
+      - 'dependencies'
+      - 'test-coverage'
+      - 'tech-debt'
+      - 'type:refactor'
+      - 'type:performance'
+  default: patch
+
+# Headers + footers around the auto-built body.
+template: |
+  ## What's changed in v$RESOLVED_VERSION
+
+  $CHANGES
+
+  ## Contributors
+
+  $CONTRIBUTORS
+
+  ---
+
+  **Full Changelog:** https://github.com/elicify-ai/omnipus/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
+
+change-template: '- $TITLE (#$NUMBER) by @$AUTHOR'
+change-title-escapes: '\<*_&'
+
+# Exclude PRs that just sync labels / chore / merge commits from the changelog.
+exclude-labels:
+  - 'duplicate'
+  - 'invalid'
+  - 'wontfix'
+  - 'status:in-review'
+
+# Auto-label uncategorised PRs as needs-triage.
+autolabeler:
+  - label: 'security'
+    branch:
+      - '/security\/.+/'
+    title:
+      - '/^security[:(]/i'
+      - '/security:/i'
+  - label: 'bug'
+    title:
+      - '/^fix[:(]/i'
+  - label: 'enhancement'
+    title:
+      - '/^feat[:(]/i'
+  - label: 'documentation'
+    title:
+      - '/^docs[:(]/i'
+  - label: 'dependencies'
+    title:
+      - '/^chore\(deps[):]/i'
+  - label: 'github_actions'
+    title:
+      - '/^ci[:(]/i'
+  - label: 'type:refactor'
+    title:
+      - '/^refactor[:(]/i'
+  - label: 'tech-debt'
+    title:
+      - '/^chore[:(]/i'
+  - label: 'type:performance'
+    title:
+      - '/^perf[:(]/i'
+  - label: 'test-coverage'
+    title:
+      - '/^test[:(]/i'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,27 @@
+name: Release drafter
+
+# Maintains a draft GitHub Release that aggregates merged PR titles since the
+# last published release, grouped by label (per .github/release-drafter.yml).
+# When you're ready to ship, edit and publish the draft.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, reopened, synchronize, edited]
+  workflow_dispatch:
+
+permissions:
+  contents: write       # required to write/update the release draft
+  pull-requests: write  # required for the autolabeler
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        with:
+          config-name: release-drafter.yml
+          disable-autolabeler: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Lands the release-drafter Action's config + workflow on `main` so the `update_release_draft` check stops failing on every PR.

## Why

Discovered while looking at PR #178's red `update_release_draft` check, which errors with:
> *"Configuration file `.github/release-drafter.yml` is not found. The configuration file must reside in your default branch."*

The release-drafter Action reads its config from the **default branch (main)** regardless of which branch triggered it. Both files (`release-drafter.yml` config + `workflows/release-drafter.yml` workflow) were originally added on `feature/iframe-preview-tier13` by commit 049593e (2026-05-22, "ci+docs(governance): bonus governance automation"), but PR #157 squash-merged before that commit, so they never reached main.

## What

Cherry-picks both files **verbatim** from 049593e:

- `.github/release-drafter.yml` — changelog categories (Features / Bug fixes / Security / Breaking / Docs / Refactor / Deps / Testing), version-resolver, autolabeler that maps conventional-commit prefixes (`feat:`, `fix:`, `docs:`, `perf:`, `refactor:`, `chore(deps):`, `ci:`, `security:`, `test:`) to the right label, and exclude rules for `duplicate` / `invalid` / `wontfix` / `status:in-review` PRs.
- `.github/workflows/release-drafter.yml` — `pull_request` (opened/reopened/synchronize/edited) + `push: main` + `workflow_dispatch` triggers, runs `release-drafter/release-drafter@v6` with `disable-autolabeler: false`.

No other files touched. Safe to merge on its own; doesn't interact with the v0.1 work in PR #178.

## Test plan

- [ ] CI green on this PR — `update_release_draft` should succeed once the config it needs is in the default branch (this PR's own pre-merge run may still fail because the config isn't on main yet; the post-merge run will pass).
- [ ] After merge, re-trigger PR #178 (any push or comment) and confirm its `update_release_draft` check goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)