### PR TITLE
chore(deps): bump typescript 5.8.3 → 6.0.3 + tsconfig migration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -75,7 +75,7 @@
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "tailwindcss": "^4.1.3",
-        "typescript": "^5.8.3",
+        "typescript": "^6.0.3",
         "vite": "^8.0.14",
         "vite-plugin-dts": "^5.0.1",
         "vitest": "^4.1.2",
@@ -15478,9 +15478,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@omnipus/ui",
   "version": "0.1.0",
   "type": "module",
-  "description": "Omnipus UI — The Sovereign Deep design system and app shell",
+  "description": "Omnipus UI \u2014 The Sovereign Deep design system and app shell",
   "main": "./dist/lib/index.cjs",
   "module": "./dist/lib/index.js",
   "types": "./dist/lib/index.d.ts",
@@ -99,7 +99,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "tailwindcss": "^4.1.3",
-    "typescript": "^5.8.3",
+    "typescript": "^6.0.3",
     "vite": "^8.0.14",
     "vite-plugin-dts": "^5.0.1",
     "vitest": "^4.1.2",
@@ -109,6 +109,11 @@
     "overrides": {
       "lodash": "^4.18.0",
       "dompurify": "^3.4.0"
+    }
+  },
+  "overrides": {
+    "openapi-typescript": {
+      "typescript": "$typescript"
     }
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -46,7 +46,7 @@
     "@types/react-dom": "^19.1.2",
     "@vitejs/plugin-react": "^4.4.1",
     "tailwindcss": "^4.1.3",
-    "typescript": "^5.8.3",
+    "typescript": "^6.0.3",
     "vite": "^6.3.2",
     "vite-plugin-dts": "^5.0.1"
   }

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -15,10 +15,10 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
-    }
+    },
+    "types": ["node", "vite/client"]
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary

Closes #189.

Bumps TypeScript from 5.8.3 to 6.0.3 in both root and `packages/ui` package.json. Two tsconfig adjustments needed to absorb TS 6's stricter checks.

## Migration

### 1. `baseUrl` removed from `tsconfig.app.json`

TS 6 emits `TS5101: Option 'baseUrl' is deprecated and will stop functioning in TypeScript 7.0`. Under `moduleResolution: "bundler"`, `paths` already resolves leading `./` relative to the tsconfig file, so `baseUrl: "."` was a no-op. Removed.

### 2. `"types": ["node", "vite/client"]` added to `tsconfig.app.json`

TS 6 stopped auto-resolving Node types via bundler-resolution fallback. Test files that use `require`, `global`, `__dirname`, `fs`, `path`, `process` started erroring with `TS2591: Cannot find name`. `@types/node` was already in devDependencies but not exposed — fix is to add it to the project's `types` array. `vite/client` covers `import.meta.env` typing.

## Local verification

```
npm run typecheck             → exits 0
npx vitest run                → 92 files / 1453 tests pass
npm run build (SPA)           → built clean
```

## Test plan

- [ ] CI green
- [ ] Confirm no runtime regressions in SPA build artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)