### PR TITLE
v0.1.0 stabilization → main: #96, #255, #265, #73, #289

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,25 +180,20 @@ The lead (you) orchestrates all work by spawning specialized subagents via the A
 - **Full-stack features:** frontend-lead + backend-lead (parallel) → qa-lead
 - **Design questions:** architect
 
-### Review pipeline (run after implementation subagents complete)
+### Review pipeline — the 7-reviewer quality gate (MANDATORY)
 
-**Step 1 — Project-specific reviews (in parallel):**
-- Go files changed → `architect` for cross-cutting concerns
-- Frontend files changed → `architect` for integration coherence
-- Security files changed → `architect` for threat model review
+**This gate runs twice: after EACH completed feature (before its PR merges to its base branch) AND again on the WHOLE epic diff before the final `→ main` PR.** All seven must be clean (or every finding explicitly deferred with a tracked issue) before merging. This is a hard release rule, on par with Hard Constraint #7.
 
-**Step 2 — PR-review-toolkit (run ALL 6 in parallel, always):**
+**The 7 reviewers:**
 1. `pr-review-toolkit:code-reviewer` — CLAUDE.md compliance, bugs, quality
 2. `pr-review-toolkit:code-simplifier` — simplify for clarity and maintainability
 3. `pr-review-toolkit:comment-analyzer` — verify comment accuracy
 4. `pr-review-toolkit:pr-test-analyzer` — test coverage quality
 5. `pr-review-toolkit:silent-failure-hunter` — find silent failures, bad error handling
 6. `pr-review-toolkit:type-design-analyzer` — type/interface design quality
+7. **Architect pass via the `/grill-code` skill** — correctness, security, error handling, testing quality, observability, overcomplexity, and (when a spec/tasks exist) spec compliance + task completeness. Run `/grill-code` over the change as the 7th reviewer.
 
