### PR TITLE
Wave 2: channel secret-ref routing (#289)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,25 +180,20 @@ The lead (you) orchestrates all work by spawning specialized subagents via the A
 - **Full-stack features:** frontend-lead + backend-lead (parallel) → qa-lead
 - **Design questions:** architect
 
-### Review pipeline (run after implementation subagents complete)
+### Review pipeline — the 7-reviewer quality gate (MANDATORY)
 
-**Step 1 — Project-specific reviews (in parallel):**
-- Go files changed → `architect` for cross-cutting concerns
-- Frontend files changed → `architect` for integration coherence
-- Security files changed → `architect` for threat model review
+**This gate runs twice: after EACH completed feature (before its PR merges to its base branch) AND again on the WHOLE epic diff before the final `→ main` PR.** All seven must be clean (or every finding explicitly deferred with a tracked issue) before merging. This is a hard release rule, on par with Hard Constraint #7.
 
-**Step 2 — PR-review-toolkit (run ALL 6 in parallel, always):**
+**The 7 reviewers:**
 1. `pr-review-toolkit:code-reviewer` — CLAUDE.md compliance, bugs, quality
 2. `pr-review-toolkit:code-simplifier` — simplify for clarity and maintainability
 3. `pr-review-toolkit:comment-analyzer` — verify comment accuracy
 4. `pr-review-toolkit:pr-test-analyzer` — test coverage quality
 5. `pr-review-toolkit:silent-failure-hunter` — find silent failures, bad error handling
 6. `pr-review-toolkit:type-design-analyzer` — type/interface design quality
+7. **Architect pass via the `/grill-code` skill** — correctness, security, error handling, testing quality, observability, overcomplexity, and (when a spec/tasks exist) spec compliance + task completeness. Run `/grill-code` over the change as the 7th reviewer.
 
-**Step 3 — Resolve findings:**
-- Fix issues found by reviews (spawn the relevant implementing subagent to fix)
-- Re-run failed reviews after fixes
-- Only create PR when all reviews pass
+Run reviewers 1–6 in parallel; run the `/grill-code` architect pass (7) as its own read-only audit. **Resolve findings:** fix (spawn the relevant implementing subagent) or defer-with-issue; re-run any failed reviewer after fixes. Only open/merge the PR when all seven pass.
 
 ## Quality Gates
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -317,6 +317,15 @@ Review for:
 
 Be constructive and specific. "This could have a race condition if two goroutines call this concurrently — consider using a mutex here" is better than "this looks wrong".
 
+### Agent-assisted review gate (7 reviewers)
+
+When work is done with Claude Code, a **7-reviewer quality gate** runs over the change **after each completed feature and again on the whole epic** before the final merge — all seven must be clean or every finding deferred with a tracked issue:
+
+1–6. The `pr-review-toolkit` agents — code-reviewer, code-simplifier, comment-analyzer, pr-test-analyzer, silent-failure-hunter, type-design-analyzer.
+7. An **architect pass via the `/grill-code` skill** — correctness, security, error handling, testing quality, observability, overcomplexity, and spec/task compliance where a spec exists.
+
+See `CLAUDE.md` → "Review pipeline — the 7-reviewer quality gate" for the canonical definition.
+
 ---
 
 ## Communication

--- a/pkg/gateway/channel_secret_ref_test.go
+++ b/pkg/gateway/channel_secret_ref_test.go
@@ -1,0 +1,307 @@
+//go:build !cgo
+
+package gateway
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/dapicom-ai/omnipus/pkg/api/generated"
+	"github.com/dapicom-ai/omnipus/pkg/bus"
+	"github.com/dapicom-ai/omnipus/pkg/config"
+	"github.com/dapicom-ai/omnipus/pkg/credentials"
+)
+
+// newLockedStoreChannelAPI builds a channel API whose credential store is
+// present but NOT unlocked, so storeCredential / credentialRefResolves return
+// ErrStoreLocked — used to exercise the store-fault paths deterministically.
+func newLockedStoreChannelAPI(t *testing.T, configJSON string) *restAPI {
+	t.Helper()
+	tmpDir := t.TempDir()
+	require.NoError(t, os.WriteFile(tmpDir+"/config.json", []byte(configJSON), 0o600))
+	cfg := &config.Config{
+		Gateway: config.GatewayConfig{Host: "127.0.0.1", Port: 8080},
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{Workspace: tmpDir, ModelName: "test-model", MaxTokens: 4096},
+		},
+	}
+	al := mustAgentLoop(t, cfg, bus.NewMessageBus(), &restMockProvider{})
+	return &restAPI{
+		agentLoop:     al,
+		homePath:      tmpDir,
+		allowedOrigin: "http://localhost:3000",
+		credStore:     credentials.NewStore(tmpDir + "/credentials.json"), // locked
+	}
+}
+
+func newChannelTestAPI(t *testing.T, configJSON string) *restAPI {
+	t.Helper()
+	tmpDir := t.TempDir()
+	require.NoError(t, os.WriteFile(tmpDir+"/config.json", []byte(configJSON), 0o600))
+	cfg := &config.Config{
+		Gateway: config.GatewayConfig{Host: "127.0.0.1", Port: 8080},
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{Workspace: tmpDir, ModelName: "test-model", MaxTokens: 4096},
+		},
+	}
+	al := mustAgentLoop(t, cfg, bus.NewMessageBus(), &restMockProvider{})
+	return newOnboardingTestAPI(t, tmpDir, al)
+}
+
+// TestConfigureChannel_RoutesSecretToCredentialStore is the core #289 guard:
+// configuring a token-based channel via the UI must store the secret in the
+// encrypted credential store and persist only its <field>_ref in config.json —
+// never the plaintext (SEC-23) — and "Test" must then report success.
+func TestConfigureChannel_RoutesSecretToCredentialStore(t *testing.T) {
+	api := newChannelTestAPI(t, `{"version":1,"agents":{"defaults":{},"list":[]},"providers":[],"channels":{}}`)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPut, "/api/v1/channels/telegram/configure",
+		strings.NewReader(`{"token":"super-secret-123"}`))
+	r.Header.Set("Content-Type", "application/json")
+	api.configureChannel(w, r, "telegram")
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	// 1. The plaintext secret must NOT appear anywhere in config.json (SEC-23).
+	raw, err := os.ReadFile(api.homePath + "/config.json")
+	require.NoError(t, err)
+	assert.NotContains(t, string(raw), "super-secret-123", "plaintext token leaked into config.json")
+
+	// 2. token_ref must be set to the conventional credential name; no inline token.
+	var diskCfg map[string]any
+	require.NoError(t, json.Unmarshal(raw, &diskCfg))
+	tg := diskCfg["channels"].(map[string]any)["telegram"].(map[string]any)
+	assert.Equal(t, "channel_telegram_token", tg["token_ref"])
+	_, hasInline := tg["token"]
+	assert.False(t, hasInline, "inline token must not be persisted to config.json")
+
+	// 3. The secret must be retrievable from the credential store.
+	got, err := api.credStore.Get("channel_telegram_token")
+	require.NoError(t, err)
+	assert.Equal(t, "super-secret-123", got)
+
+	// 4. testChannel now reports success because the ref resolves.
+	w2 := httptest.NewRecorder()
+	api.testChannel(w2, "telegram")
+	require.Equal(t, http.StatusOK, w2.Code)
+	var resp gen.ChannelTestResponse
+	require.NoError(t, json.Unmarshal(w2.Body.Bytes(), &resp))
+	assert.True(t, resp.Success, "test should pass once the credential is stored: %s", resp.Message)
+}
+
+// TestConfigureChannel_MultiSecretChannel covers a channel with two secret
+// fields (slack: bot_token + app_token) — both must be routed to refs.
+func TestConfigureChannel_MultiSecretChannel(t *testing.T) {
+	api := newChannelTestAPI(t, `{"version":1,"agents":{"defaults":{},"list":[]},"providers":[],"channels":{}}`)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPut, "/api/v1/channels/slack/configure",
+		strings.NewReader(`{"bot_token":"xoxb-aaa","app_token":"xapp-bbb"}`))
+	r.Header.Set("Content-Type", "application/json")
+	api.configureChannel(w, r, "slack")
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	raw, err := os.ReadFile(api.homePath + "/config.json")
+	require.NoError(t, err)
+	assert.NotContains(t, string(raw), "xoxb-aaa")
+	assert.NotContains(t, string(raw), "xapp-bbb")
+
+	for field, want := range map[string]string{"bot_token": "xoxb-aaa", "app_token": "xapp-bbb"} {
+		got, err := api.credStore.Get("channel_slack_" + field)
+		require.NoError(t, err, "field %s", field)
+		assert.Equal(t, want, got, "field %s", field)
+	}
+}
+
+// TestTestChannel_FailsWhenSecretMissing confirms "Test" reports failure (not a
+// false success) when a required secret has no stored credential — the exact
+// lie #289 set out to fix.
+func TestTestChannel_FailsWhenSecretMissing(t *testing.T) {
+	api := newChannelTestAPI(t,
+		`{"version":1,"agents":{"defaults":{},"list":[]},"providers":[],"channels":{"telegram":{"enabled":false}}}`)
+
+	w := httptest.NewRecorder()
+	api.testChannel(w, "telegram")
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp gen.ChannelTestResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.False(t, resp.Success, "test must fail when the token credential is absent")
+	assert.Contains(t, resp.Message, "token")
+}
+
+// TestConfigureChannel_ScrubsStaleInlinePlaintext is the key security-remediation
+// guard: a config left with an inline plaintext secret by the pre-#289 bug must
+// be scrubbed on the next save — even when the user edits an UNRELATED field and
+// does not re-supply the secret (the realistic "[configured]" UI flow).
+func TestConfigureChannel_ScrubsStaleInlinePlaintext(t *testing.T) {
+	api := newChannelTestAPI(
+		t,
+		`{"version":1,"agents":{"defaults":{},"list":[]},"providers":[],"channels":{"telegram":{"enabled":false,"token":"LEAKED-OLD-PLAINTEXT","parse_mode":"Markdown"}}}`,
+	)
+
+	// Edit only a non-secret field; do NOT re-send the token.
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPut, "/api/v1/channels/telegram/configure",
+		strings.NewReader(`{"parse_mode":"HTML"}`))
+	r.Header.Set("Content-Type", "application/json")
+	api.configureChannel(w, r, "telegram")
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	raw, err := os.ReadFile(api.homePath + "/config.json")
+	require.NoError(t, err)
+	assert.NotContains(t, string(raw), "LEAKED-OLD-PLAINTEXT", "stale inline plaintext survived the save (SEC-23)")
+
+	var diskCfg map[string]any
+	require.NoError(t, json.Unmarshal(raw, &diskCfg))
+	tg := diskCfg["channels"].(map[string]any)["telegram"].(map[string]any)
+	_, hasInline := tg["token"]
+	assert.False(t, hasInline, "stale inline token key must be removed")
+	assert.Equal(t, "HTML", tg["parse_mode"], "the unrelated edit must still apply")
+}
+
+// TestConfigureChannel_ClearSecretDeletesCredential covers the clear/rotate path:
+// re-configuring with an empty value clears the ref AND deletes the stored
+// credential so a "removed" token does not linger encrypted at rest.
+func TestConfigureChannel_ClearSecretDeletesCredential(t *testing.T) {
+	api := newChannelTestAPI(t, `{"version":1,"agents":{"defaults":{},"list":[]},"providers":[],"channels":{}}`)
+
+	// Set a token, then clear it.
+	for _, body := range []string{`{"token":"secret-1"}`, `{"token":"   "}`} {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodPut, "/api/v1/channels/telegram/configure", strings.NewReader(body))
+		r.Header.Set("Content-Type", "application/json")
+		api.configureChannel(w, r, "telegram")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	}
+
+	// Ref cleared in config; credential gone from the store.
+	raw, err := os.ReadFile(api.homePath + "/config.json")
+	require.NoError(t, err)
+	var diskCfg map[string]any
+	require.NoError(t, json.Unmarshal(raw, &diskCfg))
+	tg := diskCfg["channels"].(map[string]any)["telegram"].(map[string]any)
+	assert.Equal(t, "", tg["token_ref"], "token_ref must be cleared")
+	_, err = api.credStore.Get("channel_telegram_token")
+	assert.Error(t, err, "the stored credential must be deleted on clear")
+
+	// Test now reports failure (the channel is unconfigured again).
+	w := httptest.NewRecorder()
+	api.testChannel(w, "telegram")
+	var resp gen.ChannelTestResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.False(t, resp.Success)
+}
+
+// TestTestChannel_MatrixMixedRequiredFields locks in the inline-vs-ref
+// discrimination: matrix requires homeserver + user_id (non-secret, inline) AND
+// access_token (secret, ref). Both kinds must be validated in their own way.
+func TestTestChannel_MatrixMixedRequiredFields(t *testing.T) {
+	// access_token routed to a stored ref; homeserver + user_id inline.
+	api := newChannelTestAPI(
+		t,
+		`{"version":1,"agents":{"defaults":{},"list":[]},"providers":[],"channels":{"matrix":{"enabled":false,"homeserver":"https://m.org","user_id":"@a:m.org","access_token_ref":"channel_matrix_access_token"}}}`,
+	)
+	_, err := api.storeCredential("channel_matrix_access_token", "syt-token")
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	api.testChannel(w, "matrix")
+	var resp gen.ChannelTestResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.True(t, resp.Success, "all required fields present (inline + ref): %s", resp.Message)
+
+	// Drop the non-secret user_id → Test must fail on the inline field.
+	api2 := newChannelTestAPI(
+		t,
+		`{"version":1,"agents":{"defaults":{},"list":[]},"providers":[],"channels":{"matrix":{"enabled":false,"homeserver":"https://m.org","access_token_ref":"channel_matrix_access_token"}}}`,
+	)
+	_, err = api2.storeCredential("channel_matrix_access_token", "syt-token")
+	require.NoError(t, err)
+	w2 := httptest.NewRecorder()
+	api2.testChannel(w2, "matrix")
+	var resp2 gen.ChannelTestResponse
+	require.NoError(t, json.Unmarshal(w2.Body.Bytes(), &resp2))
+	assert.False(t, resp2.Success)
+	assert.Contains(t, resp2.Message, "user_id")
+}
+
+// TestGetChannelConfig_ShowsConfiguredMarker guards MAJ-001: after the secret
+// moves to the credential store (only token_ref in config), GET must still show
+// the "[configured]" marker so the UI knows a secret is set — never the secret.
+func TestGetChannelConfig_ShowsConfiguredMarker(t *testing.T) {
+	api := newChannelTestAPI(t, `{"version":1,"agents":{"defaults":{},"list":[]},"providers":[],"channels":{}}`)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPut, "/api/v1/channels/telegram/configure",
+		strings.NewReader(`{"token":"super-secret-123"}`))
+	r.Header.Set("Content-Type", "application/json")
+	api.configureChannel(w, r, "telegram")
+	require.Equal(t, http.StatusOK, w.Code)
+
+	w2 := httptest.NewRecorder()
+	api.getChannelConfig(w2, "telegram")
+	require.Equal(t, http.StatusOK, w2.Code)
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(w2.Body.Bytes(), &got))
+	assert.Equal(t, "[configured]", got["token"], "GET must show the configured marker via the ref")
+	assert.NotContains(t, w2.Body.String(), "super-secret-123", "GET must never echo the secret")
+}
+
+// TestConfigureChannel_RejectsNonStringSecret guards MIN-002: a non-string
+// secret value must be rejected, not silently treated as a clear (which would
+// revoke a working credential).
+func TestConfigureChannel_RejectsNonStringSecret(t *testing.T) {
+	api := newChannelTestAPI(t, `{"version":1,"agents":{"defaults":{},"list":[]},"providers":[],"channels":{}}`)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPut, "/api/v1/channels/telegram/configure",
+		strings.NewReader(`{"token":12345}`))
+	r.Header.Set("Content-Type", "application/json")
+	api.configureChannel(w, r, "telegram")
+	assert.Equal(t, http.StatusBadRequest, w.Code, "non-string secret must be rejected")
+}
+
+// TestConfigureChannel_StoreFaultFailsClosed guards MIN-001: when the credential
+// store is unavailable (locked), configure must fail with 500 and NOT modify
+// config.json — no ref written, no plaintext written (fail-closed).
+func TestConfigureChannel_StoreFaultFailsClosed(t *testing.T) {
+	api := newLockedStoreChannelAPI(t, `{"version":1,"agents":{"defaults":{},"list":[]},"providers":[],"channels":{}}`)
+	before, err := os.ReadFile(api.homePath + "/config.json")
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPut, "/api/v1/channels/telegram/configure",
+		strings.NewReader(`{"token":"secret-x"}`))
+	r.Header.Set("Content-Type", "application/json")
+	api.configureChannel(w, r, "telegram")
+	assert.Equal(t, http.StatusInternalServerError, w.Code, "store fault must fail the request")
+
+	after, err := os.ReadFile(api.homePath + "/config.json")
+	require.NoError(t, err)
+	assert.Equal(t, string(before), string(after), "config.json must be unchanged on store fault (fail-closed)")
+	assert.NotContains(t, string(after), "secret-x")
+}
+
+// TestTestChannel_StoreUnavailableIsDistinct guards MIN-001 + the (bool,error)
+// contract: a locked store must report "credential store unavailable", NOT a
+// misleading "missing token", so the user isn't told to re-enter a present secret.
+func TestTestChannel_StoreUnavailableIsDistinct(t *testing.T) {
+	api := newLockedStoreChannelAPI(
+		t,
+		`{"version":1,"agents":{"defaults":{},"list":[]},"providers":[],"channels":{"telegram":{"enabled":false,"token_ref":"channel_telegram_token"}}}`,
+	)
+
+	w := httptest.NewRecorder()
+	api.testChannel(w, "telegram")
+	var resp gen.ChannelTestResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.False(t, resp.Success)
+	assert.Contains(t, resp.Message, "unavailable", "store fault must be reported distinctly, not as 'missing'")
+	assert.NotContains(t, resp.Message, "missing")
+}

