### PR TITLE
fix(cli): single-line install works; add headless onboard flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,24 @@ Two ports open: **5000** for SPA + API, **5001** for sandboxed agent preview ifr
 
 A 256-bit AES key auto-generates at `~/.omnipus/master.key` (mode `0600`). **Back it up** — losing it means losing every encrypted credential. For headless deployments, pre-provision via `OMNIPUS_KEY_FILE` or `OMNIPUS_MASTER_KEY`. → [docs/credential_encryption.md](docs/credential_encryption.md)
 
+### Headless onboarding (no browser)
+
+If you can't open `localhost:5000` — Docker host, remote VPS, CI runner — finish onboarding from the shell instead. Secrets read from stdin so they never appear in `ps`:
+
+```bash
+printf '%s\n%s\n' "$OPENROUTER_API_KEY" "$ADMIN_PASSWORD" | \
+  omnipus onboard --non-interactive \
+    --provider openrouter \
+    --api-key-stdin \
+    --model 'z-ai/glm-5v-turbo' \
+    --admin-username admin \
+    --admin-password-stdin
+
+omnipus gateway
+```
+
+`omnipus onboard --help` lists every flag (`--provider`, `--api-key`, `--api-key-stdin`, `--model`, `--admin-username`, `--admin-password`, `--admin-password-stdin`, `--non-interactive`). Same end-state mutations as the SPA wizard — config, credentials, admin user, state — so you can log in immediately with the credentials you just passed.
+
 ---
 
 ## Documentation

