### PR TITLE
ci(build): run on pull_request so cross-compile breakage fails fast

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,14 @@
 name: build
 
 on:
+  # Run on every PR so cross-compile breakage (NetBSD, mipsle, riscv64, …)
+  # fails fast in review instead of landing on main. Before 2026-05-30 this
+  # workflow ran only on push:main, which meant `make build-all` was post-
+  # merge-only: any cross-compile regression would sit red on main for
+  # weeks (the NetBSD failure that triggered this change was red for >1
+  # month). Keep `push:main` so a successful merge still produces a build
+  # artifact for the release-drafter / nightly tooling that depends on it.
+  pull_request: { }
   push:
     branches: [ "main" ]
   workflow_dispatch:


### PR DESCRIPTION
## Summary

**Closes the gap that let `main` ship a broken `build` workflow for over a month.**

`make build-all` cross-compiles for 9 GOOS/GOARCH pairs. Until now the only trigger was `push: branches: [main]`, so cross-compile regressions only surfaced **after merge**:

- `pr.yml` Tests job builds only the runner's native arch (`go build ./...`)
- `cross-platform.yml` matrix builds native-arch on each runner OS — not the cross-compile matrix
- `build.yml` (this workflow) was the only one running `build-all`, and it was post-merge-only

Result: the NetBSD targets that #216 removes sat red on `main` from 2026-04-26 to 2026-05-30 because no PR ever ran the workflow that would have caught them.

## Change

Add `pull_request: { }` to the trigger list. `push: branches: [main]` stays so post-merge artifacts continue to land for release-drafter / nightly tooling.

```yaml
on:
  pull_request: { }
  push:
    branches: [ "main" ]
  workflow_dispatch:
```

## Stacked on #216 — verifies the gate actually works

This PR is opened with `base = fix/build-all-drop-unsupported` so its CI runs against #216's NetBSD removal already applied. The PR's own `build` job is therefore a live demonstration:

1. The `pull_request` trigger actually fires on PRs (you can see the `build` job in the checks list below)
2. `make build-all` is now green with the broken targets gone
3. Future PRs that break cross-compile will fail-fast in review

## Cost

`build-all` is `go build` only, no tests. On `ubuntu-latest` it finishes in ~3-4 minutes. Adds nothing to PR critical-path latency — Playwright still dominates.

## After both merge

Once #216 and this PR both land, every future PR is protected against cross-compile breakage. The `build` workflow on `main` should go GREEN for the first time in over a month.

## Test plan

- [ ] CI on this PR succeeds (verifies the new trigger works)
- [ ] After merge, `build` workflow on main is GREEN
- [ ] A future contrived PR that breaks a cross-compile fails the `build` check before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)