### PR TITLE
chore(deps): bump tailwind-merge 2.6.0 → 3.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "remark-gfm": "^4.0.1",
         "remark-math": "^6.0.0",
         "shiki": "^4.0.2",
-        "tailwind-merge": "^2.6.0",
+        "tailwind-merge": "^3.6.0",
         "zustand": "^5.0.14"
       },
       "devDependencies": {
@@ -15186,9 +15186,9 @@
       "license": "MIT"
     },
     "node_modules/tailwind-merge": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.6.1.tgz",
-      "integrity": "sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
+      "integrity": "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==",
       "license": "MIT",
       "funding": {
         "type": "github",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "remark-gfm": "^4.0.1",
     "remark-math": "^6.0.0",
     "shiki": "^4.0.2",
-    "tailwind-merge": "^2.6.0",
+    "tailwind-merge": "^3.6.0",
     "zustand": "^5.0.14"
   },
   "devDependencies": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -37,7 +37,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "framer-motion": "^12.6.3",
-    "tailwind-merge": "^2.6.0",
+    "tailwind-merge": "^3.6.0",
     "zustand": "^5.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Closes #187.

Bumps `tailwind-merge` from 2.6.0 to 3.6.0 in both root and `packages/ui` package.json. v3 is a major version bump driven by Tailwind CSS v4 support — which this repo already uses via `@tailwindcss/vite`.

Visible breaking changes per the project changelog are scoped to advanced config options (`postfixLookupClassGroups`, internal class-group resolution) that this repo does not touch. The repo's surface is a single import in `src/lib/utils.ts`:

```ts
import { twMerge } from 'tailwind-merge'
export function cn(...inputs: ClassValue[]) {
  return twMerge(clsx(inputs))
}
```

`twMerge(input: string)` signature unchanged across v2 → v3.

## Local verification

```
npm run typecheck             → exits 0
npx vitest run                → 92 files / 1453 tests pass
npm run build (SPA)           → built clean
```

## Test plan

- [ ] CI green
- [ ] Smoke-test SPA — verify class merging still produces expected results on a few representative components

🤖 Generated with [Claude Code](https://claude.com/claude-code)