### PR TITLE
fix(ci): welcome workflow inputs for first-interaction@v3 (underscores)

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -20,9 +20,9 @@ jobs:
     steps:
       - uses: actions/first-interaction@v3
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
 
-          issue-message: |
+          issue_message: |
             👋 Thanks for opening your first issue in Omnipus!
 
             A few quick pointers so we can route this efficiently:
@@ -34,7 +34,7 @@ jobs:
 
             A maintainer will triage this within a few business days. Thanks for taking the time to file it.
 
-          pr-message: |
+          pr_message: |
             🎉 Thanks for opening your first PR in Omnipus!
 
             Before this can be merged:


### PR DESCRIPTION
## Problem
The `actions/first-interaction` **1→3** bump (merged in #267) is a breaking change — v3 renamed its inputs to underscores. `welcome.yml` still passed the old hyphenated names, so the **welcome** job now fails on every first-time issue/PR:
```
Error: Input required and not supplied: issue_message
```
(Surfaced as a red `welcome` check on PR #287.)

## Fix
Rename the three input keys to match v3's `action.yml`:
- `repo-token` → `repo_token`
- `issue-message` → `issue_message`
- `pr-message` → `pr_message`

Verified against `actions/first-interaction@v3` action.yml. Message content unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)