### PR TITLE
fix(build): drop NetBSD targets from build-all (broken since merge, unsupported)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -219,8 +219,18 @@ build-all: spa-embed generate
 	GOOS=linux GOARCH=arm GOARM=7 $(GO) build $(GOFLAGS) -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME)-linux-armv7 ./$(CMD_DIR)
 	GOOS=darwin GOARCH=arm64 $(GO) build $(GOFLAGS) -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME)-darwin-arm64 ./$(CMD_DIR)
 	GOOS=windows GOARCH=amd64 $(GO) build $(GOFLAGS) -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME)-windows-amd64.exe ./$(CMD_DIR)
-	GOOS=netbsd GOARCH=amd64 $(GO) build $(GOFLAGS) -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME)-netbsd-amd64 ./$(CMD_DIR)
-	GOOS=netbsd GOARCH=arm64 $(GO) build $(GOFLAGS) -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME)-netbsd-arm64 ./$(CMD_DIR)
+	# NetBSD targets removed 2026-05-30. They have never built in this repo:
+	#   (a) pkg/sandbox/hardened_exec.go references applyPlatformHardening,
+	#       applyPostStartHardening, memoryLimitSupported — defined only in
+	#       _linux.go / _darwin.go / _windows.go. A _netbsd.go shim would
+	#       need to land before NetBSD compiles cleanly.
+	#   (b) modernc.org/sqlite (vendored transitively via whatsmeow) ships a
+	#       sqlite_netbsd_amd64.go with its own type errors upstream.
+	# docs/operations/platform-support.md lists only Linux x86_64, Linux
+	# aarch64, and macOS arm64 as supported, so the NetBSD lines were aspirational
+	# rather than load-bearing — the `build` workflow on main has been red on
+	# every push since 2026-04-26 purely because of these two lines.
+	# Re-add once both upstream issues are resolved.
 	@echo "All builds complete"
 
 ## release-snapshot: Run goreleaser locally without publishing (produces dist/ artifacts).


### PR DESCRIPTION
## Summary

The `build` workflow on `main` has been failing on every push since **2026-04-26** — last GREEN run was 2026-04-25. Cause: two `make build-all` targets fail at compile time.

```
GOOS=netbsd GOARCH=amd64 → undefined: applyPlatformHardening
                            undefined: applyPostStartHardening
                            undefined: memoryLimitSupported
                            + modernc.org/sqlite internal errors
GOOS=netbsd GOARCH=arm64 → same failures
```

The sandbox-symbol set is defined per-OS in `pkg/sandbox/hardened_exec_{linux,darwin,windows}.go` — there has never been a `_netbsd.go` shim. The sqlite errors are upstream in `modernc.org/sqlite@1.46.1/lib/sqlite_netbsd_amd64.go`. The NetBSD lines were inherited from the PicoClaw squash-merge and have never built in this repo.

`docs/operations/platform-support.md` lists only Linux x86_64, Linux aarch64, and macOS arm64 as supported — NetBSD was aspirational, not load-bearing.

## Change

Drop both NetBSD lines from `build-all`. Header comment explains the two gates (sandbox shim + sqlite upstream fix) that must clear before they can be re-added.

## Local verification

After the change, every remaining target builds clean:

```
$ make build-all
All builds complete
$ ls build/omnipus-* | wc -l
9
```

The 9 produced binaries:

```
omnipus-darwin-arm64
omnipus-linux-amd64
omnipus-linux-arm
omnipus-linux-armv7
omnipus-linux-arm64
omnipus-linux-loong64
omnipus-linux-mipsle
omnipus-linux-riscv64
omnipus-windows-amd64.exe
```

Matches `platform-support.md` (documented support) plus the Linux extras we already ship.

## Test plan

- [ ] CI `build` workflow goes GREEN on this PR
- [ ] After merge, the `build` workflow on `main` goes GREEN for the first time in over a month

🤖 Generated with [Claude Code](https://claude.com/claude-code)