### PR TITLE
fix(cla): make CLA Assistant able to record signatures (drop PAT, use built-in token)

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -3,12 +3,13 @@ name: CLA Assistant
 # Gates pull requests on a signed Contributor License Agreement.
 # The CLA text lives in CLA.md; signatures are recorded in-repo in the
 # `cla-signatures` branch (signatures/version1/cla.json). No third-party app is
-# used — this runs entirely as a GitHub Action with a repo-scoped token.
+# used — this runs entirely as a GitHub Action with the built-in GITHUB_TOKEN.
 #
-# Setup prerequisite (one-time, by a maintainer):
-#   Create a fine-grained Personal Access Token scoped to THIS repo only, with
-#   Repository permission "Contents: Read and write", and add it as the repo
-#   secret PERSONAL_ACCESS_TOKEN. See docs/internal/cla-setup.md.
+# No setup secret is required: signatures are stored in this same repository's
+# `cla-signatures` branch, so the workflow's built-in token (granted
+# `contents: write` below) is sufficient. The branch is seeded once with an empty
+# ledger (signatures/version1/cla.json = {"signedContributors":[]}).
+# See docs/internal/cla-setup.md.
 
 on:
   issue_comment:
@@ -18,7 +19,7 @@ on:
 
 permissions:
   actions: write
-  contents: read          # the action uses PERSONAL_ACCESS_TOKEN for the signature branch
+  contents: write         # built-in GITHUB_TOKEN commits the signature ledger to the cla-signatures branch (same repo)
   pull-requests: write
   statuses: write
 
@@ -36,10 +37,9 @@ jobs:
         # contributor-assistant/github-action v2.6.1 (pinned to commit SHA)
         uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08
         env:
+          # Signatures are stored in this same repo's cla-signatures branch, so the
+          # built-in token (granted contents: write above) is sufficient — no PAT needed.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Repo-scoped fine-grained PAT (Contents: read/write) used ONLY to write
-          # the signatures file to the cla-signatures branch.
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         with:
           # Where signatures are stored (kept out of main; its own branch).
           path-to-signatures: 'signatures/version1/cla.json'

--- a/docs/internal/cla-setup.md
+++ b/docs/internal/cla-setup.md
@@ -22,28 +22,30 @@ one-time setup a maintainer must do.
 
 ## One-time setup (maintainer)
 
-### Step 1 — Create a fine-grained Personal Access Token (scoped to this repo only)
+### Step 1 — Seed the signatures branch (one-time)
 
-1. Go to **https://github.com/settings/personal-access-tokens/new**
-2. **Token name:** `omnipus-cla-signatures`
-3. **Resource owner:** `elicify-ai`
-4. **Expiration:** 1 year (set a reminder to rotate).
-5. **Repository access:** *Only select repositories* → choose **`elicify-ai/omnipus`**.
-6. **Permissions → Repository permissions → Contents:** **Read and write**.
-   (Leave everything else as "No access".)
-7. Click **Generate token** and copy it.
+Signatures live on a dedicated `cla-signatures` branch in this same repo. Create it
+once with an empty ledger so the action only ever has to *update* the file:
 
-This token can only write contents to the one repo — nothing else, no other repos,
-no other orgs.
+```bash
+git switch --orphan cla-signatures
+git rm -rf . >/dev/null 2>&1 || true
+mkdir -p signatures/version1
+printf '{"signedContributors":[]}' > signatures/version1/cla.json
+git add signatures/version1/cla.json
+git commit -m "chore(cla): initialize empty CLA signatures ledger"
+git push -u origin cla-signatures
+git switch -   # back to your previous branch
+```
 
-### Step 2 — Add it as a repository secret
+**No Personal Access Token or repository secret is required.** The workflow grants its
+built-in `GITHUB_TOKEN` `contents: write`, which commits to this branch directly — and
+it works for fork PRs too, because `pull_request_target` runs in the base repo's
+context. (Avoiding a fine-grained org PAT also removes an expiry/approval failure mode:
+on an org-owned repo an unapproved PAT silently lacks write and the action fails with
+"Resource not accessible by integration".)
 
-1. Go to **https://github.com/elicify-ai/omnipus/settings/secrets/actions/new**
-2. **Name:** `PERSONAL_ACCESS_TOKEN`
-3. **Secret:** paste the token from Step 1.
-4. **Add secret.**
-
-### Step 3 — Let the check run once, then require it
+### Step 2 — Let the check run once, then require it
 
 1. Open (or wait for) any pull request. The CLA check will run and a status check
    named **`CLA Assistant`** / **`license/cla`** appears on the PR.
@@ -70,8 +72,8 @@ re-sign the new terms:
 
 ## Notes
 
-- The `cla-signatures` branch is created automatically on first run; do not delete
-  it — it is the signature record.
+- The `cla-signatures` branch holds the signature record (seeded in Step 1); do not
+  delete it.
 - The workflow uses `pull_request_target`, which runs in the context of the base
   repo so the token and secrets are available even for fork PRs. The action only
   reads PR metadata and writes the signatures file; it does not run contributor


### PR DESCRIPTION
## Problem
The `CLA Assistant` check on #220 failed — not because the PR was unsigned, but because the action could not write the signature ledger:

```
##[error]Error occurred when creating the signed contributors file:
Resource not accessible by integration.
```

Two root causes:
1. The `cla-signatures` branch did not exist, so the action had to *create* it at runtime.
2. The workflow granted the built-in `GITHUB_TOKEN` only `contents: read` and relied on `PERSONAL_ACCESS_TOKEN` for the write — but that fine-grained PAT lacked effective write on this org-owned repo, so the create/write 403'd.

Net effect: the gate was fail-closed but non-functional — it could comment and go red, but could never record a signature or go green.

## Fix
Signatures are stored in **this same repo**, so the built-in token is sufficient — no PAT needed:
- `permissions.contents: read` → `write`
- removed the `PERSONAL_ACCESS_TOKEN` env line (nothing to expire or get org-approved)
- header comment updated

The `cla-signatures` branch has been seeded separately with an empty ledger (`signatures/version1/cla.json` = `{"signedContributors":[]}`).

## After merge
1. Comment `recheck` on #220 → the check should record/clear and go green.
2. Add `CLA Assistant` to `main` branch protection to enforce it.
3. The `PERSONAL_ACCESS_TOKEN` repo secret can be deleted — it is no longer referenced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)