### PR TITLE
test(cla): signing-path write proof (do not merge — will close)

### DIFF
--- a/docs/internal/cla-write-test.md
+++ b/docs/internal/cla-write-test.md
@@ -1,0 +1,3 @@
+# CLA write-path test
+
+Temporary artifact to exercise the sign-and-record flow. This PR will be closed unmerged.


### PR DESCRIPTION
Throwaway PR to confirm the CLA action can record a signature to the `cla-signatures` ledger now that the maintainer is temporarily de-allow-listed (#256). Expect: red CLA check + sign request → after signing, ledger gets an entry and the check goes green. Will be closed unmerged; allow-list restored separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)