### PR TITLE
test(cla): temporarily de-allowlist maintainer (revert after signing-path test)

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -51,7 +51,7 @@ jobs:
           custom-pr-sign-comment: 'I have read the CLA Document and I hereby sign the CLA'
           custom-allsigned-prcomment: 'All contributors have signed the CLA. ✅'
           # Don't gate bots or elicify.ai maintainers (covered by employment/contract).
-          allowlist: 'dependabot[bot],dependabot-preview[bot],github-actions[bot],renovate[bot],daniel-piatkowski-ai,*[bot]'
+          allowlist: 'dependabot[bot],dependabot-preview[bot],github-actions[bot],renovate[bot],*[bot]'
           # Re-ask for a signature if the CLA changes (bump to version2, etc.).
           # signatures stay valid per-version.
           lock-pullrequest-aftermerge: false


### PR DESCRIPTION
**Temporary test PR — revert right after.** Removes `daniel-piatkowski-ai` from the CLA allow-list so a maintainer PR is forced through the *sign → record → green* path, to prove the action can now write the signatures ledger (the step that originally failed with 'Resource not accessible by integration' before the token/branch fix). A follow-up PR restores the allow-list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)