### PR TITLE
fix(cli): rename `gateway` → `start` as the canonical verb

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Three supported paths. Pick the one that matches your host, then jump to [First 
 
 ```bash
 curl -sSL https://raw.githubusercontent.com/elicify-ai/omnipus/main/scripts/install.sh | sh
-omnipus gateway
+omnipus start
 # open http://localhost:5000
 ```
 
@@ -148,7 +148,7 @@ Heavy image is not currently published to GHCR — build it yourself per the sni
 git clone https://github.com/elicify-ai/omnipus.git
 cd omnipus
 make build        # builds SPA + Go binary in one step
-./build/omnipus gateway
+./build/omnipus start
 ```
 
 Requires Go 1.26+ and Node 24+. `make build` runs `spa-embed` first so `go:embed` picks up the latest Vite output.
@@ -172,7 +172,7 @@ printf '%s\n%s\n' "$OPENROUTER_API_KEY" "$ADMIN_PASSWORD" | \
     --admin-username admin \
     --admin-password-stdin
 
-omnipus gateway
+omnipus start
 ```
 
 `omnipus onboard --help` lists every flag (`--provider`, `--api-key`, `--api-key-stdin`, `--model`, `--admin-username`, `--admin-password`, `--admin-password-stdin`, `--non-interactive`). Same end-state mutations as the SPA wizard — config, credentials, admin user, state — so you can log in immediately with the credentials you just passed.

--- a/cmd/omnipus/internal/gateway/command.go
+++ b/cmd/omnipus/internal/gateway/command.go
@@ -29,10 +29,19 @@ func NewGatewayCommand() *cobra.Command {
 	var allowEmptyDeprecated bool
 
 	cmd := &cobra.Command{
-		Use:     "gateway",
-		Aliases: []string{"g"},
-		Short:   "Start omnipus gateway",
-		Long: "Start omnipus gateway.\n\n" +
+		Use: "start",
+		// Aliases: "gateway" is preserved because every existing script,
+		// workflow, doc, and runbook references it (CLAUDE.md, evals/,
+		// tests/e2e/README.md, .github/workflows/*.yml, eval-runner, etc.).
+		// "g" is the original short alias. Both are accepted unchanged so the
+		// rename is zero-break, but only "start" is shown in --help.
+		Aliases: []string{"gateway", "g"},
+		Short:   "Start Omnipus (serves the SPA + API on port 5000)",
+		Long: "Start Omnipus.\n\n" +
+			"Opens two ports — 5000 for the SPA + REST + WebSocket API, 5001 for\n" +
+			"sandboxed agent preview iframes. On a fresh install the SPA at\n" +
+			"http://localhost:5000 runs the onboarding wizard; afterwards `start`\n" +
+			"boots straight into the chat UI with the configured provider.\n\n" +
 			"Exit codes:\n" +
 			"  0   clean shutdown\n" +
 			"  1   generic boot failure (credential/config/provider error)\n" +

--- a/cmd/omnipus/internal/gateway/command_test.go
+++ b/cmd/omnipus/internal/gateway/command_test.go
@@ -12,11 +12,16 @@ func TestNewGatewayCommand(t *testing.T) {
 
 	require.NotNil(t, cmd)
 
-	assert.Equal(t, "gateway", cmd.Use)
-	assert.Equal(t, "Start omnipus gateway", cmd.Short)
+	// Renamed `gateway` → `start` (2026-05-30) so the canonical command
+	// reflects what a new user wants to do: type `omnipus start`. The legacy
+	// names are preserved as aliases so every existing script, CI workflow,
+	// doc, and runbook keeps working.
+	assert.Equal(t, "start", cmd.Use)
+	assert.Contains(t, cmd.Short, "Start Omnipus")
 
-	assert.Len(t, cmd.Aliases, 1)
-	assert.True(t, cmd.HasAlias("g"))
+	assert.Len(t, cmd.Aliases, 2)
+	assert.True(t, cmd.HasAlias("gateway"), "legacy 'gateway' alias must be accepted")
+	assert.True(t, cmd.HasAlias("g"), "legacy 'g' short alias must be accepted")
 
 	assert.Nil(t, cmd.Run)
 	assert.NotNil(t, cmd.RunE)

--- a/cmd/omnipus/internal/onboard/onboard.go
+++ b/cmd/omnipus/internal/onboard/onboard.go
@@ -20,7 +20,7 @@
 //  4. writes a provider entry and an admin user entry into config.json;
 //  5. marks onboarding complete in system/state.json.
 //
-// On the next start `omnipus gateway` boots without requiring dev_mode_bypass
+// After this runs, `omnipus start` boots without requiring dev_mode_bypass
 // or env-injected secrets — the admin can log in immediately with the
 // username/password they entered.
 package onboard
@@ -121,7 +121,7 @@ In both modes the API key is encrypted into credentials.json (creating
 master.key on first run); the admin user and provider entry are written
 to config.json; system/state.json is marked complete.
 
-After running this command, ` + "`omnipus gateway`" + ` can boot without
+After running this command, ` + "`omnipus start`" + ` can boot without
 ` + "`dev_mode_bypass`" + ` and the operator can log in with the credentials
 they just entered. The web onboarding wizard remains available for users
 who prefer a browser.
@@ -327,7 +327,7 @@ func RunHeadless(home string, io wizardIO, in Input) error {
 
 	fmt.Fprintln(io.stdout, "")
 	fmt.Fprintln(io.stdout, "Onboarding complete.")
-	fmt.Fprintf(io.stdout, "Run `omnipus gateway` to start serving on the configured port.\n")
+	fmt.Fprintf(io.stdout, "Run `omnipus start` to serve the SPA + API on the configured port.\n")
 	fmt.Fprintf(io.stdout, "Log in as %q with the password you just entered.\n", in.Username)
 	return nil
 }
@@ -361,7 +361,7 @@ func Run(home string, io wizardIO) error {
 
 	fmt.Fprintln(io.stdout, "")
 	fmt.Fprintln(io.stdout, "Onboarding complete.")
-	fmt.Fprintf(io.stdout, "Run `omnipus gateway` to start serving on the configured port.\n")
+	fmt.Fprintf(io.stdout, "Run `omnipus start` to serve the SPA + API on the configured port.\n")
 	fmt.Fprintf(io.stdout, "Log in as %q with the password you just entered.\n", in.Username)
 	return nil
 }

--- a/cmd/omnipus/main_test.go
+++ b/cmd/omnipus/main_test.go
@@ -40,7 +40,10 @@ func TestNewOmnipusCommand(t *testing.T) {
 		"credentials",
 		"cron",
 		"doctor",
-		"gateway",
+		// "gateway" was renamed to "start" (2026-05-30). The legacy name
+		// remains accepted via Cobra aliases; only the canonical Use is
+		// enumerated by cmd.Commands().
+		"start",
 		"migrate",
 		"model",
 		"onboard",


### PR DESCRIPTION
## Summary

`omnipus gateway` was the third line of the README's one-liner install, but `gateway` is architectural jargon — the command starts an HTTP server, just like `hugo serve` / `mkdocs serve` / `ollama serve` / `caddy run`. As the default verb a new user types right after install, it should describe the action, not the role.

This PR renames `gateway` → `start` and keeps `gateway` (plus the original `g` short alias) as accepted aliases so nothing breaks.

## Changes

- `Use: "gateway"` → `Use: "start"` (`cmd/omnipus/internal/gateway/command.go`)
- Short blurb: `"Start omnipus gateway"` → `"Start Omnipus (serves the SPA + API on port 5000)"` — the top-level subcommand list now says what the command actually does
- `Aliases: ["g"]` → `Aliases: ["gateway", "g"]`. `omnipus gateway` keeps working everywhere; aliases surface only on `omnipus start --help`, not on the top-level `omnipus --help`
- README updated (3 install snippets)
- Onboard "next step" hints updated to print `omnipus start`
- `TestNewGatewayCommand` asserts the rename + both legacy aliases

## What is NOT touched (deliberately)

CLAUDE.md, evals/README.md, tests/e2e/README.md, `.github/workflows/*`, `docs/troubleshooting.md`, `docs/operations/platform-support.md`, `docs/docker.md`, `evals/cmd/eval-runner/main.go` all reference `omnipus gateway` and continue working via the alias. Updating them is pure churn since the runtime behavior is identical — happy to do a follow-up consistency sweep if you'd like, just say.

## Local verification

```
gofmt -l .                                                       → 0
golangci-lint run --build-tags=goolm,stdjson \
  cmd/omnipus/internal/onboard/... cmd/omnipus/internal/gateway/...   → 0 issues
go test -tags goolm,stdjson -count=1 \
  ./cmd/omnipus/internal/onboard/... ./cmd/omnipus/internal/gateway/... → ok
```

Live end-to-end on a freshly-installed binary:

1. `omnipus --help` shows `start` (not `gateway`) in the subcommand list.
2. `omnipus start` boots; SPA wizard appears at http://localhost:5000.
3. Playwright drives Welcome → OpenRouter → API key → glm-5v-turbo → admin → "Start Exploring" → chat → Mia replies "PONG! 🏓".
4. `omnipus gateway` (legacy) still routes to the same command and would have produced an identical boot.

## Test plan

- [ ] CI green
- [ ] Smoke-test `omnipus start` on a fresh container after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)