--- a/pkg/gateway/rest.go
+++ b/pkg/gateway/rest.go
@@ -1929,6 +1929,64 @@ func (a *restAPI) storeCredential(refName, apiKey string) (string, error) {
 	return refName, nil
 }
 
+// channelCredKey is the credential-store key for a channel's secret field. The
+// format is opaque to readers (channel constructors resolve secrets via the
+// config <field>_ref, never by reconstructing this key); it exists so the
+// producer side has a single definition.
+func channelCredKey(channelID, field string) string {
+	return "channel_" + channelID + "_" + field
+}
+
+// removeStoredCredential removes refName from the credential store. A missing
+// entry is not an error — clearing a never-set secret is legitimate. (Distinct
+// from the deleteCredential REST handler, which writes an HTTP response.)
+func (a *restAPI) removeStoredCredential(refName string) error {
+	store := a.credStore
+	if store == nil {
+		store = credentials.NewStore(a.credentialsStorePath())
+		if err := credentials.Unlock(store); err != nil {
+			return fmt.Errorf("credential store locked: %w", err)
+		}
+	}
+	if err := store.Delete(refName); err != nil {
+		var nf *credentials.NotFoundError
+		if errors.As(err, &nf) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+// credentialRefResolves reports whether refName names a non-empty secret in the
+// credential store. Used by testChannel (#289). The returned error is non-nil
+// only for store-access faults (locked / wrong master key / I/O) — distinct from
+// a genuinely absent secret, which returns (false, nil). The caller MUST surface
+// a store fault separately rather than reporting the field as "missing", or
+// "Test" would tell the user to re-enter a secret that is already correct.
+func (a *restAPI) credentialRefResolves(refName string) (bool, error) {
+	refName = strings.TrimSpace(refName)
+	if refName == "" {
+		return false, nil // genuinely not configured
+	}
+	store := a.credStore
+	if store == nil {
+		store = credentials.NewStore(a.credentialsStorePath())
+		if err := credentials.Unlock(store); err != nil {
+			return false, fmt.Errorf("credential store locked: %w", err)
+		}
+	}
+	v, err := store.Get(refName)
+	if err != nil {
+		var nf *credentials.NotFoundError
+		if errors.As(err, &nf) {
+			return false, nil // truly absent
+		}
+		return false, err // locked / wrong key / I/O — surface to the caller
+	}
+	return strings.TrimSpace(v) != "", nil
+}
+
 // safeUpdateConfigJSON reads config.json, applies a mutation function on the raw JSON map,
 // and writes it back atomically. This preserves SecureStrings (API keys) that would be
 // destroyed by config.SaveConfig's JSON round-trip through the Go struct.
@@ -4272,17 +4330,25 @@ var channelRequiredFields = map[string][]string{
 	"whatsapp": {},
 }
 
-// redactChannelConfig returns a copy of cfg with sensitive fields replaced by "[configured]"
-// (if non-empty) or "" (if empty).
+// redactChannelConfig returns a copy of cfg with sensitive fields replaced by a
+// "[configured]" marker (never the real secret). Post-#289 the secret lives in
+// the credential store and config holds only <field>_ref, so the marker is
+// driven by the presence of the ref — this preserves the UI's
+// secret-already-set indicator (the inline field is no longer present).
 func redactChannelConfig(channelID string, cfg map[string]any) map[string]any {
 	out := make(map[string]any, len(cfg))
 	for k, v := range cfg {
 		out[k] = v
 	}
 	for _, field := range channelSensitiveFields[channelID] {
+		// A set <field>_ref means a credential is stored → mark configured.
+		if ref, _ := out[field+"_ref"].(string); strings.TrimSpace(ref) != "" {
+			out[field] = "[configured]"
+			continue
+		}
+		// Legacy/pre-scrub inline value (should be transient): mask, never echo.
 		if v, ok := out[field]; ok {
-			s, _ := v.(string)
-			if s != "" {
+			if s, _ := v.(string); s != "" {
 				out[field] = "[configured]"
 			} else {
 				out[field] = ""
@@ -4316,6 +4382,43 @@ func (a *restAPI) configureChannel(w http.ResponseWriter, r *http.Request, chann
 	// Remove reserved fields that must not be set here.
 	delete(updates, "enabled")
 
+	// SEC-23 / #289: route secret fields into the encrypted credential store and
+	// persist only their <field>_ref in config.json. Every channel constructor
+	// reads its secret via the *_ref (e.g. token_ref); an inline plaintext secret
+	// is both a plaintext-at-rest violation AND unreadable by the constructor —
+	// so a UI-configured token-based channel would never start.
+	var clearedRefs []string // credentials to delete AFTER the config write commits
+	for _, field := range channelSensitiveFields[channelID] {
+		raw, present := updates[field]
+		if !present {
+			continue
+		}
+		delete(updates, field) // never persist the inline plaintext
+		refField := field + "_ref"
+		refName := channelCredKey(channelID, field)
+		secret, isStr := raw.(string)
+		if !isStr && raw != nil {
+			// A non-string, non-null secret (e.g. {"token": 123}) would collapse to
+			// "" and be misread as a clear — reject it instead of silently revoking.
+			jsonErr(w, http.StatusBadRequest, fmt.Sprintf("%s must be a string", field))
+			return
+		}
+		if strings.TrimSpace(secret) == "" {
+			// Clearing: drop the ref now, but delete the stored credential only
+			// AFTER the config write commits (below). Deleting first would strand
+			// the channel pointing at a missing credential if the config write fails.
+			updates[refField] = ""
+			clearedRefs = append(clearedRefs, refName)
+			continue
+		}
+		if _, err := a.storeCredential(refName, secret); err != nil {
+			slog.Error("rest: store channel credential", "channel", channelID, "field", field, "error", err)
+			jsonErr(w, http.StatusInternalServerError, fmt.Sprintf("could not store %s credential: %v", field, err))
+			return
+		}
+		updates[refField] = refName
+	}
+
 	var updatedCh map[string]any
 	if err := a.safeUpdateConfigJSON(func(m map[string]any) error {
 		channels, _ := m["channels"].(map[string]any)
@@ -4330,6 +4433,12 @@ func (a *restAPI) configureChannel(w http.ResponseWriter, r *http.Request, chann
 		for k, v := range updates {
 			ch[k] = v
 		}
+		// Invariant (#289/SEC-23): a known secret field is never stored inline in
+		// config.json — it lives only in the credential store via its <field>_ref.
+		// This also scrubs any stale plaintext left by the pre-#289 blind merge.
+		for _, field := range channelSensitiveFields[channelID] {
+			delete(ch, field)
+		}
 		channels[channelID] = ch
 		updatedCh = ch
 		return nil
@@ -4337,6 +4446,15 @@ func (a *restAPI) configureChannel(w http.ResponseWriter, r *http.Request, chann
 		slog.Error("rest: configure channel", "channel", channelID, "error", err)
 		jsonErr(w, http.StatusInternalServerError, fmt.Sprintf("could not save config: %v", err))
 		return
+	}
+
+	// Config (with cleared refs) is durable now — delete the now-unreferenced
+	// credentials. A failure here only leaves an orphaned encrypted blob (the ref
+	// is already gone), so log rather than fail the already-committed request.
+	for _, refName := range clearedRefs {
+		if err := a.removeStoredCredential(refName); err != nil {
+			slog.Error("rest: delete cleared channel credential", "channel", channelID, "ref", refName, "error", err)
+		}
 	}
 	jsonOK(w, redactChannelConfig(channelID, updatedCh))
 }
@@ -4352,13 +4470,37 @@ func (a *restAPI) testChannel(w http.ResponseWriter, channelID string) {
 	}
 
 	required := channelRequiredFields[channelID]
+	sensitive := make(map[string]bool, len(channelSensitiveFields[channelID]))
+	for _, f := range channelSensitiveFields[channelID] {
+		sensitive[f] = true
+	}
 	var missing []string
 	for _, field := range required {
-		if v, vOk := chCfg[field].(string); vOk {
-			if v == "" {
+		if sensitive[field] {
+			// #289: a secret required field is satisfied by its <field>_ref
+			// resolving in the credential store, NOT by an inline value — the
+			// secret never lives in config.json. Checking the inline field here
+			// (the old behavior) made "Test" report success for channels that
+			// could never activate.
+			ref, _ := chCfg[field+"_ref"].(string)
+			ok, err := a.credentialRefResolves(ref)
+			if err != nil {
+				// Store fault (locked / wrong key / I/O) — distinct from a missing
+				// secret. Reporting it as "missing" would tell the user to re-enter
+				// a credential that is already correct, so surface it as its own state.
+				slog.Error("rest: channel test credential check", "channel", channelID, "field", field, "error", err)
+				jsonOK(w, gen.ChannelTestResponse{
+					Success: false,
+					Message: "credential store unavailable — unlock it (set OMNIPUS_MASTER_KEY) and retry",
+				})
+				return
+			}
+			if !ok {
 				missing = append(missing, field)
 			}
-		} else {
+			continue
+		}
+		if v, vOk := chCfg[field].(string); !vOk || v == "" {
 			missing = append(missing, field)
 		}
 	}


### PR DESCRIPTION
## Summary

Wave-2 of the v0.1.0 stabilization (epic #280). Fixes **#289** — the Channels UI stored secrets inline, so 9 token-based channels never activated and plaintext secrets were written to `config.json` (SEC-23). Targets `hotfix/v0.1.0`.

`configureChannel` now routes each `channelSensitiveFields[channelID]` value into the encrypted credential store (`storeCredential(channel_<id>_<field>)`) and persists only `<field>_ref`; the inline plaintext is never written and any stale plaintext left by the old blind-merge is scrubbed on save. `testChannel` validates secret-backed required fields by resolving the ref (and now reports a store fault as *"credential store unavailable"* rather than the misleading *"missing"*). `redactChannelConfig` keeps the UI's `[configured]` indicator working off the ref. Clearing a secret deletes the stored credential — but only **after** the config write commits, so a failed write can't strand a channel pointing at a deleted credential.

## Quality gate

Full **7-reviewer gate** (6 `pr-review-toolkit` + `/grill-code` architect). It caught real issues across two rounds — the `credentialRefResolves` store-fault/absent conflation (a sibling of the original bug), the destructive-before-durable clear path, and the GET `[configured]` UI-contract regression — all fixed. Green: `golangci-lint` 0 issues, full `pkg/gateway` suite passes, build clean.

## Tests (10)

secret routed + only the ref in `config.json` (SEC-23); multi-secret channel; stale inline-plaintext scrubbed on an unrelated edit; clear deletes the credential + clears the ref; matrix mixed inline/ref required fields; `[configured]` marker via GET; non-string secret rejected (400); store-fault fails closed (config unchanged); Test reports store "unavailable" distinctly.

## Issues

Relates to #289. Closing keyword omitted — fires on the eventual `hotfix/v0.1.0 → main` merge.

## Follow-up

Google-Chat Configure-panel wiring (no UI descriptors today) remains a separate follow-up per the issue.
