### PR TITLE
test(cla): restore maintainer allow-list (post signing-path proof)

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -51,7 +51,7 @@ jobs:
           custom-pr-sign-comment: 'I have read the CLA Document and I hereby sign the CLA'
           custom-allsigned-prcomment: 'All contributors have signed the CLA. ✅'
           # Don't gate bots or elicify.ai maintainers (covered by employment/contract).
-          allowlist: 'dependabot[bot],dependabot-preview[bot],github-actions[bot],renovate[bot],*[bot]'
+          allowlist: 'dependabot[bot],dependabot-preview[bot],github-actions[bot],renovate[bot],daniel-piatkowski-ai,*[bot]'
           # Re-ask for a signature if the CLA changes (bump to version2, etc.).
           # signatures stay valid per-version.
           lock-pullrequest-aftermerge: false


### PR DESCRIPTION
Reverts the temporary de-allow-list from #256. The signature-write path is now proven on #257 — the action recorded `daniel-piatkowski-ai` to `cla-signatures/signatures/version1/cla.json` with the built-in token and the check went green.

Merging this returns the allow-list to its intended state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)