### PR TITLE
chore(deps): tighten mermaid range 11.13.0 → 11.15.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "framer-motion": "^12.6.3",
         "immer": "^11.1.8",
         "katex": "^0.16.44",
-        "mermaid": "^11.13.0",
+        "mermaid": "^11.15.0",
         "react-markdown": "^10.1.0",
         "react-shiki": "^0.9.2",
         "rehype-katex": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "framer-motion": "^12.6.3",
     "immer": "^11.1.8",
     "katex": "^0.16.44",
-    "mermaid": "^11.13.0",
+    "mermaid": "^11.15.0",
     "react-markdown": "^10.1.0",
     "react-shiki": "^0.9.2",
     "rehype-katex": "^7.0.1",


### PR DESCRIPTION
## Summary

Closes #173.

Aligns the `package.json` mermaid range with what the lockfile already resolves to (mermaid@11.15.0, uuid@14.0.0). Dependabot's #173 had already been materially applied via PR #193's `npm update`, but the package.json minimum-version spec was stale — this tightens the spec so dependabot stops re-flagging the same bump.

## What this is NOT

- Not a code change. `src/components/chat/mermaid-renderer.tsx` and `shiki-highlighter.tsx` already work against mermaid 11.15.0.
- Not a uuid bump in our direct deps — uuid is transitive via mermaid's `^11.1.0 || ^12 || ^13 || ^14.0.0` range, already covered.

## Local verification

```
npm run typecheck             → exits 0
npx vitest run                → 92 files / 1453 tests pass
npm run build (SPA)           → built clean
```

## Test plan

- [x] CI green
- [x] Smoke-test a mermaid diagram render in the SPA

🤖 Generated with [Claude Code](https://claude.com/claude-code)