### PR TITLE
chore(deps): bump anthropic-sdk-go 1.45.0 → 1.46.0; close #174 (no-op)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.3
 require (
 	github.com/BurntSushi/toml v1.6.0
 	github.com/adhocore/gronx v1.19.6
-	github.com/anthropics/anthropic-sdk-go v1.45.0
+	github.com/anthropics/anthropic-sdk-go v1.46.0
 	github.com/aws/aws-sdk-go-v2 v1.41.6
 	github.com/aws/aws-sdk-go-v2/config v1.32.12
 	github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.50.4

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNg
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
 github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
-github.com/anthropics/anthropic-sdk-go v1.45.0 h1:rWnpyBpm9OAm97jyH5bi6W4SRCwJeNY/RyhaJ7CHSUI=
-github.com/anthropics/anthropic-sdk-go v1.45.0/go.mod h1:bx5vWuHFuGPkELH8Z4KUiNSohFnUwScdpTyr+50myPo=
+github.com/anthropics/anthropic-sdk-go v1.46.0 h1:yl3n+el5ZfNgiCtQ7zQ7s/NXxB11YbrKXdc3uLPNWlU=
+github.com/anthropics/anthropic-sdk-go v1.46.0/go.mod h1:bx5vWuHFuGPkELH8Z4KUiNSohFnUwScdpTyr+50myPo=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=
 github.com/aws/aws-sdk-go-v2 v1.41.6 h1:1AX0AthnBQzMx1vbmir3Y4WsnJgiydmnJjiLu+LvXOg=


### PR DESCRIPTION
## Summary

Closes #192, #174.

Rolls up the last two open dependabot PRs into one tidy-up commit.

### #192 — anthropic-sdk-go 1.45.0 → 1.46.0

Patch bump, used by:
- `pkg/providers/anthropic/provider.go`
- `pkg/providers/claude_provider_test.go`
- `pkg/providers/anthropic/provider_test.go`
- `pkg/providers/anthropic/thinking_test.go`

No API surface change visible to our wrappers.

### #174 — fast-uri 3.1.0 → 3.1.2

Already materially applied. `fast-uri` is transitive (ajv → `^3.0.1`), and the lockfile already resolves to 3.1.2. Closing #174 as a duplicate — no manifest change needed.

## Local verification

```
gofmt -l .                                                       → 0
CGO_ENABLED=0 go build -tags goolm,stdjson ./...                  → clean
CGO_ENABLED=0 go test -tags goolm,stdjson -count=1 ./pkg/providers/...  → all packages ok
govulncheck -tags goolm,stdjson ./pkg/providers/...                → No vulnerabilities found
```

## Test plan

- [ ] CI green
- [ ] Smoke-test Anthropic provider on a real request

🤖 Generated with [Claude Code](https://claude.com/claude-code)