### PR TITLE
docs(channels): UI-first Channels page with screenshots (config.json as alternative)

### DIFF
--- a/docs/channels.md
+++ b/docs/channels.md
@@ -2,23 +2,28 @@
 
 > Back to [docs index](README.md)
 
-Talk to your Omnipus through Telegram, Discord, WhatsApp, Matrix, QQ, DingTalk, LINE, WeCom, Weixin, Feishu, Slack, IRC, OneBot, or Google Chat. This is the one place for everything about channels: setting them up in the app, the per-platform credentials, and which agent answers each one.
+Talk to your Omnipus through Telegram, Discord, WhatsApp, Matrix, QQ, DingTalk, LINE, WeCom, Weixin, Feishu, Slack, IRC, OneBot, or Google Chat. **The web app is the primary way to set channels up.** Editing `config.json` by hand (shown in each [per-platform section](#per-platform-credentials)) is an optional alternative for headless or automated deployments.
 
-## 1. In the app
+## Configure a channel in the app
 
-The **Channels** page (sidebar → **Channels**) lists every channel as a card. For each one you can:
+Open **Channels** in the sidebar. Every channel is a card showing its transport and status, with **Configure** and **Enable / Disable** actions.
 
-- **Enable / Disable** it,
-- open **Configure** to enter its connection details (bot token, allow-list, transport options), and
-- pick its **Default agent** under **Routing** — the agent that answers messages arriving on that channel ("(Global default)" inherits the [global default agent](using-omnipus-ui.md#managing-agents)).
+![The Channels page — one card per channel with Configure and Enable/Disable](marketing/screenshots/channels-screen.png)
 
-See the walkthrough with screenshots: **[Using the web app → Channels](using-omnipus-ui.md#channels)**.
+Click **Configure** on the channel you want. The panel has two parts:
 
-For the full routing model — per-user / per-guild / per-team bindings and the default-agent fallback — see **[Routing](routing.md)**.
+1. **Connection** — paste the channel's credentials (e.g. a Telegram **Bot Token**) and any transport options (allow-list, proxy, custom API URL). The [per-platform sections below](#per-platform-credentials) tell you exactly where to get each value. Secrets are stored encrypted in `credentials.json`, never in plain config.
+2. **Routing → Default agent** — choose which agent answers messages on this channel. Leave it on **"(Global default)"** to use your [global default agent](using-omnipus-ui.md#managing-agents) (the ★ on the Agents page), or pick a specific agent to dedicate the channel to it.
 
-## 2. Per-platform setup
+![The Configure panel — Connection fields plus the Routing "Default agent" selector](marketing/screenshots/channel-configure-routing.png)
 
-The table below links each platform's page, which tells you where to obtain its credentials (bot tokens, app secrets, webhooks, etc.).
+Click **Save & Enable** to connect the channel and start routing — no file editing required.
+
+> Which agent answers is resolved most-specific-first: per-user → per-guild/team → this channel's default → the global default. For the full model see **[Routing](routing.md)**.
+
+## Per-platform credentials
+
+Each platform's section below tells you where to obtain the credentials you paste into **Configure** (bot tokens, app secrets, webhooks, etc.). Each section also shows the equivalent **`config.json`** snippet — the manual alternative for headless/automated setups.
 
 > **Note**: Channels that rely on HTTP callbacks share a single Gateway HTTP server (`gateway.host`:`gateway.port`, default `127.0.0.1:18790`). Socket/stream-based channels such as Feishu, DingTalk, and WeCom do not rely on the shared webhook server for inbound delivery.
 

--- a/docs/using-omnipus-ui.md
+++ b/docs/using-omnipus-ui.md
@@ -172,29 +172,12 @@ For the **five core agents** (Mia, Jim, Ava, Ray, Max), their identity is **lock
 
 ## Channels
 
-The **Channels** page is where you connect Omnipus to chat apps — Telegram, Discord, Slack, WhatsApp, Matrix, and more — so you can talk to your agents from the tools you already use. It's a single scrolling list, one card per channel, showing the transport it uses and whether it's enabled.
+The **Channels** page connects Omnipus to chat apps — Telegram, Discord, Slack, WhatsApp, Matrix, and more — as a single scrolling list, one card per channel. **Configure** opens a panel to enter the channel's credentials and pick its **Default agent** (which agent answers messages there); **Enable / Disable** turns it on or off. (Web Chat is always on.)
 
 ![The Channels page listing Telegram, Discord, Slack, WhatsApp and more](marketing/screenshots/channels-screen.png)
-*Every channel in one place. Each card shows its status and a Configure / Enable action.*
+*One card per channel — Configure to connect it and choose which agent answers.*
 
-Each card has two actions:
-
-- **Configure** — opens a panel to enter the channel's connection details and choose which agent answers it.
-- **Enable / Disable** — turns the channel on or off. (Web Chat — the in-app chat — is always on and has no Configure button.)
-
-Clicking **Configure** opens a slide-over with two sections:
-
-| Section | What it's for |
-|---------|--------------|
-| **Connection** | The channel's credentials and transport settings — e.g. a Telegram **Bot Token**, an allow-list of who may message the bot, a proxy or custom API URL. Each channel's [setup page](channels.md) tells you exactly where to get these values. Secrets are stored encrypted (in `credentials.json`), never in plain config. |
-| **Routing** | **Default agent** — which agent handles inbound messages on *this* channel. Leave it on **"(Global default)"** to use your globally-configured default agent (see [Managing agents](#managing-agents)), or pick a specific agent to dedicate this channel to it. |
-
-![The Configure panel for Telegram, showing Connection fields and the Routing section with a Default agent selector](marketing/screenshots/channel-configure-routing.png)
-*Configure a channel's connection and choose which agent answers it — all in one panel.*
-
-When you're done, click **Save & Enable** to save the settings and turn the channel on (or **Save** to keep it off for now). **Test** checks that the required fields are filled in.
-
-> **Which agent answers?** Routing resolves from most-specific to least: a per-user/peer rule, then a per-channel **Default agent** (set here), and finally your global **default agent** (the ★ on the Agents page). For the full set of routing rules — including per-user and per-group bindings — see [Routing](routing.md). For step-by-step credentials for each chat app, see [Connecting chat apps](channels.md).
+→ Full step-by-step, with per-platform credentials, routing, and screenshots: **[Channels](channels.md)**.
 
 ---
 


### PR DESCRIPTION
Reframes the Channels hub to be **UI-first**, matching how Omnipus is actually meant to be configured.

## Why
`docs/channels.md` (the page README → Channels lands on) led with a 1-line link to the app, then **~530 lines of `config.json` examples** and **zero screenshots**. For a UI-first product that's backwards — manual file editing read as the primary method.

## Change
- **Leads with "Configure a channel in the app"** (primary): embeds the **Channels screen** and **Configure-panel** screenshots, with the step-by-step — open **Channels** → **Configure** → **Connection** (paste credentials) + **Routing → Default agent** → **Save & Enable**.
- **Per-platform sections reframed** as *"where to get each platform's credentials"* to paste into Configure.
- **`config.json` is now explicitly the alternative** for headless/automated setups (the per-platform JSON snippets are kept as that reference).

## Notes
- Docs-only; no code. Screenshots already in the repo (`docs/marketing/screenshots/`).
- All embedded images + internal links/anchors verified.
- The in-app channel-credential **activation** is being completed in parallel (**#289**); this PR documents the intended UI-first flow it enables.