--- a/cmd/omnipus/internal/gateway/command.go
+++ b/cmd/omnipus/internal/gateway/command.go
@@ -19,9 +19,14 @@ import (
 func NewGatewayCommand() *cobra.Command {
 	var debug bool
 	var noTruncate bool
-	var allowEmpty bool
 	var sandboxMode string
 	var allowGodMode bool
+	// allowEmptyDeprecated accepts the legacy --allow-empty flag silently so
+	// existing callers (CI workflows, ops scripts, eval-runner, etc.) keep
+	// working unchanged. The behaviour is now unconditional: the gateway
+	// boots into limited mode when no provider is configured regardless of
+	// the flag. Hidden from --help so new users don't discover it.
+	var allowEmptyDeprecated bool
 
 	cmd := &cobra.Command{
 		Use:     "gateway",
@@ -66,11 +71,17 @@ func NewGatewayCommand() *cobra.Command {
 						"remove --allow-god-mode and restart")
 				os.Exit(2)
 			}
+			// AllowEmptyStartup is unconditionally true: if no provider is
+			// configured the gateway boots into limited mode so the operator
+			// can finish onboarding via the SPA wizard (or `omnipus onboard`).
+			// The previous --allow-empty flag was a foot-gun: a fresh install
+			// failed to start with a misleading "no providers configured" error
+			// and the operator had to read the help text to discover the flag.
 			runErr := gateway.RunWithOptions(gateway.RunOptions{
 				Debug:             debug,
 				HomePath:          internal.GetOmnipusHome(),
 				ConfigPath:        internal.GetConfigPath(),
-				AllowEmptyStartup: allowEmpty,
+				AllowEmptyStartup: true,
 				SandboxMode:       sandboxMode,
 				AllowGodMode:      allowGodMode,
 			})
@@ -91,13 +102,12 @@ func NewGatewayCommand() *cobra.Command {
 
 	cmd.Flags().BoolVarP(&debug, "debug", "d", false, "Enable debug logging")
 	cmd.Flags().BoolVarP(&noTruncate, "no-truncate", "T", false, "Disable string truncation in debug logs")
-	cmd.Flags().BoolVarP(
-		&allowEmpty,
-		"allow-empty",
-		"E",
-		false,
-		"Continue starting even when no default model is configured",
-	)
+	// Legacy --allow-empty / -E: silently accepted, hidden from help. The
+	// gateway now always boots into limited mode when no provider is
+	// configured, which is what --allow-empty did. Existing scripts keep
+	// working unchanged. The variable is intentionally unread.
+	cmd.Flags().BoolVarP(&allowEmptyDeprecated, "allow-empty", "E", false, "Deprecated; gateway now always boots into limited mode on a fresh install")
+	_ = cmd.Flags().MarkHidden("allow-empty")
 	cmd.Flags().StringVar(
 		&sandboxMode,
 		"sandbox",

--- a/cmd/omnipus/internal/gateway/command.go
+++ b/cmd/omnipus/internal/gateway/command.go
@@ -23,7 +23,7 @@ func NewGatewayCommand() *cobra.Command {
 	var allowGodMode bool
 	// allowEmptyDeprecated accepts the legacy --allow-empty flag silently so
 	// existing callers (CI workflows, ops scripts, eval-runner, etc.) keep
-	// working unchanged. The behaviour is now unconditional: the gateway
+	// working unchanged. The behavior is now unconditional: the gateway
 	// boots into limited mode when no provider is configured regardless of
 	// the flag. Hidden from --help so new users don't discover it.
 	var allowEmptyDeprecated bool
@@ -106,7 +106,13 @@ func NewGatewayCommand() *cobra.Command {
 	// gateway now always boots into limited mode when no provider is
 	// configured, which is what --allow-empty did. Existing scripts keep
 	// working unchanged. The variable is intentionally unread.
-	cmd.Flags().BoolVarP(&allowEmptyDeprecated, "allow-empty", "E", false, "Deprecated; gateway now always boots into limited mode on a fresh install")
+	cmd.Flags().BoolVarP(
+		&allowEmptyDeprecated,
+		"allow-empty",
+		"E",
+		false,
+		"Deprecated; gateway always boots into limited mode on a fresh install",
+	)
 	_ = cmd.Flags().MarkHidden("allow-empty")
 	cmd.Flags().StringVar(
 		&sandboxMode,

--- a/cmd/omnipus/internal/gateway/command_test.go
+++ b/cmd/omnipus/internal/gateway/command_test.go
@@ -28,5 +28,11 @@ func TestNewGatewayCommand(t *testing.T) {
 
 	assert.True(t, cmd.HasFlags())
 	assert.NotNil(t, cmd.Flags().Lookup("debug"))
-	assert.NotNil(t, cmd.Flags().Lookup("allow-empty"))
+	// --allow-empty is preserved as a hidden, deprecated no-op so existing
+	// scripts (CI workflows, ops runbooks, eval-runner, docs.troubleshooting)
+	// keep working unchanged. The gateway now ALWAYS boots into limited mode
+	// when no provider is configured, regardless of the flag value.
+	allowEmpty := cmd.Flags().Lookup("allow-empty")
+	assert.NotNil(t, allowEmpty)
+	assert.True(t, allowEmpty.Hidden, "--allow-empty must be hidden from --help")
 }

--- a/cmd/omnipus/internal/onboard/onboard.go
+++ b/cmd/omnipus/internal/onboard/onboard.go
@@ -89,21 +89,62 @@ func defaultModelFor(providerID string) string {
 
 // NewOnboardCommand returns the `omnipus onboard` Cobra command.
 func NewOnboardCommand() *cobra.Command {
-	var homeFlag string
+	var (
+		homeFlag           string
+		providerFlag       string
+		apiKeyFlag         string
+		apiKeyStdin        bool
+		modelFlag          string
+		adminUsernameFlag  string
+		adminPasswordFlag  string
+		adminPasswordStdin bool
+		nonInteractive     bool
+	)
 	cmd := &cobra.Command{
 		Use:   "onboard",
-		Short: "Interactive first-run setup (provider, API key, admin user)",
-		Long: `Interactively configure a fresh Omnipus install.
+		Short: "First-run setup (provider, API key, admin user) — interactive or headless",
+		Long: `Configure a fresh Omnipus install.
 
-Prompts for an LLM provider, API key, default model, and admin
-username/password. The API key is encrypted into credentials.json
-(creating master.key on first run); the admin user and provider entry
-are written to config.json; system/state.json is marked complete.
+Two modes:
+
+  Interactive (default)
+    Prompts for an LLM provider, API key, default model, and admin
+    username/password.
+
+  Headless
+    Pass --non-interactive together with all of --provider, --api-key
+    (or --api-key-stdin), --admin-username, and --admin-password (or
+    --admin-password-stdin). --model is optional and defaults to a
+    sensible per-provider model.
+
+In both modes the API key is encrypted into credentials.json (creating
+master.key on first run); the admin user and provider entry are written
+to config.json; system/state.json is marked complete.
 
 After running this command, ` + "`omnipus gateway`" + ` can boot without
 ` + "`dev_mode_bypass`" + ` and the operator can log in with the credentials
 they just entered. The web onboarding wizard remains available for users
-who prefer a browser.`,
+who prefer a browser.
+
+Examples:
+
+  # interactive
+  omnipus onboard
+
+  # headless (key + password on command line — visible to other users on the box)
+  omnipus onboard --non-interactive \
+    --provider openrouter \
+    --api-key sk-or-v1-... \
+    --model 'z-ai/glm-5v-turbo' \
+    --admin-username admin \
+    --admin-password 'p@ssw0rd!'
+
+  # headless (key + password from stdin — safer)
+  printf 'sk-or-v1-...\np@ssw0rd!\n' | omnipus onboard --non-interactive \
+    --provider openrouter \
+    --api-key-stdin \
+    --admin-username admin \
+    --admin-password-stdin`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			home := homeFlag
 			if home == "" {
@@ -116,10 +157,53 @@ who prefer a browser.`,
 				}
 				home = filepath.Join(h, ".omnipus")
 			}
+			if nonInteractive {
+				in, err := inputFromFlags(cmd.InOrStdin(), inputFlags{
+					providerID:         providerFlag,
+					apiKey:             apiKeyFlag,
+					apiKeyStdin:        apiKeyStdin,
+					model:              modelFlag,
+					username:           adminUsernameFlag,
+					password:           adminPasswordFlag,
+					adminPasswordStdin: adminPasswordStdin,
+				})
+				if err != nil {
+					return err
+				}
+				return RunHeadless(home, defaultIO(cmd), in)
+			}
 			return Run(home, defaultIO(cmd))
 		},
 	}
 	cmd.Flags().StringVar(&homeFlag, "home", "", "Omnipus home directory (default: $OMNIPUS_HOME or ~/.omnipus)")
+	cmd.Flags().BoolVar(&nonInteractive, "non-interactive", false, "Skip all prompts; require the answers via flags")
+	cmd.Flags().StringVar(&providerFlag, "provider", "", "Provider id (e.g. openrouter, anthropic, openai, gemini)")
+	cmd.Flags().StringVar(
+		&apiKeyFlag,
+		"api-key",
+		"",
+		"Provider API key (visible to other users via /proc — prefer --api-key-stdin)",
+	)
+	cmd.Flags().BoolVar(&apiKeyStdin, "api-key-stdin", false, "Read the provider API key from the first line of stdin")
+	cmd.Flags().StringVar(
+		&modelFlag,
+		"model",
+		"",
+		"Default model id (e.g. z-ai/glm-5v-turbo); falls back to a per-provider default",
+	)
+	cmd.Flags().StringVar(&adminUsernameFlag, "admin-username", "", "Admin username to create")
+	cmd.Flags().StringVar(
+		&adminPasswordFlag,
+		"admin-password",
+		"",
+		"Admin password (min 8 chars; prefer --admin-password-stdin)",
+	)
+	cmd.Flags().BoolVar(
+		&adminPasswordStdin,
+		"admin-password-stdin",
+		false,
+		"Read the admin password from stdin (next line after the api key if --api-key-stdin is also set)",
+	)
 	return cmd
 }
 
@@ -136,6 +220,116 @@ func defaultIO(cmd *cobra.Command) wizardIO {
 			return string(b), nil
 		},
 	}
+}
+
+// inputFlags is the raw flag bundle the Cobra binding hands to
+// inputFromFlags. Kept as a struct rather than a parameter list so the
+// signature stays stable as we add knobs.
+type inputFlags struct {
+	providerID         string
+	apiKey             string
+	apiKeyStdin        bool
+	model              string
+	username           string
+	password           string
+	adminPasswordStdin bool
+}
+
+// inputFromFlags assembles an Input from --non-interactive flags, validating
+// each field with the same rules the interactive prompt applies. Secret
+// values are read from stdin when --api-key-stdin or --admin-password-stdin
+// is set; the api key (if requested) is read first, then the admin password,
+// each as a single line.
+func inputFromFlags(stdin io.Reader, f inputFlags) (Input, error) {
+	in := Input{}
+
+	if f.providerID == "" {
+		return in, errors.New("--provider is required in --non-interactive mode")
+	}
+	if !providers.IsKnownProtocol(f.providerID) {
+		return in, fmt.Errorf("provider %q is not a known protocol", f.providerID)
+	}
+	in.ProviderID = f.providerID
+
+	if f.apiKey != "" && f.apiKeyStdin {
+		return in, errors.New("set exactly one of --api-key or --api-key-stdin, not both")
+	}
+	if f.password != "" && f.adminPasswordStdin {
+		return in, errors.New("set exactly one of --admin-password or --admin-password-stdin, not both")
+	}
+
+	apiKey := f.apiKey
+	password := f.password
+	if f.apiKeyStdin || f.adminPasswordStdin {
+		reader := bufio.NewReader(stdin)
+		if f.apiKeyStdin {
+			line, err := reader.ReadString('\n')
+			if err != nil && !errors.Is(err, io.EOF) {
+				return in, fmt.Errorf("read api key from stdin: %w", err)
+			}
+			apiKey = strings.TrimRight(line, "\r\n")
+		}
+		if f.adminPasswordStdin {
+			line, err := reader.ReadString('\n')
+			if err != nil && !errors.Is(err, io.EOF) {
+				return in, fmt.Errorf("read admin password from stdin: %w", err)
+			}
+			password = strings.TrimRight(line, "\r\n")
+		}
+	}
+
+	if strings.TrimSpace(apiKey) == "" {
+		return in, errors.New("--api-key (or --api-key-stdin) is required in --non-interactive mode")
+	}
+	in.APIKey = strings.TrimSpace(apiKey)
+
+	if f.username == "" {
+		return in, errors.New("--admin-username is required in --non-interactive mode")
+	}
+	in.Username = strings.TrimSpace(f.username)
+
+	if password == "" {
+		return in, errors.New("--admin-password (or --admin-password-stdin) is required in --non-interactive mode")
+	}
+	if len(password) < 8 {
+		return in, errors.New("admin password must be at least 8 characters")
+	}
+	in.Password = password
+
+	in.Model = strings.TrimSpace(f.model)
+	if in.Model == "" {
+		in.Model = defaultModelFor(in.ProviderID)
+	}
+
+	return in, nil
+}
+
+// RunHeadless writes the headless onboarding state from a pre-validated Input.
+// It is the non-interactive counterpart of Run.
+func RunHeadless(home string, io wizardIO, in Input) error {
+	if err := datamodel.Init(home); err != nil {
+		return fmt.Errorf("init home: %w", err)
+	}
+	mgr := onboarding.NewManager(home)
+	if mgr.IsComplete() {
+		fmt.Fprintln(io.stdout, "Onboarding is already complete; nothing to do.")
+		fmt.Fprintln(io.stdout,
+			"To re-run, delete ~/.omnipus/system/state.json"+
+				" (or the equivalent under your OMNIPUS_HOME).",
+		)
+		return nil
+	}
+
+	in.Home = home
+	if err := applyInput(in, io); err != nil {
+		return err
+	}
+
+	fmt.Fprintln(io.stdout, "")
+	fmt.Fprintln(io.stdout, "Onboarding complete.")
+	fmt.Fprintf(io.stdout, "Run `omnipus gateway` to start serving on the configured port.\n")
+	fmt.Fprintf(io.stdout, "Log in as %q with the password you just entered.\n", in.Username)
+	return nil
 }
 
 // Run executes the wizard against the supplied IO and home directory. It is

--- a/cmd/omnipus/internal/onboard/onboard_test.go
+++ b/cmd/omnipus/internal/onboard/onboard_test.go
@@ -250,3 +250,251 @@ func TestPrompt_UnknownProvider_Rejected(t *testing.T) {
 		t.Errorf("expected 'known protocol' error, got: %v", err)
 	}
 }
+
+// ── Headless (--non-interactive) ─────────────────────────────────────────────
+
+// TestInputFromFlags_HappyPath checks that a fully-specified flag set
+// produces a usable Input without touching stdin.
+func TestInputFromFlags_HappyPath(t *testing.T) {
+	in, err := inputFromFlags(strings.NewReader(""), inputFlags{
+		providerID: "openrouter",
+		apiKey:     "sk-or-v1-test",
+		model:      "z-ai/glm-5v-turbo",
+		username:   "admin",
+		password:   "correcthorsebattery",
+	})
+	if err != nil {
+		t.Fatalf("inputFromFlags: %v", err)
+	}
+	if in.ProviderID != "openrouter" || in.APIKey != "sk-or-v1-test" ||
+		in.Model != "z-ai/glm-5v-turbo" || in.Username != "admin" ||
+		in.Password != "correcthorsebattery" {
+		t.Errorf("unexpected Input: %+v", in)
+	}
+}
+
+// TestInputFromFlags_StdinSecrets confirms that --api-key-stdin and
+// --admin-password-stdin read one line each, in that order, and trim CR/LF.
+func TestInputFromFlags_StdinSecrets(t *testing.T) {
+	stdin := strings.NewReader("sk-secret\r\np@ssw0rd-from-stdin\n")
+	in, err := inputFromFlags(stdin, inputFlags{
+		providerID:         "openrouter",
+		apiKeyStdin:        true,
+		username:           "admin",
+		adminPasswordStdin: true,
+	})
+	if err != nil {
+		t.Fatalf("inputFromFlags: %v", err)
+	}
+	if in.APIKey != "sk-secret" {
+		t.Errorf("API key not trimmed correctly, got %q", in.APIKey)
+	}
+	if in.Password != "p@ssw0rd-from-stdin" {
+		t.Errorf("password not trimmed correctly, got %q", in.Password)
+	}
+}
+
+// TestInputFromFlags_ModelDefault confirms that omitting --model picks the
+// per-provider default rather than failing.
+func TestInputFromFlags_ModelDefault(t *testing.T) {
+	in, err := inputFromFlags(strings.NewReader(""), inputFlags{
+		providerID: "anthropic",
+		apiKey:     "sk-ant-test",
+		username:   "admin",
+		password:   "longenoughpw",
+	})
+	if err != nil {
+		t.Fatalf("inputFromFlags: %v", err)
+	}
+	if in.Model != "claude-sonnet-4-6" {
+		t.Errorf("expected per-provider default model, got %q", in.Model)
+	}
+}
+
+func TestInputFromFlags_Validation(t *testing.T) {
+	cases := []struct {
+		name string
+		f    inputFlags
+		want string // substring of error message
+	}{
+		{
+			name: "missing provider",
+			f:    inputFlags{apiKey: "k", username: "u", password: "longenoughpw"},
+			want: "--provider is required",
+		},
+		{
+			name: "unknown provider",
+			f:    inputFlags{providerID: "not-real", apiKey: "k", username: "u", password: "longenoughpw"},
+			want: "known protocol",
+		},
+		{
+			name: "api-key + api-key-stdin both set",
+			f: inputFlags{
+				providerID:  "openai",
+				apiKey:      "k",
+				apiKeyStdin: true,
+				username:    "u",
+				password:    "longenoughpw",
+			},
+			want: "exactly one of --api-key or --api-key-stdin",
+		},
+		{
+			name: "admin-password + admin-password-stdin both set",
+			f: inputFlags{
+				providerID:         "openai",
+				apiKey:             "k",
+				username:           "u",
+				password:           "longenoughpw",
+				adminPasswordStdin: true,
+			},
+			want: "exactly one of --admin-password or --admin-password-stdin",
+		},
+		{
+			name: "missing api key",
+			f:    inputFlags{providerID: "openai", username: "u", password: "longenoughpw"},
+			want: "--api-key (or --api-key-stdin) is required",
+		},
+		{
+			name: "missing username",
+			f:    inputFlags{providerID: "openai", apiKey: "k", password: "longenoughpw"},
+			want: "--admin-username is required",
+		},
+		{
+			name: "missing password",
+			f:    inputFlags{providerID: "openai", apiKey: "k", username: "u"},
+			want: "--admin-password (or --admin-password-stdin) is required",
+		},
+		{
+			name: "short password",
+			f:    inputFlags{providerID: "openai", apiKey: "k", username: "u", password: "short"},
+			want: "at least 8 characters",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := inputFromFlags(strings.NewReader(""), tc.f)
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.want)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("expected error containing %q, got: %v", tc.want, err)
+			}
+		})
+	}
+}
+
+// TestRunHeadless_EndToEnd drives the non-interactive Run path against a
+// fresh OMNIPUS_HOME and asserts the same on-disk shape as the interactive
+// regression test in TestRun_FreshInstall_WritesUsableConfig.
+func TestRunHeadless_EndToEnd(t *testing.T) {
+	home := t.TempDir()
+
+	var stdout, stderr bytes.Buffer
+	io := wizardIO{
+		stdin:  strings.NewReader(""),
+		stdout: &stdout,
+		stderr: &stderr,
+		readPassword: func() (string, error) {
+			t.Fatal("readPassword called but headless path must not prompt")
+			return "", nil
+		},
+	}
+
+	in := Input{
+		ProviderID: "openrouter",
+		APIKey:     "sk-or-v1-headless-test",
+		Model:      "z-ai/glm-5v-turbo",
+		Username:   "alice",
+		Password:   "correcthorsebatterystaple",
+	}
+	if err := RunHeadless(home, io, in); err != nil {
+		t.Fatalf("RunHeadless: %v", err)
+	}
+
+	// State.json is committed.
+	mgr := onboarding.NewManager(home)
+	if !mgr.IsComplete() {
+		t.Errorf("state.json onboarding_complete is false after headless run")
+	}
+
+	// Credentials store has the API key.
+	credPath := filepath.Join(home, "credentials.json")
+	if _, err := os.Stat(credPath); err != nil {
+		t.Fatalf("credentials.json missing: %v", err)
+	}
+	store := credentials.NewStore(credPath)
+	if err := credentials.Unlock(store); err != nil {
+		t.Fatalf("unlock store: %v", err)
+	}
+	got, err := store.Get("openrouter_api_key")
+	if err != nil {
+		t.Fatalf("get api key: %v", err)
+	}
+	if got != "sk-or-v1-headless-test" {
+		t.Errorf("api key roundtrip mismatch, got %q", got)
+	}
+
+	// Config.json has provider + admin entries; password bcrypt-validates.
+	rawCfg, err := os.ReadFile(filepath.Join(home, "config.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(rawCfg, &cfg); err != nil {
+		t.Fatal(err)
+	}
+	gw, _ := cfg["gateway"].(map[string]any)
+	users, _ := gw["users"].([]any)
+	if len(users) == 0 {
+		t.Fatalf("config.gateway.users empty: %s", rawCfg)
+	}
+	user, _ := users[0].(map[string]any)
+	hash, _ := user["password_hash"].(string)
+	if hash == "" {
+		t.Fatalf("password_hash empty")
+	}
+	if err := bcrypt.CompareHashAndPassword([]byte(hash), []byte(in.Password)); err != nil {
+		t.Errorf("password_hash does not bcrypt-validate against the headless password: %v", err)
+	}
+
+	out := stdout.String()
+	if !strings.Contains(out, "Onboarding complete.") {
+		t.Errorf("stdout missing completion line, got: %s", out)
+	}
+	_ = stderr // silence unused
+}
+
+// TestRunHeadless_AlreadyComplete confirms the headless path mirrors the
+// interactive no-op behavior — never overwriting an existing install.
+func TestRunHeadless_AlreadyComplete(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, "system"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := onboarding.NewManager(home).CompleteOnboarding(); err != nil {
+		t.Fatal(err)
+	}
+	var stdout bytes.Buffer
+	io := wizardIO{
+		stdin:  strings.NewReader(""),
+		stdout: &stdout,
+		stderr: io.Discard,
+		readPassword: func() (string, error) {
+			t.Fatal("readPassword called but RunHeadless must short-circuit")
+			return "", nil
+		},
+	}
+	in := Input{
+		ProviderID: "openrouter",
+		APIKey:     "irrelevant",
+		Model:      "z-ai/glm-5v-turbo",
+		Username:   "alice",
+		Password:   "longenoughpw",
+	}
+	if err := RunHeadless(home, io, in); err != nil {
+		t.Fatalf("RunHeadless on completed install must be a no-op, got: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "already complete") {
+		t.Errorf("expected 'already complete' in stdout, got: %s", stdout.String())
+	}
+}


### PR DESCRIPTION
## Summary

Closes the README's broken "single-line install" promise and gives ops a real headless path.

### 1. Gateway: drop the `--allow-empty` foot-gun

The README told users to run `omnipus gateway` after install. On a fresh box that exited with `Error: error creating provider: no providers configured` because the boot path called `providers.CreateProvider` against an empty config. `--allow-empty` toggled the right behaviour but was undiscoverable.

Now the gateway **always** boots into limited mode when no provider is configured. The SPA shows the onboarding wizard, the user completes setup, and the next boot is fully wired. Result: `omnipus gateway` (no flags) Just Works on a fresh install — single-line install is honest again.

`--allow-empty` / `-E` is kept as a hidden deprecated no-op so every existing caller keeps working unchanged (CI workflows, docs.troubleshooting, eval-runner, CLAUDE.md, …). Marked hidden via Cobra's `MarkHidden` so new users never see it.

### 2. `omnipus onboard`: add `--non-interactive` + headless flags

Headless install is now a one-liner:

```bash
printf '%s\n%s\n' "$OPENROUTER_API_KEY" "$ADMIN_PASS" | \
  omnipus onboard --non-interactive \
    --provider openrouter \
    --api-key-stdin \
    --model 'z-ai/glm-5v-turbo' \
    --admin-username admin \
    --admin-password-stdin
omnipus gateway
```

Stdin secrets read one line each, api key first then admin password. Both trim trailing CR/LF. Same validation + side effects as the interactive wizard (provider must be a known protocol, password ≥ 8 chars, credentials.json + master.key + config.json + state.json updated).

## Test plan

- [x] `CGO_ENABLED=0 go test -tags goolm,stdjson -count=1 ./cmd/omnipus/internal/onboard/... ./cmd/omnipus/internal/gateway/... ./pkg/gateway/...` — all pass (new: TestInputFromFlags_* ×4, TestRunHeadless_EndToEnd, TestRunHeadless_AlreadyComplete)
- [x] `golangci-lint run --build-tags=goolm,stdjson cmd/omnipus/internal/onboard/... cmd/omnipus/internal/gateway/...` — 0 issues
- [x] End-to-end on a real OpenRouter key: headless onboard → `omnipus gateway` (no flag) → SPA login → "PONG" reply from Mia. Screenshots saved.
- [x] Legacy `--allow-empty` still accepted (CI workflows + docs.troubleshooting still work).
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)