-**Step 3 — Resolve findings:**
-- Fix issues found by reviews (spawn the relevant implementing subagent to fix)
-- Re-run failed reviews after fixes
-- Only create PR when all reviews pass
+Run reviewers 1–6 in parallel; run the `/grill-code` architect pass (7) as its own read-only audit. **Resolve findings:** fix (spawn the relevant implementing subagent) or defer-with-issue; re-run any failed reviewer after fixes. Only open/merge the PR when all seven pass.
 
 ## Quality Gates
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,11 @@ When filing or triaging GitHub issues, follow `docs/internal/issue-and-board-con
 - **Labels are cross-cutting only**: `priority:*` (one), `area:*` (one+), plus `security`/`tech-debt`/`test-coverage`/`documentation`. The `type:*` labels are **PR/changelog only** (release-drafter) — never put them on issues.
 - **Board #3 automation does the rote work**: new issues auto-add as `Backlog`; closing auto-sets `Done`. Do **not** manually add issues to the board or hand-set initial/`Done` status. You do set **Sprint** (single-select) and promote Status as work proceeds.
 - **Bundle related work** under an **Epic** with real sub-issues (`addSubIssue`); sprints are an Epic + its sub-issues sharing one Sprint value.
+- **Every PR MUST close its issues via keyword (mandatory).** A PR that resolves issues MUST list a closing keyword **per issue** in the **PR description** (not just commit messages) — e.g. `Closes #264, closes #289, closes #283`. This is non-negotiable: the only acceptable reason an issue stays open after its fix merges is that the work genuinely isn't done. Rules that bite us:
+  - **Repeat the keyword for each issue.** `Closes #1, #2` only closes `#1`. Write `Closes #1, closes #2`. Keywords: `close[s|d]` / `fix[es|ed]` / `resolve[s|d]`.
+  - **Auto-close only fires when the PR merges into the *default* branch (`main`).** A PR merged into a non-default base (e.g. a release/hotfix branch) links but does **not** close — the closure happens when that branch later merges to `main`, and only if the keywords ride along in that merge's PR body. Target `main` whenever you want the issues closed on merge.
+  - **Put keywords in the PR *description*, not only commit messages.** On squash-merge, commit-message keywords are unreliable; the PR body is what GitHub honors. (This is why Sprint #258 / PR #292 left 8 issues open despite shipping their fixes.)
+  - If a PR can't use auto-close (non-`main` base), it MUST still reference every issue it resolves, and whoever merges is responsible for closing them with a comment citing the PR.
 
 ## Subagent Workflow
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -317,6 +317,15 @@ Review for:
 
 Be constructive and specific. "This could have a race condition if two goroutines call this concurrently — consider using a mutex here" is better than "this looks wrong".
 
+### Agent-assisted review gate (7 reviewers)
+
+When work is done with Claude Code, a **7-reviewer quality gate** runs over the change **after each completed feature and again on the whole epic** before the final merge — all seven must be clean or every finding deferred with a tracked issue:
+
+1–6. The `pr-review-toolkit` agents — code-reviewer, code-simplifier, comment-analyzer, pr-test-analyzer, silent-failure-hunter, type-design-analyzer.
+7. An **architect pass via the `/grill-code` skill** — correctness, security, error handling, testing quality, observability, overcomplexity, and spec/task compliance where a spec exists.
+
+See `CLAUDE.md` → "Review pipeline — the 7-reviewer quality gate" for the canonical definition.
+
 ---
 
 ## Communication

--- a/docs/internal/issue-and-board-conventions.md
+++ b/docs/internal/issue-and-board-conventions.md
@@ -109,10 +109,29 @@ gh api graphql -f query='mutation{addSubIssue(input:{issueId:"'"$PARENT"'",subIs
 
 Sprints are tracked this way: a Sprint epic with its work items as sub-issues, all assigned to the same **Sprint** field value.
 
+## Closing issues via PRs (mandatory)
+
+**Every PR that resolves issues MUST auto-close them on merge via closing keywords.** Issues do not get closed by hand after a fix ships — the PR closes them. The only acceptable reason an issue stays open after its fixing PR merges is that the work genuinely isn't complete.
+
+Put the keywords in the **PR description** (the body), with **one keyword per issue**:
+
+```
+Closes #264, closes #289, closes #283
+```
+
+Three rules that GitHub enforces — get any of them wrong and the issues silently stay open:
+
+1. **One keyword per issue.** `Closes #264, #289` closes only `#264`; the rest are merely linked. Repeat the keyword: `Closes #264, closes #289`. Valid keywords: `close` / `closes` / `closed`, `fix` / `fixes` / `fixed`, `resolve` / `resolves` / `resolved`.
+2. **Auto-close fires only when the PR merges into the *default* branch (`main`).** A PR merged into a non-default base (a release or `hotfix/*` branch) **links but does not close**. Closure then happens when that branch later merges to `main` — and only if the closing keywords are present in *that* merge's PR body. If you want the issues closed on this merge, target `main`.
+3. **Keywords belong in the PR *description*, not only commit messages.** On **squash-merge** the commit-message keywords are unreliable; only the PR body is honored. (Real example: Sprint #258 / PR #292 shipped fixes for 8 issues but left them all open because the squash-merge omitted body-level keywords — they had to be closed manually afterward.)
+
+If a PR genuinely can't auto-close (e.g. it must merge into a non-`main` base), it MUST still reference every issue it resolves, and whoever performs the eventual `main` merge is responsible for ensuring the keywords carry through — or closing the issues manually with a comment citing the PR.
+
 ## Quick don't-list
 
 - ❌ Don't use `bug` / `enhancement` labels — they're retired; set the **Type**.
 - ❌ Don't put `type:*` labels on issues — those are PR/changelog only.
 - ❌ Don't manually add issues to the board or set initial/`Done` status — automation does it.
 - ❌ Don't encode "kind" in both a label and the Type — Type is authoritative.
+- ❌ Don't open a PR that resolves issues without `Closes #N` (one keyword per issue) in the **PR body** — and remember auto-close only fires on merge to `main`.
 - ✅ Do set: Type (exactly one), a priority label, an area label, and a milestone when confident.

--- a/pkg/agent/apply_agent_model_test.go
+++ b/pkg/agent/apply_agent_model_test.go
@@ -1,0 +1,126 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/dapicom-ai/omnipus/pkg/bus"
+	"github.com/dapicom-ai/omnipus/pkg/config"
+	"github.com/dapicom-ai/omnipus/pkg/providers"
+)
+
+// TestApplyAgentModel_SwitchesInPlacePreservingInstance guards #73: a model
+// change must update the LIVE agent instance (model + provider + candidates)
+// without replacing the instance, so the in-memory conversation context is
+// preserved and the change takes effect on the next turn — no hot-reload, no
+// WebSocket drop.
+func TestApplyAgentModel_SwitchesInPlacePreservingInstance(t *testing.T) {
+	t.Setenv("LOOP_APPLY_LOCAL_KEY", "local-key")
+	t.Setenv("LOOP_APPLY_REMOTE_KEY", "remote-key")
+
+	cfg := &config.Config{
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{
+				Workspace:         t.TempDir(),
+				Provider:          "openai",
+				ModelName:         "local",
+				MaxTokens:         4096,
+				MaxToolIterations: 10,
+			},
+		},
+		Providers: []*config.ModelConfig{
+			{
+				ModelName: "local",
+				Model:     "openai/qwen",
+				APIBase:   "http://127.0.0.1:1",
+				APIKeyRef: "LOOP_APPLY_LOCAL_KEY",
+			},
+			{
+				ModelName: "deepseek",
+				Model:     "openrouter/deepseek",
+				APIBase:   "http://127.0.0.1:1",
+				APIKeyRef: "LOOP_APPLY_REMOTE_KEY",
+			},
+		},
+	}
+
+	provider, _, err := providers.CreateProvider(cfg)
+	if err != nil {
+		t.Fatalf("CreateProvider: %v", err)
+	}
+	al := mustNewAgentLoop(t, cfg, bus.NewMessageBus(), provider)
+
+	before := al.GetRegistry().GetDefaultAgent()
+	if before == nil {
+		t.Fatal("no default agent")
+	}
+	id := before.ID
+	if before.Model != "local" {
+		t.Fatalf("initial model = %q, want local", before.Model)
+	}
+	beforeProvider := before.Provider
+
+	old, err := al.ApplyAgentModel(id, "deepseek")
+	if err != nil {
+		t.Fatalf("ApplyAgentModel: %v", err)
+	}
+	if old != "local" {
+		t.Errorf("returned previous model = %q, want local", old)
+	}
+
+	after, ok := al.GetRegistry().GetAgent(id)
+	if !ok {
+		t.Fatal("agent vanished after ApplyAgentModel")
+	}
+	if after != before {
+		t.Error("agent instance was replaced — in-memory conversation context would be lost (#73)")
+	}
+	if after.Model != "deepseek" {
+		t.Errorf("model after switch = %q, want deepseek", after.Model)
+	}
+	if after.Provider == beforeProvider {
+		t.Error("provider was not switched to the new model's provider")
+	}
+}
+
+// TestApplyAgentModel_UnknownModelRejectedNoMutation confirms an invalid model
+// is rejected and leaves the instance untouched (no half-applied state).
+func TestApplyAgentModel_UnknownModelRejectedNoMutation(t *testing.T) {
+	t.Setenv("LOOP_APPLY2_KEY", "k")
+
+	cfg := &config.Config{
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{
+				Workspace:         t.TempDir(),
+				Provider:          "openai",
+				ModelName:         "local",
+				MaxTokens:         4096,
+				MaxToolIterations: 10,
+			},
+		},
+		Providers: []*config.ModelConfig{
+			{ModelName: "local", Model: "openai/qwen", APIBase: "http://127.0.0.1:1", APIKeyRef: "LOOP_APPLY2_KEY"},
+		},
+	}
+
+	provider, _, err := providers.CreateProvider(cfg)
+	if err != nil {
+		t.Fatalf("CreateProvider: %v", err)
+	}
+	al := mustNewAgentLoop(t, cfg, bus.NewMessageBus(), provider)
+	id := al.GetRegistry().GetDefaultAgent().ID
+
+	if _, err := al.ApplyAgentModel(id, "does-not-exist"); err == nil {
+		t.Fatal("expected error for unknown model, got nil")
+	}
+	after, _ := al.GetRegistry().GetAgent(id)
+	if after.Model != "local" {
+		t.Errorf("model = %q after failed switch; want unchanged 'local'", after.Model)
+	}
+
+	if _, err := al.ApplyAgentModel(id, "   "); err == nil {
+		t.Error("expected error for empty model")
+	}
+	if _, err := al.ApplyAgentModel("no-such-agent", "local"); err == nil {
+		t.Error("expected error for unknown agent id")
+	}
+}

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -215,6 +215,19 @@ type AgentLoop struct {
 	// LoadOrStore ensures only one goroutine triggers recap per session.
 	claimedCloseSessions sync.Map // sessionID (string) → true
 
+	// Session-end recap drain (#265). Recap goroutines (CloseSession → runRecap)
+	// write LAST_SESSION.md / retro files and emit audit entries in the
+	// background. Close() drains them (recapWG.Wait) BEFORE it tears down the
+	// registry, session stores, and audit logger they write through, so the
+	// recaps both complete and finish writing before shutdown returns — leaving
+	// them detached races the temp-dir cleanup in tests. recapMu+closing gate
+	// scheduling so a recap can never be Added after the drain begins (no
+	// WaitGroup Add-after-Wait). Recaps are not canceled; each self-bounds at
+	// 60s and shares the 70s graceful-shutdown budget with the active-turn wait.
+	recapMu sync.Mutex
+	closing bool
+	recapWG sync.WaitGroup
+
 	// stopCancel is the CancelFunc created by Run to support Stop(). When
 	// Stop() is called it cancels this func so the Run select wakes
 	// immediately without waiting for the next message or ticker. Stored
@@ -1569,7 +1582,13 @@ func (al *AgentLoop) Run(ctx context.Context) error {
 
 			// System messages are handled inline in a goroutine (no scope).
 			if msg.Channel == "system" {
+				// Track in activeRequests so graceful shutdown's
+				// WaitForActiveRequests drains this turn before teardown —
+				// otherwise its cost.json / session-context writes can outlive
+				// RunContext and race temp-dir cleanup (#265, macOS APFS).
+				al.activeRequests.Add(1)
 				go func() {
+					defer al.activeRequests.Done()
 					defer func() {
 						if r := recover(); r != nil {
 							logger.ErrorCF("agent", "Panic in system-message goroutine",
@@ -1596,7 +1615,10 @@ func (al *AgentLoop) Run(ctx context.Context) error {
 			if !ok {
 				// Unroutable — fall through to the original single-shot path so
 				// channels with no configured agent still get an error reply.
+				// Tracked in activeRequests so shutdown drains it (#265).
+				al.activeRequests.Add(1)
 				go func() {
+					defer al.activeRequests.Done()
 					defer func() {
 						if r := recover(); r != nil {
 							logger.ErrorCF("agent", "Panic in unroutable-message goroutine",
@@ -1780,6 +1802,16 @@ func (al *AgentLoop) WaitForActiveRequests() {
 
 // Close releases resources held by agent session stores. Call after Stop.
 func (al *AgentLoop) Close() {
+	// #265: stop scheduling new recaps, then drain the in-flight ones FIRST —
+	// while the registry, session stores, memory stores, and audit logger they
+	// write through are all still live (the teardown below closes them). A recap
+	// caught mid-flight completes its summary and finishes writing before we
+	// proceed, so nothing writes after Close() returns to race temp-dir cleanup.
+	al.recapMu.Lock()
+	al.closing = true
+	al.recapMu.Unlock()
+	al.recapWG.Wait()
+
 	// Cancel all active session workers and wait for them to drain (5 s budget).
 	// stopSessionWorkers is idempotent — safe to call here even if Run() has
 	// already called it on context-cancellation, because workers cancel their
@@ -2344,6 +2376,60 @@ func (al *AgentLoop) MutateConfig(fn func(*config.Config) error) error {
 // GetTaskStore returns the shared TaskStore (may be nil in tests).
 func GetTaskStore(al *AgentLoop) *taskstore.TaskStore {
 	return al.taskStore
+}
+
+// ApplyAgentModel switches a live agent instance to a new primary model in
+// place — rebuilding its provider, candidate chain, and thinking level under
+// the instance lock WITHOUT recreating the instance. This preserves the agent's
+// in-memory conversation state and avoids a config hot-reload that would drop
+// the WebSocket (#73). The new model must already be persisted to config (the
+// REST handler writes config.json first) so resolution observes it. Returns the
+// previous primary model. Shared by the switch_model tool and the
+// PUT /api/v1/agents/{id} model-change path.
+func (al *AgentLoop) ApplyAgentModel(agentID, model string) (string, error) {
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return "", fmt.Errorf("model is required")
+	}
+	agent, ok := al.registry.GetAgent(agentID)
+	if !ok {
+		return "", fmt.Errorf("agent %q not found", agentID)
+	}
+
+	al.mu.RLock()
+	cfg := al.cfg
+	al.mu.RUnlock()
+
+	modelCfg, err := resolvedModelConfig(cfg, model, agent.Workspace)
+	if err != nil {
+		return "", err
+	}
+	nextProvider, _, err := providers.CreateProviderFromConfig(modelCfg)
+	if err != nil {
+		return "", fmt.Errorf("failed to initialize model %q: %w", model, err)
+	}
+	nextCandidates := resolveModelCandidates(cfg, cfg.Agents.Defaults.Provider, modelCfg.Model, agent.Fallbacks)
+	if len(nextCandidates) == 0 {
+		return "", fmt.Errorf("model %q did not resolve to any provider candidates", model)
+	}
+
+	agent.mu.Lock()
+	oldModel := agent.Model
+	oldProvider := agent.Provider
+	agent.Model = model
+	agent.Provider = nextProvider
+	agent.Candidates = nextCandidates
+	agent.ThinkingLevel = parseThinkingLevel(modelCfg.ThinkingLevel)
+	agent.mu.Unlock()
+
+	// Close the previous provider if it holds resources (e.g. a stateful
+	// session) and is actually being replaced.
+	if oldProvider != nil && oldProvider != nextProvider {
+		if stateful, ok := oldProvider.(providers.StatefulProvider); ok {
+			stateful.Close()
+		}
+	}
+	return oldModel, nil
 }
 
 // GetTaskExecutor returns the shared TaskExecutor (may be nil in tests).
@@ -5993,37 +6079,9 @@ func (al *AgentLoop) buildCommandsRuntime(agent *AgentInstance, opts *processOpt
 			return m, resolvedCandidateProvider(c, cfg.Agents.Defaults.Provider)
 		}
 		rt.SwitchModel = func(value string) (string, error) {
-			value = strings.TrimSpace(value)
-			modelCfg, err := resolvedModelConfig(cfg, value, agent.Workspace)
-			if err != nil {
-				return "", err
-			}
-
-			nextProvider, _, err := providers.CreateProviderFromConfig(modelCfg)
-			if err != nil {
-				return "", fmt.Errorf("failed to initialize model %q: %w", value, err)
-			}
-
-			nextCandidates := resolveModelCandidates(cfg, cfg.Agents.Defaults.Provider, modelCfg.Model, agent.Fallbacks)
-			if len(nextCandidates) == 0 {
-				return "", fmt.Errorf("model %q did not resolve to any provider candidates", value)
-			}
-
-			agent.mu.Lock()
-			oldModel := agent.Model
-			oldProvider := agent.Provider
-			agent.Model = value
-			agent.Provider = nextProvider
-			agent.Candidates = nextCandidates
-			agent.ThinkingLevel = parseThinkingLevel(modelCfg.ThinkingLevel)
-			agent.mu.Unlock()
-
-			if oldProvider != nil && oldProvider != nextProvider {
-				if stateful, ok := oldProvider.(providers.StatefulProvider); ok {
-					stateful.Close()
-				}
-			}
-			return oldModel, nil
+			// Shared in-place model switch (#73): same path as the
+			// PUT /api/v1/agents/{id} model change.
+			return al.ApplyAgentModel(agent.ID, value)
 		}
 
 		rt.ClearHistory = func() error {

--- a/pkg/agent/session_end.go
+++ b/pkg/agent/session_end.go
@@ -42,7 +42,22 @@ func (al *AgentLoop) CloseSession(sessionID, trigger string) {
 	// Cancel any outstanding idle ticker for this session.
 	al.cancelIdleTicker(sessionID)
 
-	go al.runRecap(sessionID, trigger)
+	// Track the recap goroutine so Close() can drain it before shutdown — its
+	// LAST_SESSION.md / retro writes must not outlive the gateway (#265). Gate
+	// the Add under recapMu against Close()'s drain: once shutdown has begun we
+	// skip scheduling (the session is re-recapped on next start by
+	// BootstrapRecapPass) rather than risk a WaitGroup Add-after-Wait.
+	al.recapMu.Lock()
+	if al.closing {
+		al.recapMu.Unlock()
+		return
+	}
+	al.recapWG.Add(1)
+	al.recapMu.Unlock()
+	go func() {
+		defer al.recapWG.Done()
+		al.runRecap(sessionID, trigger)
+	}()
 }
 
 // runRecap performs the session-end LLM summarisation and persists the result.
@@ -142,6 +157,9 @@ func (al *AgentLoop) runRecap(sessionID, trigger string) {
 		},
 	}
 
+	// Self-bounded at 60s. On graceful shutdown, AgentLoop.Close() waits for this
+	// goroutine to finish (recapWG) rather than canceling it, so the recap runs
+	// to completion within the 70s shutdown budget (#265).
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 

--- a/pkg/agent/testutil/gateway_harness.go
+++ b/pkg/agent/testutil/gateway_harness.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -297,17 +298,18 @@ func (g *TestGateway) Close() {
 		return
 	}
 
-	// Drain hold-off — RunContext returning does NOT guarantee every
-	// background goroutine that touches the session store, cost tracker, or
-	// audit logger has finished its final write/rename. On macOS APFS and
-	// some Linux runners, t.TempDir's RemoveAll fires immediately after this
-	// returns and races those writers ("directory not empty" / cost.json
-	// rename misses). Wait for the sessions/ subtree to stop changing for a
-	// short window before yielding to the caller — drain is best-effort and
-	// capped, never blocks the test on its own. A proper fix wires the
-	// session-store backend's Close into omnipusGracefulShutdown (tracked
-	// as v0.2).
-	waitForHomeDirStability(g.homeDir, 200*time.Millisecond, 3*time.Second)
+	// #265: deterministic cleanup-race safety net for macOS APFS. The shutdown
+	// fixes (recap drain + tracking the system/unroutable turn goroutines +
+	// stopping heartbeat/cron before the drain) drain the writers — confirmed on
+	// Linux (no post-close writes). But on the slower macOS runner a straggler
+	// write can still land just after RunContext returns and race t.TempDir's
+	// RemoveAll ("directory not empty"). Wait until the sessions subtree is stable
+	// for a short settle window before yielding to the test's RemoveAll. This is
+	// bounded and, on Linux where there is nothing in flight, returns on the first
+	// stable scan (~one settle window). Earlier fixed-sleep attempts failed
+	// because they ran WITHOUT the shutdown drains above (writers never stopped);
+	// with the residual now bounded, quiescence is reached well inside the budget.
+	waitForSessionsQuiescent(g.homeDir, 150*time.Millisecond, 3*time.Second)
 
 	// Surface any boot error that occurred after the gateway became ready.
 	if p := g.bootErr.Load(); p != nil && *p != nil {
@@ -317,47 +319,46 @@ func (g *TestGateway) Close() {
 	}
 }
 
-// waitForHomeDirStability polls homeDir/sessions until two consecutive scans
-// produce the same (file-count, total-size) snapshot, or the budget elapses.
-// Caller-side hold-off for the documented gateway-shutdown drain race; see
-// TestGateway.Close. Pure read-only — never errors, never blocks beyond budget.
-func waitForHomeDirStability(homeDir string, settleWindow, budget time.Duration) {
+// waitForSessionsQuiescent blocks until the homeDir/sessions subtree produces two
+// consecutive identical (path,size,mtime) snapshots `settle` apart, or `budget`
+// elapses. Pure read-only; never errors. Used by Close to avoid the macOS APFS
+// RemoveAll-vs-late-write race (#265). On Linux (nothing in flight post-Close) it
+// returns after the first settle window.
+func waitForSessionsQuiescent(homeDir string, settle, budget time.Duration) {
 	if homeDir == "" {
 		return
 	}
-	sessionsDir := filepath.Join(homeDir, "sessions")
+	sessions := filepath.Join(homeDir, "sessions")
 	deadline := time.Now().Add(budget)
-	var prevCount, prevSize int64 = -1, -1
+	prev := ""
 	stableSince := time.Time{}
 	for time.Now().Before(deadline) {
-		var count, size int64
-		_ = filepath.WalkDir(sessionsDir, func(_ string, d os.DirEntry, err error) error {
+		var sb strings.Builder
+		_ = filepath.WalkDir(sessions, func(p string, d os.DirEntry, err error) error {
 			if err != nil {
-				return err
+				return nil //nolint:nilerr // best-effort read-only scan; ignore transient walk errors
 			}
 			if d.IsDir() {
 				return nil
 			}
-			info, infoErr := d.Info()
-			if infoErr != nil {
-				return infoErr
+			if fi, e := d.Info(); e == nil {
+				fmt.Fprintf(&sb, "%s:%d:%d;", p, fi.Size(), fi.ModTime().UnixNano())
 			}
-			count++
-			size += info.Size()
 			return nil
 		})
-		if count == prevCount && size == prevSize {
+		sig := sb.String()
+		if sig == prev {
 			if stableSince.IsZero() {
 				stableSince = time.Now()
 			}
-			if time.Since(stableSince) >= settleWindow {
+			if time.Since(stableSince) >= settle {
 				return
 			}
 		} else {
+			prev = sig
 			stableSince = time.Time{}
-			prevCount, prevSize = count, size
 		}
-		time.Sleep(50 * time.Millisecond)
+		time.Sleep(25 * time.Millisecond)
 	}
 }
 

--- a/pkg/gateway/channel_secret_ref_test.go
+++ b/pkg/gateway/channel_secret_ref_test.go
@@ -1,0 +1,307 @@
+//go:build !cgo
+
+package gateway
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/dapicom-ai/omnipus/pkg/api/generated"
+	"github.com/dapicom-ai/omnipus/pkg/bus"
+	"github.com/dapicom-ai/omnipus/pkg/config"
+	"github.com/dapicom-ai/omnipus/pkg/credentials"
+)
+
+// newLockedStoreChannelAPI builds a channel API whose credential store is
+// present but NOT unlocked, so storeCredential / credentialRefResolves return
+// ErrStoreLocked — used to exercise the store-fault paths deterministically.
+func newLockedStoreChannelAPI(t *testing.T, configJSON string) *restAPI {
+	t.Helper()
+	tmpDir := t.TempDir()
+	require.NoError(t, os.WriteFile(tmpDir+"/config.json", []byte(configJSON), 0o600))
+	cfg := &config.Config{
+		Gateway: config.GatewayConfig{Host: "127.0.0.1", Port: 8080},
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{Workspace: tmpDir, ModelName: "test-model", MaxTokens: 4096},
+		},
+	}
+	al := mustAgentLoop(t, cfg, bus.NewMessageBus(), &restMockProvider{})
+	return &restAPI{
+		agentLoop:     al,
+		homePath:      tmpDir,
+		allowedOrigin: "http://localhost:3000",
+		credStore:     credentials.NewStore(tmpDir + "/credentials.json"), // locked
+	}
+}
+
+func newChannelTestAPI(t *testing.T, configJSON string) *restAPI {
+	t.Helper()
+	tmpDir := t.TempDir()
+	require.NoError(t, os.WriteFile(tmpDir+"/config.json", []byte(configJSON), 0o600))
+	cfg := &config.Config{
+		Gateway: config.GatewayConfig{Host: "127.0.0.1", Port: 8080},
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{Workspace: tmpDir, ModelName: "test-model", MaxTokens: 4096},
+		},
+	}
+	al := mustAgentLoop(t, cfg, bus.NewMessageBus(), &restMockProvider{})
+	return newOnboardingTestAPI(t, tmpDir, al)
+}
+
+// TestConfigureChannel_RoutesSecretToCredentialStore is the core #289 guard:
+// configuring a token-based channel via the UI must store the secret in the
+// encrypted credential store and persist only its <field>_ref in config.json —
+// never the plaintext (SEC-23) — and "Test" must then report success.
+func TestConfigureChannel_RoutesSecretToCredentialStore(t *testing.T) {
+	api := newChannelTestAPI(t, `{"version":1,"agents":{"defaults":{},"list":[]},"providers":[],"channels":{}}`)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPut, "/api/v1/channels/telegram/configure",
+		strings.NewReader(`{"token":"super-secret-123"}`))
+	r.Header.Set("Content-Type", "application/json")
+	api.configureChannel(w, r, "telegram")
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	// 1. The plaintext secret must NOT appear anywhere in config.json (SEC-23).
+	raw, err := os.ReadFile(api.homePath + "/config.json")
+	require.NoError(t, err)
+	assert.NotContains(t, string(raw), "super-secret-123", "plaintext token leaked into config.json")
+
+	// 2. token_ref must be set to the conventional credential name; no inline token.
+	var diskCfg map[string]any
+	require.NoError(t, json.Unmarshal(raw, &diskCfg))
+	tg := diskCfg["channels"].(map[string]any)["telegram"].(map[string]any)
+	assert.Equal(t, "channel_telegram_token", tg["token_ref"])
+	_, hasInline := tg["token"]
+	assert.False(t, hasInline, "inline token must not be persisted to config.json")
+
+	// 3. The secret must be retrievable from the credential store.
+	got, err := api.credStore.Get("channel_telegram_token")
+	require.NoError(t, err)
+	assert.Equal(t, "super-secret-123", got)
+
+	// 4. testChannel now reports success because the ref resolves.
+	w2 := httptest.NewRecorder()
+	api.testChannel(w2, "telegram")
+	require.Equal(t, http.StatusOK, w2.Code)
+	var resp gen.ChannelTestResponse
+	require.NoError(t, json.Unmarshal(w2.Body.Bytes(), &resp))
+	assert.True(t, resp.Success, "test should pass once the credential is stored: %s", resp.Message)
+}
+
+// TestConfigureChannel_MultiSecretChannel covers a channel with two secret
+// fields (slack: bot_token + app_token) — both must be routed to refs.
+func TestConfigureChannel_MultiSecretChannel(t *testing.T) {
+	api := newChannelTestAPI(t, `{"version":1,"agents":{"defaults":{},"list":[]},"providers":[],"channels":{}}`)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPut, "/api/v1/channels/slack/configure",
+		strings.NewReader(`{"bot_token":"xoxb-aaa","app_token":"xapp-bbb"}`))
+	r.Header.Set("Content-Type", "application/json")
+	api.configureChannel(w, r, "slack")
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	raw, err := os.ReadFile(api.homePath + "/config.json")
+	require.NoError(t, err)
+	assert.NotContains(t, string(raw), "xoxb-aaa")
+	assert.NotContains(t, string(raw), "xapp-bbb")
+
+	for field, want := range map[string]string{"bot_token": "xoxb-aaa", "app_token": "xapp-bbb"} {
+		got, err := api.credStore.Get("channel_slack_" + field)
+		require.NoError(t, err, "field %s", field)
+		assert.Equal(t, want, got, "field %s", field)
+	}
+}
+
+// TestTestChannel_FailsWhenSecretMissing confirms "Test" reports failure (not a
+// false success) when a required secret has no stored credential — the exact
+// lie #289 set out to fix.
+func TestTestChannel_FailsWhenSecretMissing(t *testing.T) {
+	api := newChannelTestAPI(t,
+		`{"version":1,"agents":{"defaults":{},"list":[]},"providers":[],"channels":{"telegram":{"enabled":false}}}`)
+
+	w := httptest.NewRecorder()
+	api.testChannel(w, "telegram")
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp gen.ChannelTestResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.False(t, resp.Success, "test must fail when the token credential is absent")
+	assert.Contains(t, resp.Message, "token")
+}
+
+// TestConfigureChannel_ScrubsStaleInlinePlaintext is the key security-remediation
+// guard: a config left with an inline plaintext secret by the pre-#289 bug must
+// be scrubbed on the next save — even when the user edits an UNRELATED field and
+// does not re-supply the secret (the realistic "[configured]" UI flow).
+func TestConfigureChannel_ScrubsStaleInlinePlaintext(t *testing.T) {
+	api := newChannelTestAPI(
+		t,
+		`{"version":1,"agents":{"defaults":{},"list":[]},"providers":[],"channels":{"telegram":{"enabled":false,"token":"LEAKED-OLD-PLAINTEXT","parse_mode":"Markdown"}}}`,
+	)
+
+	// Edit only a non-secret field; do NOT re-send the token.
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPut, "/api/v1/channels/telegram/configure",
+		strings.NewReader(`{"parse_mode":"HTML"}`))
+	r.Header.Set("Content-Type", "application/json")
+	api.configureChannel(w, r, "telegram")
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	raw, err := os.ReadFile(api.homePath + "/config.json")
+	require.NoError(t, err)
+	assert.NotContains(t, string(raw), "LEAKED-OLD-PLAINTEXT", "stale inline plaintext survived the save (SEC-23)")
+
+	var diskCfg map[string]any
+	require.NoError(t, json.Unmarshal(raw, &diskCfg))
+	tg := diskCfg["channels"].(map[string]any)["telegram"].(map[string]any)
+	_, hasInline := tg["token"]
+	assert.False(t, hasInline, "stale inline token key must be removed")
+	assert.Equal(t, "HTML", tg["parse_mode"], "the unrelated edit must still apply")
+}
+
+// TestConfigureChannel_ClearSecretDeletesCredential covers the clear/rotate path:
+// re-configuring with an empty value clears the ref AND deletes the stored
+// credential so a "removed" token does not linger encrypted at rest.
+func TestConfigureChannel_ClearSecretDeletesCredential(t *testing.T) {
+	api := newChannelTestAPI(t, `{"version":1,"agents":{"defaults":{},"list":[]},"providers":[],"channels":{}}`)
+
+	// Set a token, then clear it.
+	for _, body := range []string{`{"token":"secret-1"}`, `{"token":"   "}`} {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodPut, "/api/v1/channels/telegram/configure", strings.NewReader(body))
+		r.Header.Set("Content-Type", "application/json")
+		api.configureChannel(w, r, "telegram")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	}
+
+	// Ref cleared in config; credential gone from the store.
+	raw, err := os.ReadFile(api.homePath + "/config.json")
+	require.NoError(t, err)
+	var diskCfg map[string]any
+	require.NoError(t, json.Unmarshal(raw, &diskCfg))
+	tg := diskCfg["channels"].(map[string]any)["telegram"].(map[string]any)
+	assert.Equal(t, "", tg["token_ref"], "token_ref must be cleared")
+	_, err = api.credStore.Get("channel_telegram_token")
+	assert.Error(t, err, "the stored credential must be deleted on clear")
+
+	// Test now reports failure (the channel is unconfigured again).
+	w := httptest.NewRecorder()
+	api.testChannel(w, "telegram")
+	var resp gen.ChannelTestResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.False(t, resp.Success)
+}
+
+// TestTestChannel_MatrixMixedRequiredFields locks in the inline-vs-ref
+// discrimination: matrix requires homeserver + user_id (non-secret, inline) AND
+// access_token (secret, ref). Both kinds must be validated in their own way.
+func TestTestChannel_MatrixMixedRequiredFields(t *testing.T) {
+	// access_token routed to a stored ref; homeserver + user_id inline.
+	api := newChannelTestAPI(
+		t,
+		`{"version":1,"agents":{"defaults":{},"list":[]},"providers":[],"channels":{"matrix":{"enabled":false,"homeserver":"https://m.org","user_id":"@a:m.org","access_token_ref":"channel_matrix_access_token"}}}`,
+	)
+	_, err := api.storeCredential("channel_matrix_access_token", "syt-token")
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	api.testChannel(w, "matrix")
+	var resp gen.ChannelTestResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.True(t, resp.Success, "all required fields present (inline + ref): %s", resp.Message)
+
+	// Drop the non-secret user_id → Test must fail on the inline field.
+	api2 := newChannelTestAPI(
+		t,
+		`{"version":1,"agents":{"defaults":{},"list":[]},"providers":[],"channels":{"matrix":{"enabled":false,"homeserver":"https://m.org","access_token_ref":"channel_matrix_access_token"}}}`,
+	)
+	_, err = api2.storeCredential("channel_matrix_access_token", "syt-token")
+	require.NoError(t, err)
+	w2 := httptest.NewRecorder()
+	api2.testChannel(w2, "matrix")
+	var resp2 gen.ChannelTestResponse
+	require.NoError(t, json.Unmarshal(w2.Body.Bytes(), &resp2))
+	assert.False(t, resp2.Success)
+	assert.Contains(t, resp2.Message, "user_id")
+}
+
+// TestGetChannelConfig_ShowsConfiguredMarker guards MAJ-001: after the secret
+// moves to the credential store (only token_ref in config), GET must still show
+// the "[configured]" marker so the UI knows a secret is set — never the secret.
+func TestGetChannelConfig_ShowsConfiguredMarker(t *testing.T) {
+	api := newChannelTestAPI(t, `{"version":1,"agents":{"defaults":{},"list":[]},"providers":[],"channels":{}}`)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPut, "/api/v1/channels/telegram/configure",
+		strings.NewReader(`{"token":"super-secret-123"}`))
+	r.Header.Set("Content-Type", "application/json")
+	api.configureChannel(w, r, "telegram")
+	require.Equal(t, http.StatusOK, w.Code)
+
+	w2 := httptest.NewRecorder()
+	api.getChannelConfig(w2, "telegram")
+	require.Equal(t, http.StatusOK, w2.Code)
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(w2.Body.Bytes(), &got))
+	assert.Equal(t, "[configured]", got["token"], "GET must show the configured marker via the ref")
+	assert.NotContains(t, w2.Body.String(), "super-secret-123", "GET must never echo the secret")
+}
+
+// TestConfigureChannel_RejectsNonStringSecret guards MIN-002: a non-string
+// secret value must be rejected, not silently treated as a clear (which would
+// revoke a working credential).
+func TestConfigureChannel_RejectsNonStringSecret(t *testing.T) {
+	api := newChannelTestAPI(t, `{"version":1,"agents":{"defaults":{},"list":[]},"providers":[],"channels":{}}`)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPut, "/api/v1/channels/telegram/configure",
+		strings.NewReader(`{"token":12345}`))
+	r.Header.Set("Content-Type", "application/json")
+	api.configureChannel(w, r, "telegram")
+	assert.Equal(t, http.StatusBadRequest, w.Code, "non-string secret must be rejected")
+}
+
+// TestConfigureChannel_StoreFaultFailsClosed guards MIN-001: when the credential
+// store is unavailable (locked), configure must fail with 500 and NOT modify
+// config.json — no ref written, no plaintext written (fail-closed).
+func TestConfigureChannel_StoreFaultFailsClosed(t *testing.T) {
+	api := newLockedStoreChannelAPI(t, `{"version":1,"agents":{"defaults":{},"list":[]},"providers":[],"channels":{}}`)
+	before, err := os.ReadFile(api.homePath + "/config.json")
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPut, "/api/v1/channels/telegram/configure",
+		strings.NewReader(`{"token":"secret-x"}`))
+	r.Header.Set("Content-Type", "application/json")
+	api.configureChannel(w, r, "telegram")
+	assert.Equal(t, http.StatusInternalServerError, w.Code, "store fault must fail the request")
+
+	after, err := os.ReadFile(api.homePath + "/config.json")
+	require.NoError(t, err)
+	assert.Equal(t, string(before), string(after), "config.json must be unchanged on store fault (fail-closed)")
+	assert.NotContains(t, string(after), "secret-x")
+}
+
+// TestTestChannel_StoreUnavailableIsDistinct guards MIN-001 + the (bool,error)
+// contract: a locked store must report "credential store unavailable", NOT a
+// misleading "missing token", so the user isn't told to re-enter a present secret.
+func TestTestChannel_StoreUnavailableIsDistinct(t *testing.T) {
+	api := newLockedStoreChannelAPI(
+		t,
+		`{"version":1,"agents":{"defaults":{},"list":[]},"providers":[],"channels":{"telegram":{"enabled":false,"token_ref":"channel_telegram_token"}}}`,
+	)
+
+	w := httptest.NewRecorder()
+	api.testChannel(w, "telegram")
+	var resp gen.ChannelTestResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.False(t, resp.Success)
+	assert.Contains(t, resp.Message, "unavailable", "store fault must be reported distinctly, not as 'missing'")
+	assert.NotContains(t, resp.Message, "missing")
+}

--- a/pkg/gateway/rest.go
+++ b/pkg/gateway/rest.go
@@ -259,19 +259,21 @@ func (a *restAPI) adminWrap(h http.HandlerFunc) http.HandlerFunc {
 	)
 }
 
-func jsonOK(w http.ResponseWriter, body any) {
+// writeJSON marshals body and writes it with the given status code. The
+// Content-Type is set BEFORE WriteHeader so it is honored regardless of status
+// — once WriteHeader is called the header map is flushed and later Set calls are
+// silently ignored, which is how 201 responses were leaking out as text/plain
+// (#96). All JSON-returning handlers must route through this (or jsonOK /
+// jsonCreated, which wrap it) rather than calling w.WriteHeader themselves.
+func writeJSON(w http.ResponseWriter, code int, body any) {
 	buf, err := json.Marshal(body)
 	if err != nil {
 		slog.Error("rest: json encode failed", "error", err)
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusInternalServerError)
-		errMsg := "internal server error"
-		if encErr := json.NewEncoder(w).Encode(gen.ErrorResponse{Error: errMsg}); encErr != nil {
-			slog.Debug("rest: write fallback error response failed", "error", encErr)
-		}
+		jsonErr(w, http.StatusInternalServerError, "internal server error")
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
 	if _, err := w.Write(buf); err != nil {
 		slog.Debug("rest: write response body failed", "error", err)
 		return
@@ -281,6 +283,17 @@ func jsonOK(w http.ResponseWriter, body any) {
 	}
 }
 
+// jsonOK writes body as a 200 OK JSON response.
+func jsonOK(w http.ResponseWriter, body any) { writeJSON(w, http.StatusOK, body) }
+
+// jsonCreated writes body as a 201 Created JSON response. Use this instead of
+// `w.WriteHeader(http.StatusCreated); jsonOK(w, ...)` — that ordering drops the
+// Content-Type and the response is served as text/plain (#96).
+func jsonCreated(w http.ResponseWriter, body any) { writeJSON(w, http.StatusCreated, body) }
+
+// jsonErr writes an ErrorResponse with the given status. Like writeJSON it sets
+// Content-Type before WriteHeader so error bodies are never served as text/plain
+// (#96). It does not call writeJSON to avoid recursion on a marshal failure.
 func jsonErr(w http.ResponseWriter, status int, msg string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
@@ -689,8 +702,7 @@ func (a *restAPI) createSessionHTTP(w http.ResponseWriter, r *http.Request) {
 		jsonErr(w, http.StatusInternalServerError, fmt.Sprintf("could not create session: %v", err))
 		return
 	}
-	w.WriteHeader(http.StatusCreated)
-	jsonOK(w, unifiedMetaToGenSession(meta))
+	jsonCreated(w, unifiedMetaToGenSession(meta))
 }
 
 // --- Agents ---
@@ -1346,8 +1358,7 @@ func (a *restAPI) createAgent(w http.ResponseWriter, r *http.Request) {
 	if createReloadWarning != "" {
 		ag.Warning = &createReloadWarning
 	}
-	w.WriteHeader(http.StatusCreated)
-	jsonOK(w, ag)
+	jsonCreated(w, ag)
 }
 
 // deleteAgent handles DELETE /api/v1/agents/{id}.
@@ -1727,6 +1738,31 @@ func (a *restAPI) updateAgent(w http.ResponseWriter, r *http.Request, id string)
 		if err := a.agentLoop.TriggerReload(); err != nil {
 			slog.Error("config reload after agent update failed", "error", err)
 			reloadWarning = fmt.Sprintf("config reload failed: %v", err)
+		}
+	}
+
+	// #73: a model-only change is intentionally config-only (no reload above, so
+	// the WebSocket and conversation context survive). But persisting to config +
+	// SwapConfig does NOT touch the already-constructed agent instance — its
+	// cached provider/model would keep serving the OLD model until a restart.
+	// Apply the change in place so it takes effect on the next turn while the
+	// live session context is preserved. Skip when needsReload fired, since
+	// TriggerReload already rebuilt the instance with the new model.
+	if req.Model != nil && newModel != "" && !needsReload {
+		if _, err := a.agentLoop.ApplyAgentModel(id, newModel); err != nil {
+			// Error, not Warn: a live-apply failure means the running agent keeps
+			// serving the OLD model despite a 200 response. The cause (bad model
+			// config, provider init / API-key failure, no candidates) typically
+			// recurs on the next reload too, so this is not reliably "applies
+			// later" — surface it loudly and in the response so it is not silent.
+			slog.Error("updateAgent: live model apply failed; running agent still on previous model",
+				"agent_id", id, "model", newModel, "error", err)
+			if reloadWarning == "" {
+				reloadWarning = fmt.Sprintf(
+					"model saved to config but could not be applied to the running agent (still serving the previous model): %v",
+					err,
+				)
+			}
 		}
 	}
 	// Re-read the files so the response reflects what was just persisted.
@@ -2925,8 +2961,7 @@ func (a *restAPI) createTask(w http.ResponseWriter, r *http.Request) {
 		jsonErr(w, http.StatusInternalServerError, fmt.Sprintf("could not save task: %v", err))
 		return
 	}
-	w.WriteHeader(http.StatusCreated)
-	jsonOK(w, t)
+	jsonCreated(w, t)
 }
 
 func (a *restAPI) updateTask(w http.ResponseWriter, r *http.Request, id string) {
@@ -3621,8 +3656,7 @@ func (a *restAPI) addMCPServer(w http.ResponseWriter, r *http.Request) {
 		Status:    gen.McpServerStatusDisconnected,
 		ToolCount: 0,
 	}
-	w.WriteHeader(http.StatusCreated)
-	jsonOK(w, resp)
+	jsonCreated(w, resp)
 }
 
 func (a *restAPI) deleteMCPServer(w http.ResponseWriter, id string) {
@@ -4689,11 +4723,7 @@ func (a *restAPI) HandleUpload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusCreated)
-	if err := json.NewEncoder(w).Encode(resp); err != nil {
-		slog.Warn("rest: upload: encode response failed", "error", err)
-	}
+	jsonCreated(w, resp)
 }
 
 // HandleServeUpload serves uploaded files for display in chat.

--- a/pkg/gateway/rest.go
+++ b/pkg/gateway/rest.go
@@ -1965,6 +1965,64 @@ func (a *restAPI) storeCredential(refName, apiKey string) (string, error) {
 	return refName, nil
 }
 
+// channelCredKey is the credential-store key for a channel's secret field. The
+// format is opaque to readers (channel constructors resolve secrets via the
+// config <field>_ref, never by reconstructing this key); it exists so the
+// producer side has a single definition.
+func channelCredKey(channelID, field string) string {
+	return "channel_" + channelID + "_" + field
+}
+
+// removeStoredCredential removes refName from the credential store. A missing
+// entry is not an error — clearing a never-set secret is legitimate. (Distinct
+// from the deleteCredential REST handler, which writes an HTTP response.)
+func (a *restAPI) removeStoredCredential(refName string) error {
+	store := a.credStore
+	if store == nil {
+		store = credentials.NewStore(a.credentialsStorePath())
+		if err := credentials.Unlock(store); err != nil {
+			return fmt.Errorf("credential store locked: %w", err)
+		}
+	}
+	if err := store.Delete(refName); err != nil {
+		var nf *credentials.NotFoundError
+		if errors.As(err, &nf) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+// credentialRefResolves reports whether refName names a non-empty secret in the
+// credential store. Used by testChannel (#289). The returned error is non-nil
+// only for store-access faults (locked / wrong master key / I/O) — distinct from
+// a genuinely absent secret, which returns (false, nil). The caller MUST surface
+// a store fault separately rather than reporting the field as "missing", or
+// "Test" would tell the user to re-enter a secret that is already correct.
+func (a *restAPI) credentialRefResolves(refName string) (bool, error) {
+	refName = strings.TrimSpace(refName)
+	if refName == "" {
+		return false, nil // genuinely not configured
+	}
+	store := a.credStore
+	if store == nil {
+		store = credentials.NewStore(a.credentialsStorePath())
+		if err := credentials.Unlock(store); err != nil {
+			return false, fmt.Errorf("credential store locked: %w", err)
+		}
+	}
+	v, err := store.Get(refName)
+	if err != nil {
+		var nf *credentials.NotFoundError
+		if errors.As(err, &nf) {
+			return false, nil // truly absent
+		}
+		return false, err // locked / wrong key / I/O — surface to the caller
+	}
+	return strings.TrimSpace(v) != "", nil
+}
+
 // safeUpdateConfigJSON reads config.json, applies a mutation function on the raw JSON map,
 // and writes it back atomically. This preserves SecureStrings (API keys) that would be
 // destroyed by config.SaveConfig's JSON round-trip through the Go struct.
@@ -4306,17 +4364,25 @@ var channelRequiredFields = map[string][]string{
 	"whatsapp": {},
 }
 
-// redactChannelConfig returns a copy of cfg with sensitive fields replaced by "[configured]"
-// (if non-empty) or "" (if empty).
+// redactChannelConfig returns a copy of cfg with sensitive fields replaced by a
+// "[configured]" marker (never the real secret). Post-#289 the secret lives in
+// the credential store and config holds only <field>_ref, so the marker is
+// driven by the presence of the ref — this preserves the UI's
+// secret-already-set indicator (the inline field is no longer present).
 func redactChannelConfig(channelID string, cfg map[string]any) map[string]any {
 	out := make(map[string]any, len(cfg))
 	for k, v := range cfg {
 		out[k] = v
 	}
 	for _, field := range channelSensitiveFields[channelID] {
+		// A set <field>_ref means a credential is stored → mark configured.
+		if ref, _ := out[field+"_ref"].(string); strings.TrimSpace(ref) != "" {
+			out[field] = "[configured]"
+			continue
+		}
+		// Legacy/pre-scrub inline value (should be transient): mask, never echo.
 		if v, ok := out[field]; ok {
-			s, _ := v.(string)
-			if s != "" {
+			if s, _ := v.(string); s != "" {
 				out[field] = "[configured]"
 			} else {
 				out[field] = ""
@@ -4350,6 +4416,43 @@ func (a *restAPI) configureChannel(w http.ResponseWriter, r *http.Request, chann
 	// Remove reserved fields that must not be set here.
 	delete(updates, "enabled")
 
+	// SEC-23 / #289: route secret fields into the encrypted credential store and
+	// persist only their <field>_ref in config.json. Every channel constructor
+	// reads its secret via the *_ref (e.g. token_ref); an inline plaintext secret
+	// is both a plaintext-at-rest violation AND unreadable by the constructor —
+	// so a UI-configured token-based channel would never start.
+	var clearedRefs []string // credentials to delete AFTER the config write commits
+	for _, field := range channelSensitiveFields[channelID] {
+		raw, present := updates[field]
+		if !present {
+			continue
+		}
+		delete(updates, field) // never persist the inline plaintext
+		refField := field + "_ref"
+		refName := channelCredKey(channelID, field)
+		secret, isStr := raw.(string)
+		if !isStr && raw != nil {
+			// A non-string, non-null secret (e.g. {"token": 123}) would collapse to
+			// "" and be misread as a clear — reject it instead of silently revoking.
+			jsonErr(w, http.StatusBadRequest, fmt.Sprintf("%s must be a string", field))
+			return
+		}
+		if strings.TrimSpace(secret) == "" {
+			// Clearing: drop the ref now, but delete the stored credential only
+			// AFTER the config write commits (below). Deleting first would strand
+			// the channel pointing at a missing credential if the config write fails.
+			updates[refField] = ""
+			clearedRefs = append(clearedRefs, refName)
+			continue
+		}
+		if _, err := a.storeCredential(refName, secret); err != nil {
+			slog.Error("rest: store channel credential", "channel", channelID, "field", field, "error", err)
+			jsonErr(w, http.StatusInternalServerError, fmt.Sprintf("could not store %s credential: %v", field, err))
+			return
+		}
+		updates[refField] = refName
+	}
+
 	var updatedCh map[string]any
 	if err := a.safeUpdateConfigJSON(func(m map[string]any) error {
 		channels, _ := m["channels"].(map[string]any)
@@ -4364,6 +4467,12 @@ func (a *restAPI) configureChannel(w http.ResponseWriter, r *http.Request, chann
 		for k, v := range updates {
 			ch[k] = v
 		}
+		// Invariant (#289/SEC-23): a known secret field is never stored inline in
+		// config.json — it lives only in the credential store via its <field>_ref.
+		// This also scrubs any stale plaintext left by the pre-#289 blind merge.
+		for _, field := range channelSensitiveFields[channelID] {
+			delete(ch, field)
+		}
 		channels[channelID] = ch
 		updatedCh = ch
 		return nil
@@ -4371,6 +4480,15 @@ func (a *restAPI) configureChannel(w http.ResponseWriter, r *http.Request, chann
 		slog.Error("rest: configure channel", "channel", channelID, "error", err)
 		jsonErr(w, http.StatusInternalServerError, fmt.Sprintf("could not save config: %v", err))
 		return
+	}
+
+	// Config (with cleared refs) is durable now — delete the now-unreferenced
+	// credentials. A failure here only leaves an orphaned encrypted blob (the ref
+	// is already gone), so log rather than fail the already-committed request.
+	for _, refName := range clearedRefs {
+		if err := a.removeStoredCredential(refName); err != nil {
+			slog.Error("rest: delete cleared channel credential", "channel", channelID, "ref", refName, "error", err)
+		}
 	}
 	jsonOK(w, redactChannelConfig(channelID, updatedCh))
 }
@@ -4386,13 +4504,37 @@ func (a *restAPI) testChannel(w http.ResponseWriter, channelID string) {
 	}
 
 	required := channelRequiredFields[channelID]
+	sensitive := make(map[string]bool, len(channelSensitiveFields[channelID]))
+	for _, f := range channelSensitiveFields[channelID] {
+		sensitive[f] = true
+	}
 	var missing []string
 	for _, field := range required {
-		if v, vOk := chCfg[field].(string); vOk {
-			if v == "" {
+		if sensitive[field] {
+			// #289: a secret required field is satisfied by its <field>_ref
+			// resolving in the credential store, NOT by an inline value — the
+			// secret never lives in config.json. Checking the inline field here
+			// (the old behavior) made "Test" report success for channels that
+			// could never activate.
+			ref, _ := chCfg[field+"_ref"].(string)
+			ok, err := a.credentialRefResolves(ref)
+			if err != nil {
+				// Store fault (locked / wrong key / I/O) — distinct from a missing
+				// secret. Reporting it as "missing" would tell the user to re-enter
+				// a credential that is already correct, so surface it as its own state.
+				slog.Error("rest: channel test credential check", "channel", channelID, "field", field, "error", err)
+				jsonOK(w, gen.ChannelTestResponse{
+					Success: false,
+					Message: "credential store unavailable — unlock it (set OMNIPUS_MASTER_KEY) and retry",
+				})
+				return
+			}
+			if !ok {
 				missing = append(missing, field)
 			}
-		} else {
+			continue
+		}
+		if v, vOk := chCfg[field].(string); !vOk || v == "" {
 			missing = append(missing, field)
 		}
 	}

--- a/pkg/gateway/rest_content_type_handler_test.go
+++ b/pkg/gateway/rest_content_type_handler_test.go
@@ -1,0 +1,41 @@
+//go:build !cgo
+
+package gateway
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	gen "github.com/dapicom-ai/omnipus/pkg/api/generated"
+)
+
+// TestHandleAgentsCreate_201IsJSON drives the real 201 handler end-to-end
+// (not just the writeJSON helper) and asserts the Content-Type, guarding #96 at
+// the handler layer: the bug was a handler calling w.WriteHeader(201) before
+// jsonOK, so a future edit reintroducing that ordering must fail a test that
+// exercises the handler — the helper-level test alone would stay green.
+func TestHandleAgentsCreate_201IsJSON(t *testing.T) {
+	api := newTestRestAPIWithHome(t)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/agents", strings.NewReader(`{"name":"Scout"}`))
+	r.Header.Set("Content-Type", "application/json")
+	api.HandleAgents(w, r)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201 (body=%s)", w.Code, w.Body.String())
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("201 Content-Type = %q, want application/json (#96)", ct)
+	}
+	var resp gen.Agent
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("201 body is not valid JSON: %v (body=%s)", err, w.Body.String())
+	}
+	if resp.Name != "Scout" {
+		t.Errorf("created agent name = %q, want Scout", resp.Name)
+	}
+}

--- a/pkg/gateway/rest_content_type_test.go
+++ b/pkg/gateway/rest_content_type_test.go
@@ -1,0 +1,101 @@
+//go:build !cgo
+
+package gateway
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// These tests guard #96: JSON responses were served as text/plain on 201-Created
+// paths because Content-Type was set AFTER w.WriteHeader (which silently drops
+// header mutations). Every JSON helper must emit application/json regardless of
+// the status code it writes.
+
+func TestWriteJSON_ContentTypeAcrossStatusCodes(t *testing.T) {
+	for _, code := range []int{
+		http.StatusOK,
+		http.StatusCreated,
+		http.StatusAccepted,
+		http.StatusBadRequest,
+		http.StatusInternalServerError,
+	} {
+		rec := httptest.NewRecorder()
+		writeJSON(rec, code, map[string]any{"ok": true})
+
+		if rec.Code != code {
+			t.Errorf("status %d: got code %d", code, rec.Code)
+		}
+		if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+			t.Errorf("status %d: Content-Type = %q, want application/json", code, ct)
+		}
+		var body map[string]any
+		if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+			t.Errorf("status %d: body not valid JSON: %v (body=%q)", code, err, rec.Body.String())
+		}
+	}
+}
+
+func TestJSONOK_Is200JSON(t *testing.T) {
+	rec := httptest.NewRecorder()
+	jsonOK(rec, map[string]string{"hello": "world"})
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("jsonOK status = %d, want 200", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("jsonOK Content-Type = %q, want application/json", ct)
+	}
+}
+
+func TestJSONCreated_Is201JSON(t *testing.T) {
+	rec := httptest.NewRecorder()
+	jsonCreated(rec, map[string]string{"id": "abc"})
+
+	if rec.Code != http.StatusCreated {
+		t.Errorf("jsonCreated status = %d, want 201", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("jsonCreated Content-Type = %q, want application/json", ct)
+	}
+	var body map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("jsonCreated body not valid JSON: %v", err)
+	}
+	if body["id"] != "abc" {
+		t.Errorf("jsonCreated body = %v, want id=abc", body)
+	}
+}
+
+func TestJSONErr_Is4xxJSON(t *testing.T) {
+	rec := httptest.NewRecorder()
+	jsonErr(rec, http.StatusBadRequest, "bad")
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("jsonErr status = %d, want 400", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("jsonErr Content-Type = %q, want application/json", ct)
+	}
+}
+
+// TestNoWriteHeaderBeforeJSONOK documents the regression: the buggy pattern was
+// `w.WriteHeader(201)` followed by `jsonOK(w, ...)`, which drops the Content-Type.
+// jsonCreated exists precisely to avoid that ordering. This asserts the fixed
+// helper does NOT require a preceding WriteHeader and still lands a 201.
+func TestJSONCreated_NoPrecedingWriteHeaderNeeded(t *testing.T) {
+	rec := httptest.NewRecorder()
+	// No w.WriteHeader call before jsonCreated — the helper owns the status.
+	jsonCreated(rec, struct {
+		Name string `json:"name"`
+	}{Name: "x"})
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("expected application/json, got %q", ct)
+	}
+}

--- a/pkg/gateway/shutdown.go
+++ b/pkg/gateway/shutdown.go
@@ -52,6 +52,20 @@ func omnipusGracefulShutdown(
 		runningServices.ChannelManager.StopAll(stopCtx)
 	}
 
+	// #265: stop the turn-triggering background services (heartbeat, cron) BEFORE
+	// draining active turns. If they fire during the drain, the resulting turn's
+	// cost.json / session-context writes can outlive RunContext and race
+	// t.TempDir cleanup on macOS APFS. The channel manager (above) is the other
+	// inbound source; together they guarantee no new bus message — hence no new
+	// activeRequests.Add — after this point. Device/health/preview registries
+	// have no turn side effects and stop later (step 4).
+	if runningServices.HeartbeatService != nil {
+		runningServices.HeartbeatService.Stop()
+	}
+	if runningServices.CronService != nil {
+		runningServices.CronService.Stop()
+	}
+
 	// US-7 / FR-008: Wait for active turns to complete before force-closing.
 	// Cap the wait to omnipusShutdownTimeout - 5 s so it always fits in the budget.
 	maxActiveTurnWait := int((omnipusShutdownTimeout - 5*time.Second).Seconds()) // 65 s
@@ -107,13 +121,8 @@ func omnipusGracefulShutdown(
 	// the agent loop's context cancellation path (handled in pkg/agent).
 
 	slog.Info("shutdown: step 4 — stopping background services")
-	// Stop remaining services (heartbeat, cron, media, devices).
-	if runningServices.HeartbeatService != nil {
-		runningServices.HeartbeatService.Stop()
-	}
-	if runningServices.CronService != nil {
-		runningServices.CronService.Stop()
-	}
+	// Heartbeat + cron were already stopped in step 1 (they trigger turns).
+	// Stop the remaining services that have no turn side effects.
 	if runningServices.DeviceService != nil {
 		runningServices.DeviceService.Stop()
 	}

--- a/pkg/sandbox/dev_servers.go
+++ b/pkg/sandbox/dev_servers.go
@@ -29,6 +29,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net"
 	"os"
 	"sync"
 	"syscall"
@@ -210,6 +211,127 @@ func (r *DevServerRegistry) Register(
 		"pid", pid,
 	)
 	return reg, nil
+}
+
+// ReservePort atomically selects and reserves a loopback port for agentID,
+// inserting a placeholder registration (PID 0) under the registry lock so that
+// concurrent callers cannot pick the same port. The caller MUST follow up with
+// ConfirmReservation(token, pid, command) once the child has spawned, or
+// Unregister(token) if the spawn (or bind probe) fails.
+//
+// wantPort > 0 reserves that exact port if it is free; wantPort == 0
+// auto-selects the lowest free port in [lo, hi], skipping ports already held by
+// the registry. "Free" means not currently registered AND bindable on loopback.
+// Caps mirror Register: ErrPerAgentCap (1 dev server per agent) and
+// GatewayCapError (cfg.Sandbox.MaxConcurrentDevServers).
+//
+// This replaces the previous web_serve behavior of always auto-picking
+// PortRange[0], which made every concurrent dev server collide on one port
+// (#255).
+func (r *DevServerRegistry) ReservePort(
+	agentID string,
+	wantPort, lo, hi int32,
+	maxConcurrent int,
+) (string, int32, error) {
+	if agentID == "" {
+		return "", 0, errors.New("dev_servers: agentID is required")
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// Per-agent cap: 1 active.
+	for _, e := range r.entries {
+		if e.AgentID == agentID {
+			return "", 0, ErrPerAgentCap
+		}
+	}
+	// Per-gateway cap.
+	if maxConcurrent > 0 && len(r.entries) >= maxConcurrent {
+		return "", 0, GatewayCapError{
+			Current:        len(r.entries),
+			Max:            maxConcurrent,
+			EarliestExpiry: r.earliestExpiryLocked(),
+		}
+	}
+
+	used := make(map[int32]bool, len(r.entries))
+	for _, e := range r.entries {
+		used[e.Port] = true
+	}
+
+	var port int32
+	switch {
+	case wantPort > 0:
+		if used[wantPort] || !portAvailable(wantPort) {
+			return "", 0, fmt.Errorf("dev_servers: port %d is not available", wantPort)
+		}
+		port = wantPort
+	default:
+		for p := lo; p <= hi; p++ {
+			if used[p] {
+				continue
+			}
+			if portAvailable(p) {
+				port = p
+				break
+			}
+		}
+		if port == 0 {
+			return "", 0, fmt.Errorf("dev_servers: no free port available in range [%d, %d]", lo, hi)
+		}
+	}
+
+	token, err := generateDevServerToken()
+	if err != nil {
+		return "", 0, fmt.Errorf("dev_servers: token generation: %w", err)
+	}
+	now := time.Now()
+	r.entries[token] = &DevServerRegistration{
+		AgentID:      agentID,
+		Token:        token,
+		Port:         port,
+		PID:          0, // populated by ConfirmReservation once the child spawns
+		CreatedAt:    now,
+		LastActivity: now,
+	}
+	slog.Info("dev_servers: reserved", "agent_id", agentID, "port", port)
+	return token, port, nil
+}
+
+// ConfirmReservation attaches the spawned child's PID and command to a prior
+// ReservePort reservation. It is a no-op if the token is unknown — e.g. the
+// reservation was already released via Unregister after a spawn failure.
+func (r *DevServerRegistry) ConfirmReservation(token string, pid int, command string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	e, ok := r.entries[token]
+	if !ok {
+		// The reservation is gone (released after a spawn failure, or evicted by
+		// the janitor between ReservePort and here). The child this pid belongs
+		// to is now untracked by the registry — surface it so a leaked dev-server
+		// process is at least visible. The caller (web_serve) only confirms a
+		// token it just reserved and has not released, so in practice this fires
+		// only on the rare expiry race.
+		slog.Warn("dev_servers: ConfirmReservation for unknown token; child PID is now untracked",
+			"pid", pid)
+		return
+	}
+	e.PID = pid
+	e.Command = command
+}
+
+// portAvailable reports whether a loopback TCP port can currently be bound. The
+// probe is advisory — the child binds shortly after — but combined with the
+// in-registry reservation it prevents both stale-port reuse and concurrent
+// same-port selection.
+func portAvailable(port int32) bool {
+	ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		return false
+	}
+	_ = ln.Close()
+	return true
 }
 
 // Lookup returns the registration matching token, or nil if the token is

--- a/pkg/sandbox/dev_servers_reserve_test.go
+++ b/pkg/sandbox/dev_servers_reserve_test.go
@@ -1,0 +1,146 @@
+// Tests for DevServerRegistry.ReservePort / ConfirmReservation — the #255 fix.
+// The old web_serve dev mode always auto-picked PortRange[0], so every
+// concurrent dev server collided on one port. ReservePort must hand out
+// distinct, free ports under the registry lock.
+
+package sandbox
+
+import (
+	"errors"
+	"sync"
+	"testing"
+)
+
+const (
+	testPortLo int32 = 18000
+	testPortHi int32 = 18999
+)
+
+// TestReservePort_AutoPicksDistinctPortsAcrossAgents is the core #255
+// regression: two agents that both auto-select (wantPort=0) must receive
+// different ports, not both PortRange[0].
+func TestReservePort_AutoPicksDistinctPortsAcrossAgents(t *testing.T) {
+	r := NewDevServerRegistry()
+	defer r.Close()
+
+	_, p1, err := r.ReservePort("agentA", 0, testPortLo, testPortHi, 10)
+	if err != nil {
+		t.Fatalf("ReservePort agentA: %v", err)
+	}
+	_, p2, err := r.ReservePort("agentB", 0, testPortLo, testPortHi, 10)
+	if err != nil {
+		t.Fatalf("ReservePort agentB: %v", err)
+	}
+	if p1 == p2 {
+		t.Fatalf("both agents got the same port %d (the #255 bug)", p1)
+	}
+	for _, p := range []int32{p1, p2} {
+		if p < testPortLo || p > testPortHi {
+			t.Errorf("port %d out of range [%d,%d]", p, testPortLo, testPortHi)
+		}
+	}
+}
+
+// TestReservePort_SkipsRegisteredPort confirms auto-select skips a port already
+// held by a Register-path entry (explicit-port dev server).
+func TestReservePort_SkipsRegisteredPort(t *testing.T) {
+	r := NewDevServerRegistry()
+	defer r.Close()
+
+	if _, err := r.Register("explicit", testPortLo, 1, "next dev", 10); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	_, port, err := r.ReservePort("auto", 0, testPortLo, testPortHi, 10)
+	if err != nil {
+		t.Fatalf("ReservePort: %v", err)
+	}
+	if port == testPortLo {
+		t.Fatalf("ReservePort handed out the already-registered port %d", port)
+	}
+}
+
+// TestReservePort_ExplicitPortInUse rejects an explicit port already reserved.
+func TestReservePort_ExplicitPortInUse(t *testing.T) {
+	r := NewDevServerRegistry()
+	defer r.Close()
+
+	if _, _, err := r.ReservePort("a", testPortLo, testPortLo, testPortHi, 10); err != nil {
+		t.Fatalf("first explicit ReservePort: %v", err)
+	}
+	if _, _, err := r.ReservePort("b", testPortLo, testPortLo, testPortHi, 10); err == nil {
+		t.Fatalf("second ReservePort on the same explicit port should fail")
+	}
+}
+
+// TestReservePort_ConfirmReservationSetsPID confirms the reservation is a real
+// registry entry that ConfirmReservation fills in.
+func TestReservePort_ConfirmReservationSetsPID(t *testing.T) {
+	r := NewDevServerRegistry()
+	defer r.Close()
+
+	token, _, err := r.ReservePort("a", 0, testPortLo, testPortHi, 10)
+	if err != nil {
+		t.Fatalf("ReservePort: %v", err)
+	}
+	// Before confirm: entry exists with PID 0.
+	if got := r.Lookup(token); got == nil || got.PID != 0 {
+		t.Fatalf("reservation entry = %+v; want PID 0", got)
+	}
+	r.ConfirmReservation(token, 4242, "next dev")
+	got := r.Lookup(token)
+	if got == nil || got.PID != 4242 || got.Command != "next dev" {
+		t.Fatalf("after confirm = %+v; want PID 4242, command 'next dev'", got)
+	}
+}
+
+// TestReservePort_EnforcesCaps confirms the per-agent and gateway caps apply on
+// the reservation path just as they do on Register.
+func TestReservePort_EnforcesCaps(t *testing.T) {
+	r := NewDevServerRegistry()
+	defer r.Close()
+
+	if _, _, err := r.ReservePort("a", 0, testPortLo, testPortHi, 1); err != nil {
+		t.Fatalf("first ReservePort: %v", err)
+	}
+	if _, _, err := r.ReservePort("a", 0, testPortLo, testPortHi, 10); !errors.Is(err, ErrPerAgentCap) {
+		t.Errorf("same-agent reservation err = %v; want ErrPerAgentCap", err)
+	}
+	var capErr GatewayCapError
+	if _, _, err := r.ReservePort("b", 0, testPortLo, testPortHi, 1); !errors.As(err, &capErr) {
+		t.Errorf("over-cap reservation err = %v; want GatewayCapError", err)
+	}
+}
+
+// TestReservePort_ConcurrentDistinct stresses the atomicity: N concurrent
+// auto-reservations across distinct agents must all get distinct ports.
+func TestReservePort_ConcurrentDistinct(t *testing.T) {
+	r := NewDevServerRegistry()
+	defer r.Close()
+
+	const n = 8
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	seen := make(map[int32]bool, n)
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func(i int) {
+			defer wg.Done()
+			agent := string(rune('A' + i))
+			_, port, err := r.ReservePort(agent, 0, testPortLo, testPortHi, n)
+			if err != nil {
+				t.Errorf("agent %s ReservePort: %v", agent, err)
+				return
+			}
+			mu.Lock()
+			if seen[port] {
+				t.Errorf("port %d handed out twice", port)
+			}
+			seen[port] = true
+			mu.Unlock()
+		}(i)
+	}
+	wg.Wait()
+	if len(seen) != n {
+		t.Errorf("got %d distinct ports; want %d", len(seen), n)
+	}
+}

--- a/pkg/tools/web_serve.go
+++ b/pkg/tools/web_serve.go
@@ -141,8 +141,6 @@ type WebServeTool struct {
 	// minDuration / maxDuration clamp static-mode registration lifetimes.
 	minDuration time.Duration
 	maxDuration time.Duration
-	// runMu guards the dev-mode validate-then-register path.
-	runMu sync.Mutex
 }
 
 // NewWebServeTool constructs the unified web_serve tool for a given agent.
@@ -448,25 +446,21 @@ func (t *WebServeTool) executeDev(ctx context.Context, rawPath, command string, 
 		return ErrorResult(fmt.Sprintf("path rejected: %v", err))
 	}
 
-	// Parse the port argument.
-	var exposePort int32
+	// Resolve the port: an explicit port (validated against the range) or 0 to
+	// auto-select a free one from the range inside ReservePort.
+	var wantPort int32
 	if portRaw, ok := args["port"]; ok && portRaw != nil {
 		p, parseErr := normalisePort(portRaw)
 		if parseErr != nil {
 			return ErrorResult(fmt.Sprintf("invalid port: %v", parseErr))
 		}
-		exposePort = p
-	} else {
-		// Auto-pick from the configured range.
-		exposePort = t.devCfg.PortRange[0]
-	}
-
-	// Port range check.
-	if exposePort < t.devCfg.PortRange[0] || exposePort > t.devCfg.PortRange[1] {
-		return ErrorResult(fmt.Sprintf(
-			"port out of allowed range [%d, %d]",
-			t.devCfg.PortRange[0], t.devCfg.PortRange[1],
-		))
+		if p < t.devCfg.PortRange[0] || p > t.devCfg.PortRange[1] {
+			return ErrorResult(fmt.Sprintf(
+				"port out of allowed range [%d, %d]",
+				t.devCfg.PortRange[0], t.devCfg.PortRange[1],
+			))
+		}
+		wantPort = p
 	}
 
 	agentID := t.agentID
@@ -477,16 +471,27 @@ func (t *WebServeTool) executeDev(ctx context.Context, rawPath, command string, 
 		return ErrorResult("web_serve: missing agent id in context")
 	}
 
-	// Per-agent cap pre-check.
-	t.runMu.Lock()
-	existing := t.devReg.LookupByAgent(agentID)
-	t.runMu.Unlock()
-	if existing != nil {
-		return ErrorResult(fmt.Sprintf(
-			"dev server already running on this agent; previous registration expires at %s",
-			existing.CreatedAt.Add(sandbox.HardTimeout).UTC().Format(time.RFC3339),
-		))
+	// Atomically reserve a free port (and a registry slot) BEFORE spawning so
+	// concurrent dev servers can never collide on one port (#255 — the old code
+	// always auto-picked PortRange[0]). The reservation is confirmed with the
+	// child PID on success, or released via Unregister on any failure below.
+	token, exposePort, reserveErr := t.devReg.ReservePort(
+		agentID, wantPort, t.devCfg.PortRange[0], t.devCfg.PortRange[1], int(t.devCfg.MaxConcurrent),
+	)
+	if reserveErr != nil {
+		var capErr sandbox.GatewayCapError
+		if errors.As(reserveErr, &capErr) {
+			return ErrorResult(fmt.Sprintf(
+				"too many concurrent dev servers (%d/%d); earliest expiry at %s",
+				capErr.Current, capErr.Max, capErr.EarliestExpiry.UTC().Format(time.RFC3339),
+			))
+		}
+		if errors.Is(reserveErr, sandbox.ErrPerAgentCap) {
+			return ErrorResult("dev server already running on this agent")
+		}
+		return ErrorResult(fmt.Sprintf("web_serve: %v", reserveErr))
 	}
+	startedAt := time.Now()
 
 	// Build env: PORT + HOST force the dev server to bind loopback only.
 	envSlice := []string{
@@ -496,44 +501,19 @@ func (t *WebServeTool) executeDev(ctx context.Context, rawPath, command string, 
 
 	// HIGH-6: audit BEFORE spawning (fail-closed option).
 	if auditErr := t.auditDevStart(ctx, agentID, command, exposePort); auditErr != nil {
+		t.devReg.Unregister(token)
 		return auditErr
 	}
 
-	// Spawn the background child.
+	// Spawn the background child. Release the reservation if the spawn fails.
 	cmd, spawnErr := t.spawnDevChild(command, absDir, envSlice, exposePort)
 	if spawnErr != nil {
+		t.devReg.Unregister(token)
 		return ErrorResult(fmt.Sprintf("web_serve: failed to start dev server: %v", spawnErr))
 	}
 
-	// Register. Kill orphan if registration fails.
-	reg, regErr := t.devReg.Register(agentID, exposePort, cmd.Process.Pid, command, int(t.devCfg.MaxConcurrent))
-	if regErr != nil {
-		_ = cmd.Process.Signal(syscall.SIGTERM)
-		orphanPid := cmd.Process.Pid
-		go func() {
-			waitErr := cmd.Wait()
-			exitCode := -1
-			if waitErr == nil {
-				exitCode = 0
-			} else if ee, ok := waitErr.(*exec.ExitError); ok {
-				exitCode = ee.ExitCode()
-			}
-			slog.Info("web_serve: orphaned child exited (registration failed)",
-				"agent_id", agentID, "pid", orphanPid, "exit_code", exitCode, "error", waitErr)
-		}()
-
-		var capErr sandbox.GatewayCapError
-		if errors.As(regErr, &capErr) {
-			return ErrorResult(fmt.Sprintf(
-				"too many concurrent dev servers (%d/%d); earliest expiry at %s",
-				capErr.Current, capErr.Max, capErr.EarliestExpiry.UTC().Format(time.RFC3339),
-			))
-		}
-		if errors.Is(regErr, sandbox.ErrPerAgentCap) {
-			return ErrorResult("dev server already running on this agent")
-		}
-		return ErrorResult(fmt.Sprintf("web_serve: registration failed: %v", regErr))
-	}
+	// Attach the child PID to the reservation.
+	t.devReg.ConfirmReservation(token, cmd.Process.Pid, command)
 
 	// Reap goroutine: log exit outcome and clean up registration.
 	bgPid := cmd.Process.Pid
@@ -546,9 +526,9 @@ func (t *WebServeTool) executeDev(ctx context.Context, rawPath, command string, 
 			exitCode = ee.ExitCode()
 		}
 		slog.Info("web_serve: dev server exited",
-			"agent_id", agentID, "pid", bgPid, "token", reg.Token,
+			"agent_id", agentID, "pid", bgPid, "token", token,
 			"exit_code", exitCode, "error", waitErr)
-		t.devReg.Unregister(reg.Token)
+		t.devReg.Unregister(token)
 	}()
 
 	// Brief startup grace so the dev server binds before the first request.
@@ -566,7 +546,11 @@ func (t *WebServeTool) executeDev(ctx context.Context, rawPath, command string, 
 	probeAddr := fmt.Sprintf("127.0.0.1:%d", exposePort)
 	probeConn, probeErr := net.DialTimeout("tcp", probeAddr, 50*time.Millisecond)
 	if probeErr != nil {
-		t.devReg.Unregister(reg.Token)
+		// The child spawned but never bound a reachable loopback port. Kill it so
+		// we don't leak an orphaned dev-server process (the reap goroutine logs
+		// its exit; Unregister here is idempotent with the reap's own Unregister).
+		_ = cmd.Process.Signal(syscall.SIGTERM)
+		t.devReg.Unregister(token)
 		return &ToolResult{
 			IsError: true,
 			ForLLM: fmt.Sprintf(
@@ -577,14 +561,14 @@ func (t *WebServeTool) executeDev(ctx context.Context, rawPath, command string, 
 	}
 	_ = probeConn.Close()
 
-	path := fmt.Sprintf("/preview/%s/%s/", agentID, reg.Token)
+	path := fmt.Sprintf("/preview/%s/%s/", agentID, token)
 	// Build the URL by concatenating the base URL and the path. The base
 	// URL is constructed upstream with a scheme (http/https), so the simple
 	// concat is the canonical builder here; sandbox.BuildDevURL's dead first
 	// line has been removed (H3/A4).
 	url := t.gatewayPreviewBaseURL + path
 
-	deadline := reg.CreatedAt.Add(sandbox.HardTimeout).UTC().Format(time.RFC3339)
+	deadline := startedAt.Add(sandbox.HardTimeout).UTC().Format(time.RFC3339)
 	summary := fmt.Sprintf(
 		"web_serve: dev server started. URL: %s. Command: %s. Port: %d. Token expires after 30 min idle / 4 h hard cap.",
 		url,

--- a/tests/integration/handoff_agent_id_test.go
+++ b/tests/integration/handoff_agent_id_test.go
@@ -173,8 +173,6 @@ func writeMockToolCallStream(w http.ResponseWriter, toolName, argsJSON string) {
 //
 // Traces to: Round-2 Bug 1 — post-handoff agent_id labeling
 func TestPostHandoff_ToolCallEntriesCarryNewAgentID(t *testing.T) {
-	skipOnMacOSAPFSCleanupRace(t)
-
 	// Boot a gateway with a mock LLM that performs a handoff sequence.
 	mock := mockLLMHandoffThenToolCall(t)
 	gw := testutil.StartTestGateway(t,

--- a/tests/integration/helpers_test.go
+++ b/tests/integration/helpers_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"runtime"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -131,27 +130,6 @@ func startIntegrationGateway(t *testing.T) *testutil.TestGateway {
 	t.Helper()
 	mock := mockLLMServer(t, "")
 	return testutil.StartTestGateway(t, testutil.WithAPIBase(mock.URL), testutil.WithBearerAuth())
-}
-
-// skipOnMacOSAPFSCleanupRace skips tests that race t.TempDir's RemoveAll
-// against the gateway's background session/context writers. The race only
-// manifests on macos-latest/arm64 CI runners — on Linux ext4 the looser
-// directory-empty semantics hide it. Two attempts to drain (100ms, then 1s)
-// did not close the window because the gateway's session-manager keeps
-// writing past TestGateway.Close until its own background goroutines
-// fully drain.
-//
-// The test BODY assertions pass on every platform; only cleanup is racy.
-// Filed as a v0.2 follow-up: make TestGateway.Close block on the
-// session-store backend Close() so the test side never has to drain.
-// Until then, skip on darwin so CI does not flake.
-func skipOnMacOSAPFSCleanupRace(t *testing.T) {
-	t.Helper()
-	if runtime.GOOS == "darwin" {
-		t.Skip(
-			"v0.2 follow-up: TestGateway.Close needs to drain session-store writers before returning (macOS APFS surfaces the race; Linux hides it)",
-		)
-	}
 }
 
 // wsConnect dials the gateway's WS endpoint and sends the mandatory auth frame.

--- a/tests/integration/idle_heartbeat_test.go
+++ b/tests/integration/idle_heartbeat_test.go
@@ -23,7 +23,6 @@ import (
 // Traces to: WebSocket-heartbeat fix (server-side pong response).
 // This is the integration-level counterpart of TestServerRespondsToAppLayerPing.
 func TestIdleHeartbeat(t *testing.T) {
-	skipOnMacOSAPFSCleanupRace(t)
 	gw := startIntegrationGateway(t)
 	conn := wsConnect(t, gw)
 

--- a/tests/integration/media_store_swap_test.go
+++ b/tests/integration/media_store_swap_test.go
@@ -33,8 +33,6 @@ import (
 //
 // Traces to: #254 stale media store (BLOCKER)
 func TestUploadMediaRef_StoreSwapResolves(t *testing.T) {
-	skipOnMacOSAPFSCleanupRace(t)
-
 	mock := mockLLMServer(t, "ok")
 	gw := testutil.StartTestGateway(t,
 		testutil.WithAPIBase(mock.URL),
@@ -73,8 +71,6 @@ func TestUploadMediaRef_StoreSwapResolves(t *testing.T) {
 //	When a random bogus ref is resolved
 //	Then it gets 404
 func TestUploadMediaRef_UnknownRefDropped(t *testing.T) {
-	skipOnMacOSAPFSCleanupRace(t)
-
 	mock := mockLLMServer(t, "ok")
 	gw := testutil.StartTestGateway(t,
 		testutil.WithAPIBase(mock.URL),

--- a/tests/integration/replay_ordering_test.go
+++ b/tests/integration/replay_ordering_test.go
@@ -47,7 +47,6 @@ import (
 //
 // Traces to: Bug-5 (replay frame ordering preserved)
 func TestReplayOrdering_ToolCallStartBeforeResult(t *testing.T) {
-	skipOnMacOSAPFSCleanupRace(t)
 	gw := startIntegrationGateway(t)
 
 	// Create a session via REST API.
@@ -187,7 +186,6 @@ func TestReplayOrdering_EarlierTurnBeforeLaterTurn(t *testing.T) {
 // Traces to: Bug-5 (replay frame ordering) — multi-cycle disconnect/reconnect
 // Traces to: review-pr-test-analyzer.md — "Disconnect → reconnect → disconnect → reconnect"
 func TestReplayOrdering_DisconnectReconnectDisconnectReconnect(t *testing.T) {
-	skipOnMacOSAPFSCleanupRace(t)
 	gw := startIntegrationGateway(t)
 	sessionID := createSession(t, gw)
 	seedTwoTurnTranscript(t, gw, sessionID)
@@ -347,7 +345,6 @@ func TestReplayOrdering_LateLiveFrameDuringDrain(t *testing.T) {
 //
 // Traces to: Bug-2 (replay omits tool_call_start / tool_call_result pairs)
 func TestReplay_ToolCallPairsEmitted(t *testing.T) {
-	skipOnMacOSAPFSCleanupRace(t)
 	gw := startIntegrationGateway(t)
 	sessionID := createSession(t, gw)
 
@@ -450,8 +447,6 @@ func TestReplay_ToolCallPairsEmitted(t *testing.T) {
 //
 // Traces to: Bug-3 (assistant text lost when WS disconnects before LLM reply)
 func TestReplay_AssistantTextSurvivesDisconnect(t *testing.T) {
-	skipOnMacOSAPFSCleanupRace(t)
-
 	// Use a slow LLM (200 ms delay) so we can reliably disconnect before the
 	// server produces its first token.
 	const llmDelay = 200 * time.Millisecond

--- a/tests/integration/since_cursor_reconnect_test.go
+++ b/tests/integration/since_cursor_reconnect_test.go
@@ -39,7 +39,6 @@ import (
 //
 // Traces to: spa-streaming-refactor.md Phase 2D, T1
 func TestSinceCursor_IncrementalReplay(t *testing.T) {
-	skipOnMacOSAPFSCleanupRace(t)
 	gw := startIntegrationGateway(t)
 
 	// ── Step 1: Seed a two-turn transcript with known timestamps ──────────────
@@ -161,7 +160,6 @@ func TestSinceCursor_IncrementalReplay(t *testing.T) {
 //
 // Traces to: spa-streaming-refactor.md Phase 2D, T1 (negative case)
 func TestSinceCursor_FullReplayWithoutSince(t *testing.T) {
-	skipOnMacOSAPFSCleanupRace(t)
 	gw := startIntegrationGateway(t)
 
 	sessionID := createSession(t, gw)
@@ -249,7 +247,6 @@ func TestSinceCursor_FullReplayWithoutSince(t *testing.T) {
 //
 // Traces to: spa-streaming-refactor.md Phase 2D, T1 (boundary semantic)
 func TestSinceCursor_CursorAtExactBoundary(t *testing.T) {
-	skipOnMacOSAPFSCleanupRace(t)
 	gw := startIntegrationGateway(t)
 
 	sessionID := createSession(t, gw)
@@ -337,7 +334,6 @@ func TestSinceCursor_CursorAtExactBoundary(t *testing.T) {
 //
 // Traces to: spa-streaming-refactor.md Phase 2D, T1 (edge case: empty window)
 func TestSinceCursor_FutureCursorProducesEmptyReplay(t *testing.T) {
-	skipOnMacOSAPFSCleanupRace(t)
 	gw := startIntegrationGateway(t)
 
 	sessionID := createSession(t, gw)
@@ -414,7 +410,6 @@ func TestSinceCursor_FutureCursorProducesEmptyReplay(t *testing.T) {
 //
 // Traces to: spa-streaming-refactor.md Phase 2D, T1 (differentiation)
 func TestSinceCursor_DifferentInputsDifferentOutputs(t *testing.T) {
-	skipOnMacOSAPFSCleanupRace(t)
 	gw := startIntegrationGateway(t)
 
 	sessionID := createSession(t, gw)


### PR DESCRIPTION
## Summary

Ships the completed **v0.1.0 stabilization** work (epic #280) from `hotfix/v0.1.0` to `main`. Five fixes, each landed via its own reviewed + CI-green PR into the hotfix branch (#295, #296), all passing the mandated 7-reviewer quality gate (6 pr-review-toolkit agents + `/grill-code` architect). Also folds in the `main` docs reorg (#293/#294) merged into hotfix.

### Fixes

- **#96** — JSON 201-Created responses were served as `text/plain` (MIME-sniff XSS surface). `writeJSON`/`jsonCreated` set Content-Type before WriteHeader; four 201 handlers + upload converted.
- **#255** — `web_serve` dev mode always grabbed port 18000, so concurrent dev servers collided. New `DevServerRegistry.ReservePort` atomically allocates a free port (reserve → spawn → confirm).
- **#265** — flaky `tests/integration` cleanup race. Recap-goroutine drain + tracking the previously-untracked turn goroutines + reordering shutdown to stop heartbeat/cron before the active-turn drain + a bounded sessions-quiescence wait. The macOS APFS skip is **removed for real** — those tests now run on all three platforms (Linux/macOS/Windows-arm matrices green).
- **#73** — UI model change didn't apply to the live agent until restart. New `AgentLoop.ApplyAgentModel` switches the running instance in place (preserving context), shared by the `switch_model` tool and the REST path.
- **#289** — Channels UI stored secrets inline in `config.json` (SEC-23) so 9 token-based channels never activated. Secrets now route to the encrypted credential store via `<field>_ref`; `Test` resolves the ref and distinguishes a store fault from an absent secret; clearing a secret deletes it; stale plaintext is scrubbed.

## Quality

Every fix passed the 7-reviewer gate (the gate caught — and we fixed — real blockers: a #265 drain mis-ordering + Add-after-Wait, a #255 orphaned-child leak, and a #289 store-fault conflation that was a sibling of the original bug). `hotfix/v0.1.0` is green: lint (golangci-lint v2.10.1, 0 issues), full `go test` incl. `-race`, govulncheck, typecheck, vitest, verify-contracts, Playwright, and all three platform matrices.

## Closes

Closes #96, closes #255, closes #265, closes #73, closes #289.

## Not in this PR (v0.1.0 remaining)

#283 (WhatsApp QR live push) and #264 (autonomous agents + Schedules) are still in progress and will ship in follow-up PRs before the `v0.1.0` tag.
