### PR TITLE
docs(cmd): add package doc comment to omnipus main

### DIFF
--- a/cmd/omnipus/main.go
+++ b/cmd/omnipus/main.go
@@ -4,6 +4,7 @@
 //
 // Copyright (c) 2026 Omnipus contributors
 
+// Package main is the entry point for the Omnipus CLI.
 package main
 
 import (


### PR DESCRIPTION
Tiny comment-only change: `cmd/omnipus/main.go` had a license header but no Go package doc comment. Added an idiomatic `// Package main ...` line. No behavior change.

Doubles as the first PR to exercise the in-repo **CLA Assistant** workflow now that `cla.yml` is on `main`, surfacing the `CLA Assistant` status check so it can be added to branch protection (see #213).

🤖 Generated with [Claude Code](https://claude.com/claude-code)