### PR TITLE
docs: flatten navigation — one docs index + a single Channels hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Tell them once in Settings → Profile ("be concise", "I use Python", your timez
 
 Use the web app, the terminal, or wire your agents into Telegram, Discord, Slack, WhatsApp, and 10 other chat platforms — voice notes and images included.
 
-→ [Chat apps](docs/chat-apps.md)
+→ [Channels](docs/channels.md)
 
 ### You stay in control
 
@@ -105,7 +105,7 @@ Pick from 35+ AI providers — including fully-local options like Ollama.
 
 **Full audit trail** — every tool call, LLM request, and agent event lands in a replayable on-disk transcript that feeds the UI, subprocess hooks, and a tamper-evident audit log. → [Session transcript](docs/observability.md#session-transcript)
 
-**14 in-process chat channels and 35+ LLM providers** — with fallback chains, multi-key rotation, streaming, and vision. → [Registered channels](pkg/channels/README.md#10-registered-channels) · [Providers](docs/providers.md#providers)
+**14 in-process chat channels and 35+ LLM providers** — with fallback chains, multi-key rotation, streaming, and vision. → [Channels](docs/channels.md) · [Providers](docs/providers.md#providers)
 
 **Channel-to-agent routing** — binds inbound messages to specific agents by channel, account, guild, team, or peer. → [Inbound bindings](docs/routing.md#inbound-bindings)
 
@@ -314,34 +314,14 @@ It applies the same end-state mutations as the SPA wizard — config, credential
 
 ## Documentation
 
-User-facing guides, grouped by what you're trying to do:
+**[→ Full documentation index](docs/README.md)** — every guide, grouped by what you're trying to do.
 
-| Topic | Where to go |
-|---|---|
-| **▶ Start here — your first 10 minutes** | [docs/getting-started.md](docs/getting-started.md) |
-| **How Omnipus works (plain English)** | [docs/concepts.md](docs/concepts.md) |
-| **Using the web app** | [docs/using-omnipus-ui.md](docs/using-omnipus-ui.md) |
-| **Using the terminal / CLI** | [docs/using-omnipus-cli.md](docs/using-omnipus-cli.md) |
-| **Full documentation index** | [docs/README.md](docs/README.md) |
-| **Memory system** | [docs/memory.md](docs/memory.md) |
-| **Channel-to-agent routing** | [docs/routing.md](docs/routing.md) |
-| **Session history & event stream** | [docs/observability.md](docs/observability.md) |
-| **Skills & MCP** | [docs/skills.md](docs/skills.md) · [docs/tools_configuration.md](docs/tools_configuration.md) |
-| **Channels (per-channel guides)** | [pkg/channels/README.md](pkg/channels/README.md) |
-| **Hooks (subprocess + in-process)** | [docs/hooks/README.md](docs/hooks/README.md) |
-| **Tools reference (full catalog)** | [docs/tools-reference.md](docs/tools-reference.md) |
-| **LLM providers** | [docs/providers.md](docs/providers.md) |
-| **Sandbox: config & status** | [docs/operations/sandbox-config.md](docs/operations/sandbox-config.md) |
-| **Sandbox: known limitations** | [docs/operations/sandbox-limitations.md](docs/operations/sandbox-limitations.md) |
-| **Reverse proxy & TLS** | [docs/operations/reverse-proxy.md](docs/operations/reverse-proxy.md) |
-| **Docker** | [docs/docker.md](docs/docker.md) |
-| **Credential vault** | [docs/credential_encryption.md](docs/credential_encryption.md) |
-| **Configuration reference** | [docs/configuration.md](docs/configuration.md) |
-| **Platform support** | [docs/operations/platform-support.md](docs/operations/platform-support.md) |
-| **Troubleshooting** | [docs/troubleshooting.md](docs/troubleshooting.md) |
-| **Debug & log spelunking** | [docs/debug.md](docs/debug.md) |
+New here? Start with:
 
-Browse the full index at [docs/README.md](docs/README.md).
+- [Your first 10 minutes](docs/getting-started.md) — install → first chat → handoff → build an agent
+- [How Omnipus works](docs/concepts.md) — agents, sessions, memory, channels, skills (plain English)
+- [Using the web app](docs/using-omnipus-ui.md) · [Using the terminal](docs/using-omnipus-cli.md)
+- [Channels](docs/channels.md) — connect Telegram / Discord / Slack / … and choose which agent answers each
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,8 +39,7 @@ New to Omnipus? Read these in order.
 | Channel-to-agent routing & handoff | [routing.md](routing.md) |
 | Session history & event stream | [observability.md](observability.md) |
 | Skills (ClawHub installs, SKILL.md format) | [skills.md](skills.md) |
-| Channels (15 chat platforms) | [../pkg/channels/README.md](../pkg/channels/README.md) |
-| Chat-apps configuration | [chat-apps.md](chat-apps.md) |
+| Channels — set up chat platforms & route them to agents | [channels.md](channels.md) |
 | Hooks (subprocess + in-process) | [hooks/README.md](hooks/README.md) |
 | Antigravity provider | [ANTIGRAVITY_USAGE.md](ANTIGRAVITY_USAGE.md) |
 

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -1,30 +1,42 @@
-# Chat Apps Configuration
+# Channels
 
-> Back to [README](../README.md)
+> Back to [docs index](README.md)
 
-## Chat Apps
+Talk to your Omnipus through Telegram, Discord, WhatsApp, Matrix, QQ, DingTalk, LINE, WeCom, Weixin, Feishu, Slack, IRC, OneBot, or Google Chat. This is the one place for everything about channels: setting them up in the app, the per-platform credentials, and which agent answers each one.
 
-Talk to your Omnipus through Telegram, Discord, WhatsApp, Matrix, QQ, DingTalk, LINE, WeCom, Weixin, Feishu, Slack, IRC, OneBot, or Google Chat.
+## 1. In the app
 
-> **In the web app:** the **Channels** page (sidebar → Channels) lists every channel — enable/disable each one, open **Configure** to enter its connection details, and pick the **Default agent** that answers it. See [Using the web app → Channels](using-omnipus-ui.md#channels). The per-channel pages below tell you where to obtain each channel's credentials (bot tokens, app secrets, etc.).
+The **Channels** page (sidebar → **Channels**) lists every channel as a card. For each one you can:
+
+- **Enable / Disable** it,
+- open **Configure** to enter its connection details (bot token, allow-list, transport options), and
+- pick its **Default agent** under **Routing** — the agent that answers messages arriving on that channel ("(Global default)" inherits the [global default agent](using-omnipus-ui.md#managing-agents)).
+
+See the walkthrough with screenshots: **[Using the web app → Channels](using-omnipus-ui.md#channels)**.
+
+For the full routing model — per-user / per-guild / per-team bindings and the default-agent fallback — see **[Routing](routing.md)**.
+
+## 2. Per-platform setup
+
+The table below links each platform's page, which tells you where to obtain its credentials (bot tokens, app secrets, webhooks, etc.).
 
 > **Note**: Channels that rely on HTTP callbacks share a single Gateway HTTP server (`gateway.host`:`gateway.port`, default `127.0.0.1:18790`). Socket/stream-based channels such as Feishu, DingTalk, and WeCom do not rely on the shared webhook server for inbound delivery.
 
 | Channel              | Difficulty         | Description                                           | Documentation                                                                                                    |
 | -------------------- | ------------------ | ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| **Telegram**         | ⭐ Easy            | Recommended, voice-to-text, long polling (no public IP needed) | [Docs](channels/telegram/README.md)                                                                  |
-| **Discord**          | ⭐ Easy            | Socket Mode, group/DM support, rich bot ecosystem     | [Docs](channels/discord/README.md)                                                                           |
-| **WhatsApp**         | ⭐ Easy            | Native (QR scan) or Bridge URL                        | [Docs](channels/whatsapp/README.md) / [Native](channels/whatsapp_native/README.md)                              |
+| **Telegram**         | ⭐ Easy            | Recommended, voice-to-text, long polling (no public IP needed) | [Docs](channels/telegram.md)                                                                  |
+| **Discord**          | ⭐ Easy            | Socket Mode, group/DM support, rich bot ecosystem     | [Docs](channels/discord.md)                                                                           |
+| **WhatsApp**         | ⭐ Easy            | Native (QR scan) or Bridge URL                        | [Docs](channels/whatsapp.md) / [Native](channels/whatsapp_native.md)                              |
 | **Weixin**           | ⭐ Easy            | Native QR scan (Tencent iLink API)                    | [Docs](#weixin)                                                                            |
-| **Slack**            | ⭐ Easy            | **Socket Mode** (no public IP needed), enterprise     | [Docs](channels/slack/README.md)                                                                             |
-| **Matrix**           | ⭐⭐ Medium        | Federated protocol, self-hosting supported            | [Docs](channels/matrix/README.md)                                                                            |
-| **QQ**               | ⭐⭐ Medium        | Official bot API, Chinese community                   | [Docs](channels/qq/README.md)                                                                                |
-| **DingTalk**         | ⭐⭐ Medium        | Stream mode (no public IP needed), enterprise         | [Docs](channels/dingtalk/README.md)                                                                          |
-| **LINE**             | ⭐⭐⭐ Advanced    | HTTPS Webhook required                                | [Docs](channels/line/README.md)                                                                              |
-| **WeCom (企业微信)** | ⭐⭐⭐ Advanced    | Official AI Bot over WebSocket, streaming + media     | [Docs](channels/wecom/README.md) |
-| **Feishu (飞书)**    | ⭐⭐⭐ Advanced    | Enterprise collaboration, feature-rich                | [Docs](channels/feishu/README.md)                                                                            |
-| **IRC**              | ⭐⭐ Medium        | Server + TLS configuration                            | [Docs](channels/irc/README.md)                                                                                  |
-| **OneBot**           | ⭐⭐ Medium        | NapCat/Go-CQHTTP compatible, community ecosystem      | [Docs](channels/onebot/README.md)                                                                            |
+| **Slack**            | ⭐ Easy            | **Socket Mode** (no public IP needed), enterprise     | [Docs](channels/slack.md)                                                                             |
+| **Matrix**           | ⭐⭐ Medium        | Federated protocol, self-hosting supported            | [Docs](channels/matrix.md)                                                                            |
+| **QQ**               | ⭐⭐ Medium        | Official bot API, Chinese community                   | [Docs](channels/qq.md)                                                                                |
+| **DingTalk**         | ⭐⭐ Medium        | Stream mode (no public IP needed), enterprise         | [Docs](channels/dingtalk.md)                                                                          |
+| **LINE**             | ⭐⭐⭐ Advanced    | HTTPS Webhook required                                | [Docs](channels/line.md)                                                                              |
+| **WeCom (企业微信)** | ⭐⭐⭐ Advanced    | Official AI Bot over WebSocket, streaming + media     | [Docs](channels/wecom.md) |
+| **Feishu (飞书)**    | ⭐⭐⭐ Advanced    | Enterprise collaboration, feature-rich                | [Docs](channels/feishu.md)                                                                            |
+| **IRC**              | ⭐⭐ Medium        | Server + TLS configuration                            | [Docs](channels/irc.md)                                                                                  |
+| **OneBot**           | ⭐⭐ Medium        | NapCat/Go-CQHTTP compatible, community ecosystem      | [Docs](channels/onebot.md)                                                                            |
 
 <a id="telegram"></a>
 <details>
@@ -303,7 +315,7 @@ Use your preferred homeserver (e.g. `https://matrix.org` or self-hosted), create
 omnipus start
 ```
 
-For full options (`device_id`, `join_on_invite`, `group_trigger`, `placeholder`, `reasoning_channel_id`), see [Matrix Channel Configuration Guide](channels/matrix/README.md).
+For full options (`device_id`, `join_on_invite`, `group_trigger`, `placeholder`, `reasoning_channel_id`), see [Matrix Channel Configuration Guide](channels/matrix.md).
 
 </details>
 
@@ -360,7 +372,7 @@ omnipus start
 
 Omnipus exposes WeCom as a single AI Bot channel over WebSocket. No public webhook callback URL is required.
 
-See [WeCom Configuration Guide](channels/wecom/README.md) for the full configuration reference and migration notes.
+See [WeCom Configuration Guide](channels/wecom.md) for the full configuration reference and migration notes.
 
 **Quick Setup - Recommended**
 
@@ -435,7 +447,7 @@ omnipus start
 
 Open Feishu, search for your bot name, and start chatting. You can also add the bot to a group — use `group_trigger.mention_only: true` to only respond when @mentioned.
 
-For full options, see [Feishu Channel Configuration Guide](channels/feishu/README.md).
+For full options, see [Feishu Channel Configuration Guide](channels/feishu.md).
 
 </details>
 

--- a/docs/channels/dingtalk.md
+++ b/docs/channels/dingtalk.md
@@ -1,4 +1,4 @@
-> Back to [README](../../../README.md)
+> Back to [Channels](../channels.md)
 
 # DingTalk
 
@@ -49,4 +49,4 @@ DingTalk (钉钉) is Alibaba's enterprise communication platform. Omnipus connec
 - **Outbound.** Replies use the per-session webhook URL provided by the DingTalk platform in each incoming event; no additional send API key is needed beyond `client_id` / `client_secret_ref`.
 - **Group chats.** Use `group_trigger.mention_only: true` or `group_trigger.prefixes` to avoid the bot responding to every message in a group.
 
-For deeper details on how channels are orchestrated, see [pkg/channels/README.md](../../../pkg/channels/README.md).
+For deeper details on how channels are orchestrated, see [pkg/channels/README.md](../../pkg/channels/README.md).

--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -1,4 +1,4 @@
-> Back to [README](../../../README.md)
+> Back to [Channels](../channels.md)
 
 # Discord
 
@@ -60,4 +60,4 @@ Omnipus connects to Discord as a bot using the [discordgo](https://github.com/bw
 - **Group chats.** In guild text channels, use `group_trigger.mention_only: true` so the bot only responds when directly @-mentioned.
 - **Deprecated top-level `mention_only`.** `DiscordConfig` still has a top-level `mention_only` field for backward compatibility, but the channel code reads only `group_trigger.mention_only`. The top-level field is inert — leave it unset and configure under `group_trigger`.
 
-For deeper details on how channels are orchestrated, see [pkg/channels/README.md](../../../pkg/channels/README.md).
+For deeper details on how channels are orchestrated, see [pkg/channels/README.md](../../pkg/channels/README.md).

--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -1,4 +1,4 @@
-> Back to [README](../../../README.md)
+> Back to [Channels](../channels.md)
 
 # Feishu
 
@@ -65,4 +65,4 @@ Feishu (international name: Lark) is a ByteDance enterprise collaboration platfo
 
 **Token cache invalidation.** The channel detects Feishu error code `99991663` (invalid tenant token) and invalidates the SDK token cache immediately, avoiding the default ~2-hour stale-token window.
 
-For deeper details on how channels are orchestrated, see [pkg/channels/README.md](../../../pkg/channels/README.md).
+For deeper details on how channels are orchestrated, see [pkg/channels/README.md](../../pkg/channels/README.md).

--- a/docs/channels/google-chat.md
+++ b/docs/channels/google-chat.md
@@ -1,4 +1,4 @@
-> Back to [README](../../../README.md)
+> Back to [Channels](../channels.md)
 
 # Google Chat
 
@@ -122,4 +122,4 @@ When neither is set, the bot responds to all messages in group spaces (permissiv
 - **Webhook-mode `webhook_url` is a bearer secret.** The URL contains a `?key=…` query parameter that grants posting rights to the space. Do not commit it to `config.json` in plain text — store the URL itself in the credential store and reference it via `_ref` patterns (the field name follows the convention used elsewhere; see your config for the exact key).
 - **Bot-mode signature verification runs inside the channel**, not in the shared gateway mux. The implementation parses the `Google-Signature` header, fetches Google's JWKS (with caching), verifies RSA-SHA256 over the request body, and rejects on mismatch. If you front the bot endpoint with a reverse proxy, **do not strip the `Google-Signature` header** — that breaks verification. The shared gateway mux does no HMAC/signature enforcement of its own; see `pkg/channels/README.md` §12.4.
 
-For deeper details on how channels are orchestrated, see [pkg/channels/README.md](../../../pkg/channels/README.md).
+For deeper details on how channels are orchestrated, see [pkg/channels/README.md](../../pkg/channels/README.md).

--- a/docs/channels/irc.md
+++ b/docs/channels/irc.md
@@ -1,4 +1,4 @@
-> Back to [README](../../../README.md)
+> Back to [Channels](../channels.md)
 
 # IRC
 
@@ -81,4 +81,4 @@ Omnipus connects to any IRC server via a persistent TCP connection (optionally T
 - **Group chat trigger.** In IRC channels (targets starting with `#` or `&`), the group trigger controls response. The most common IRC convention — `botnick: message` or `botnick, message` — is recognized as a mention and the prefix is stripped before the message reaches the agent.
 - **Direct messages.** PRIVMSGs sent directly to the bot's nick (not to a channel) are always handled without trigger filtering.
 
-For deeper details on how channels are orchestrated, see [pkg/channels/README.md](../../../pkg/channels/README.md).
+For deeper details on how channels are orchestrated, see [pkg/channels/README.md](../../pkg/channels/README.md).

--- a/docs/channels/line.md
+++ b/docs/channels/line.md
@@ -1,4 +1,4 @@
-> Back to [README](../../../README.md)
+> Back to [Channels](../channels.md)
 
 # LINE
 
@@ -65,4 +65,4 @@ Omnipus connects to LINE Official Accounts via the [LINE Messaging API](https://
 - **HTTPS required.** LINE will not deliver webhooks to plain HTTP endpoints.
 - **Webhook security.** The LINE channel itself signature-verifies every inbound request — HMAC-SHA256 of the raw body using your Channel Secret, compared against the `X-Line-Signature` header. The shared gateway mux does no HMAC enforcement (see `pkg/channels/README.md` §12.4). If you reverse-proxy the webhook path with nginx / Caddy / Cloudflare, **do not strip the `X-Line-Signature` header** — that breaks verification and inbound delivery will fail.
 
-For deeper details on how channels are orchestrated, see [pkg/channels/README.md](../../../pkg/channels/README.md).
+For deeper details on how channels are orchestrated, see [pkg/channels/README.md](../../pkg/channels/README.md).

--- a/docs/channels/matrix.md
+++ b/docs/channels/matrix.md
@@ -1,4 +1,4 @@
-> Back to [README](../../../README.md)
+> Back to [Channels](../channels.md)
 
 # Matrix
 
@@ -99,4 +99,4 @@ Credentials (`access_token_ref`, `crypto_passphrase_ref`) are resolved from the 
 - Auto-join invited rooms (`join_on_invite`)
 - End-to-end encryption via `goolm` + `cryptohelper` (opt-in via `crypto_passphrase_ref`)
 
-For deeper details on how channels are orchestrated, see [pkg/channels/README.md](../../../pkg/channels/README.md).
+For deeper details on how channels are orchestrated, see [pkg/channels/README.md](../../pkg/channels/README.md).

--- a/docs/channels/onebot.md
+++ b/docs/channels/onebot.md
@@ -1,4 +1,4 @@
-> Back to [README](../../../README.md)
+> Back to [Channels](../channels.md)
 
 # OneBot
 
@@ -68,4 +68,4 @@ Note: `group_trigger_prefix` (legacy flat array) is still accepted and migrated 
 - Duplicate message suppression (ring buffer, last 1024 message IDs)
 - Automatic reconnect with configurable interval
 
-For deeper details on how channels are orchestrated, see [pkg/channels/README.md](../../../pkg/channels/README.md).
+For deeper details on how channels are orchestrated, see [pkg/channels/README.md](../../pkg/channels/README.md).

--- a/docs/channels/qq.md
+++ b/docs/channels/qq.md
@@ -1,4 +1,4 @@
-> Back to [README](../../../README.md)
+> Back to [Channels](../channels.md)
 
 # QQ
 
@@ -57,4 +57,4 @@ Omnipus connects to QQ via the official QQ Bot Open Platform API using a persist
 
 **Group chats.** The QQ Bot API requires an @-mention in group chats for the bot to receive the message. `group_trigger.mention_only` is therefore the effective default for group interactions regardless of its value; `group_trigger.prefixes` applies to the content after the @-mention is stripped.
 
-For deeper details on how channels are orchestrated, see [pkg/channels/README.md](../../../pkg/channels/README.md).
+For deeper details on how channels are orchestrated, see [pkg/channels/README.md](../../pkg/channels/README.md).

--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -1,4 +1,4 @@
-> Back to [README](../../../README.md)
+> Back to [Channels](../channels.md)
 
 # Slack
 
@@ -66,4 +66,4 @@ Omnipus connects to Slack using [Socket Mode](https://api.slack.com/apis/socket-
 - **Message length.** Slack caps individual messages at 40 000 characters; longer responses are automatically split.
 - **Group chats.** Use `group_trigger.mention_only: true` so the bot only responds in channels when directly @-mentioned.
 
-For deeper details on how channels are orchestrated, see [pkg/channels/README.md](../../../pkg/channels/README.md).
+For deeper details on how channels are orchestrated, see [pkg/channels/README.md](../../pkg/channels/README.md).

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -1,4 +1,4 @@
-> Back to [README](../../../README.md)
+> Back to [Channels](../channels.md)
 
 # Telegram
 
@@ -91,4 +91,4 @@ At startup Telegram registers Omnipus's built-in bot commands automatically via 
 
 **Message length.** The channel enforces a 4000-character soft limit before sending, with an additional overflow-split guard at Telegram's 4096-character API hard limit. Long messages are split at natural break points (newlines, spaces, code-block boundaries).
 
-For deeper details on how channels are orchestrated, see [pkg/channels/README.md](../../../pkg/channels/README.md).
+For deeper details on how channels are orchestrated, see [pkg/channels/README.md](../../pkg/channels/README.md).

--- a/docs/channels/wecom.md
+++ b/docs/channels/wecom.md
@@ -1,4 +1,4 @@
-> Back to [README](../../../README.md)
+> Back to [Channels](../channels.md)
 
 # WeCom
 
@@ -150,4 +150,4 @@ Fields can be overridden via environment variables. The parent block uses the pr
 - Check whether `allow_from` is blocking the sender.
 - Check that `channels.wecom.bot_id` and `channels.wecom.secret_ref` are set and non-empty, and that the referenced credential exists in the store.
 
-For deeper details on how channels are orchestrated, see [pkg/channels/README.md](../../../pkg/channels/README.md).
+For deeper details on how channels are orchestrated, see [pkg/channels/README.md](../../pkg/channels/README.md).

--- a/docs/channels/weixin.md
+++ b/docs/channels/weixin.md
@@ -1,4 +1,4 @@
-> Back to [README](../../../README.md)
+> Back to [Channels](../channels.md)
 
 # Weixin (WeChat Personal)
 
@@ -60,4 +60,4 @@ omnipus start
 
 **Rate limits.** Avoid high-frequency automated broadcasts; WeChat anti-spam systems may restrict accounts that send messages at excessive rates.
 
-For deeper details on how channels are orchestrated, see [pkg/channels/README.md](../../../pkg/channels/README.md).
+For deeper details on how channels are orchestrated, see [pkg/channels/README.md](../../pkg/channels/README.md).

--- a/docs/channels/whatsapp.md
+++ b/docs/channels/whatsapp.md
@@ -1,10 +1,10 @@
-> Back to [README](../../../README.md)
+> Back to [Channels](../channels.md)
 
 # WhatsApp (bridge mode)
 
 This document covers **bridge mode** — the transport used when `use_native: false` (the default). Omnipus connects to an external WhatsApp bridge process over a persistent WebSocket connection (`BridgeURL`). The bridge is responsible for maintaining the WhatsApp session; Omnipus only sends and receives JSON-encoded message frames over that WebSocket.
 
-For the in-process whatsmeow mode, see [docs/channels/whatsapp_native/README.md](../whatsapp_native/README.md). Set `use_native: true` to select that mode instead.
+For the in-process whatsmeow mode, see [docs/channels/whatsapp_native.md](whatsapp_native.md). Set `use_native: true` to select that mode instead.
 
 ## Configuration
 
@@ -54,4 +54,4 @@ For the in-process whatsmeow mode, see [docs/channels/whatsapp_native/README.md]
 - **Message length.** Outbound messages are capped at 65 536 characters by the base channel layer. WhatsApp itself imposes its own limits on the bridge side.
 - **Group chat trigger.** Group trigger and `allow_from` filtering applies to inbound messages before they reach the agent. The bridge must populate the `chat` field with the group JID and `from` with the sender JID for group routing to work correctly.
 
-For deeper details on how channels are orchestrated, see [pkg/channels/README.md](../../../pkg/channels/README.md).
+For deeper details on how channels are orchestrated, see [pkg/channels/README.md](../../pkg/channels/README.md).

--- a/docs/channels/whatsapp_native.md
+++ b/docs/channels/whatsapp_native.md
@@ -1,10 +1,10 @@
-> Back to [README](../../../README.md)
+> Back to [Channels](../channels.md)
 
 # WhatsApp Native (whatsmeow)
 
 This document covers **native mode** — the transport used when `use_native: true`. Omnipus connects directly to WhatsApp servers using the [whatsmeow](https://github.com/tulir/whatsmeow) library in-process. No external bridge process is required. Session state is stored in a local SQLite database via `modernc.org/sqlite` (pure Go, no CGo).
 
-For the external bridge mode, see [docs/channels/whatsapp/README.md](../whatsapp/README.md). Set `use_native: false` (or omit the field) to select that mode instead.
+For the external bridge mode, see [docs/channels/whatsapp.md](whatsapp.md). Set `use_native: false` (or omit the field) to select that mode instead.
 
 ## Build requirement
 
@@ -72,4 +72,4 @@ Both bridge mode and native mode share the `WhatsAppConfig` struct. Fields relev
 - **Chat ID format.** For outbound messages the `chat_id` field accepts either a bare phone number (e.g. `15551234567`) or a full JID (e.g. `15551234567@s.whatsapp.net`). For groups, use the group JID (e.g. `12345678-1234567890@g.us`).
 - **No credential ref.** Session credentials are managed entirely by whatsmeow in `store.db`. The Omnipus credential store is not used for WhatsApp authentication.
 
-For deeper details on how channels are orchestrated, see [pkg/channels/README.md](../../../pkg/channels/README.md).
+For deeper details on how channels are orchestrated, see [pkg/channels/README.md](../../pkg/channels/README.md).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -122,7 +122,7 @@ When she's done, it shows up in your roster alongside the others.
 
 ## 8. Where to go next
 
-**Connect a chat channel** (talk to your agents from Telegram, Discord, and more): **[chat-apps.md](chat-apps.md)**
+**Connect a chat channel** (talk to your agents from Telegram, Discord, and more): **[channels.md](channels.md)**
 
 **Prefer the terminal?** **[Using the CLI](using-omnipus-cli.md)**
 

--- a/docs/using-omnipus-cli.md
+++ b/docs/using-omnipus-cli.md
@@ -332,7 +332,7 @@ omnipus auth weixin
 omnipus auth wecom
 ```
 
-For connecting full chat platforms (Telegram, Slack, Discord, and more), see [Chat apps](chat-apps.md).
+For connecting full chat platforms (Telegram, Slack, Discord, and more), see [Chat apps](channels.md).
 
 ---
 

--- a/docs/using-omnipus-ui.md
+++ b/docs/using-omnipus-ui.md
@@ -89,7 +89,7 @@ Agents can also send files **back** to you. Ask Jim to write something to a file
 
 The web app is **text-first** — you type, the agent replies in text.
 
-If you'd rather talk, connect a chat channel that supports voice. On channels like **Telegram**, you can send a voice message and Omnipus will transcribe it to text for the agent automatically. That's a great option from your phone when typing is awkward. See [Connecting chat apps](chat-apps.md) to set one up.
+If you'd rather talk, connect a chat channel that supports voice. On channels like **Telegram**, you can send a voice message and Omnipus will transcribe it to text for the agent automatically. That's a great option from your phone when typing is awkward. See [Connecting chat apps](channels.md) to set one up.
 
 ---
 
@@ -186,7 +186,7 @@ Clicking **Configure** opens a slide-over with two sections:
 
 | Section | What it's for |
 |---------|--------------|
-| **Connection** | The channel's credentials and transport settings — e.g. a Telegram **Bot Token**, an allow-list of who may message the bot, a proxy or custom API URL. Each channel's [setup page](chat-apps.md) tells you exactly where to get these values. Secrets are stored encrypted (in `credentials.json`), never in plain config. |
+| **Connection** | The channel's credentials and transport settings — e.g. a Telegram **Bot Token**, an allow-list of who may message the bot, a proxy or custom API URL. Each channel's [setup page](channels.md) tells you exactly where to get these values. Secrets are stored encrypted (in `credentials.json`), never in plain config. |
 | **Routing** | **Default agent** — which agent handles inbound messages on *this* channel. Leave it on **"(Global default)"** to use your globally-configured default agent (see [Managing agents](#managing-agents)), or pick a specific agent to dedicate this channel to it. |
 
 ![The Configure panel for Telegram, showing Connection fields and the Routing section with a Default agent selector](marketing/screenshots/channel-configure-routing.png)
@@ -194,7 +194,7 @@ Clicking **Configure** opens a slide-over with two sections:
 
 When you're done, click **Save & Enable** to save the settings and turn the channel on (or **Save** to keep it off for now). **Test** checks that the required fields are filled in.
 
-> **Which agent answers?** Routing resolves from most-specific to least: a per-user/peer rule, then a per-channel **Default agent** (set here), and finally your global **default agent** (the ★ on the Agents page). For the full set of routing rules — including per-user and per-group bindings — see [Routing](routing.md). For step-by-step credentials for each chat app, see [Connecting chat apps](chat-apps.md).
+> **Which agent answers?** Routing resolves from most-specific to least: a per-user/peer rule, then a per-channel **Default agent** (set here), and finally your global **default agent** (the ★ on the Agents page). For the full set of routing rules — including per-user and per-group bindings — see [Routing](routing.md). For step-by-step credentials for each chat app, see [Connecting chat apps](channels.md).
 
 ---
 
@@ -272,6 +272,6 @@ In **Settings → Profile** there's a box labelled **"What should the agents kno
 
 **[Using Omnipus from the command line](using-omnipus-cli.md)** — the terminal half of this guide.
 
-**[Connecting chat apps](chat-apps.md)** — use your agents from Telegram, Discord, Slack, and more.
+**[Connecting chat apps](channels.md)** — use your agents from Telegram, Discord, Slack, and more.
 
 **[Skills](skills.md)** — find, install, and get the most out of skills.

--- a/pkg/channels/README.md
+++ b/pkg/channels/README.md
@@ -1,5 +1,7 @@
 # Omnipus Channel System
 
+> **Setting up a channel as a user? → [docs/channels.md](../../docs/channels.md).** This page is a **contributor / architecture reference** for the channel *system internals* (code structure, with file:line citations) — not a setup guide.
+
 > **Scope**: `pkg/channels/`, `pkg/bus/`, `pkg/media/`, `pkg/identity/`
 
 This document describes the channel system as it exists in the current codebase. Every concrete claim cites the file and line range it was verified against.


### PR DESCRIPTION
Flattens the user-docs navigation so the path from the README actually reaches the content, and consolidates the channel docs into a single hub. **Docs-only — no code changes.**

## Problem (the critical review)
- **Three competing nav indexes** that drift: the README "New here?" line, a ~20-row README "Documentation" table, and `docs/README.md`.
- **Channels was unreachable from the README:** channel links pointed to *three* different docs, dominated by `pkg/channels/README.md` — a developer/architecture doc (file:line citations) in the **code tree**. The in-app Channels guide wasn't linked at all.
- **Channel content scattered across 5 places** with no home; per-channel docs nested as `channels/<name>/README.md` (dir + README each); terminology split ("Chat apps" vs "Channels").

## Changes
- **One index of truth.** README drops the duplicate 20-row table for a single **→ Full documentation index** pointer to `docs/README.md` + a 4-item curated "start here" (incl. a Channels link).
- **One Channels hub.** `docs/chat-apps.md` → **`docs/channels.md`**, restructured into **1. In the app** (links the in-app Channels walkthrough + screenshots), **2. Per-platform setup** (the per-channel table), and a **Routing** pointer. Consistent "Channels" naming (retires "Chat apps"). All channel links across README + `docs/README.md` now point here.
- **Flatter per-channel docs.** `docs/channels/<name>/README.md` → `docs/channels/<name>.md` (15 dirs → 15 files; one less hop). Relative-link depth fixed; each "Back" link now goes to the Channels hub.
- **Demoted the code-tree doc.** `pkg/channels/README.md` gets a banner redirecting users to `docs/channels.md`; removed from the user-facing index (kept as a contributor/architecture reference).

## Result
`README → docs/README.md (one index) → topic page`, with a single Channels hub. Any user topic is ≤2 hops; a specific channel ≤3 (was 3–4, landing in the code tree).

## Verification
- All internal markdown links audited: **0 broken**, **0 stale `chat-apps.md` / `channels/<name>/README.md` references** anywhere in the repo.
- Renames recorded as `git mv` (history preserved). No code touched, so code/CI gates are unaffected.
