### PR TITLE
channels: fix gateway crash when enabling WhatsApp via config reload

### DIFF
--- a/pkg/channels/manager.go
+++ b/pkg/channels/manager.go
@@ -1634,6 +1634,19 @@ func (m *Manager) Reload(ctx context.Context, cfg *config.Config, secrets creden
 		n := name // local copy — prevents closure from capturing the loop variable
 		// Stop all channels
 		channel := m.channels[n]
+		// Defense-in-depth: a "removed" name that never resolved to a registered
+		// channel (e.g. it failed to construct on a prior boot/reload) leaves
+		// m.channels[n] nil. Calling Stop would panic and crash the gateway. Skip the
+		// Stop but still queue the unregister so any stale bookkeeping is cleaned up.
+		if channel == nil {
+			logger.WarnCF("channels", "Skipping stop for unregistered channel", map[string]any{
+				"channel": n,
+			})
+			deferFuncs = append(deferFuncs, func() {
+				m.unregisterChannelLocked(n)
+			})
+			continue
+		}
 		logger.InfoCF("channels", "Stopping channel", map[string]any{
 			"channel": n,
 		})
@@ -1694,6 +1707,19 @@ func (m *Manager) Reload(ctx context.Context, cfg *config.Config, secrets creden
 	for _, name := range added {
 		n := name // local copy — prevents closure from capturing the loop variable
 		channel := m.channels[n]
+		// Defense-in-depth: if the diff produced an "added" name that does not resolve
+		// to a constructed channel (e.g. a config-key/registered-name mismatch, or an
+		// initChannels if-ladder that skipped a misconfigured channel), m.channels[n]
+		// is nil. Calling Start on it would panic and crash the entire gateway. Record
+		// a degraded failure, drop the hash so the channel is re-attempted on the next
+		// reload, and continue — a single missing channel must NEVER take down the bus.
+		if channel == nil {
+			m.recordChannelFailure(n, n, fmt.Errorf(
+				"reload: channel %q was marked for start but is not registered "+
+					"(config/registration name mismatch or skipped init)", n))
+			delete(list, n)
+			continue
+		}
 		logger.InfoCF("channels", "Starting channel", map[string]any{
 			"channel": n,
 		})

--- a/pkg/channels/manager_channel.go
+++ b/pkg/channels/manager_channel.go
@@ -16,6 +16,31 @@ import (
 // fields are plain strings (*Ref), they survive JSON marshal/unmarshal without any
 // special handling.
 
+// configKeyToChannelName maps a channels config JSON key to the channel name that
+// initChannels registers in m.channels (and that StartAll iterates). For almost all
+// channels the config key IS the registered name, so the map only needs the divergent
+// cases. WhatsApp is the one mismatch: its config lives under the "whatsapp" key
+// (config.ChannelsConfig.WhatsApp `json:"whatsapp"`), but initChannels registers the
+// always-native whatsmeow implementation under "whatsapp_native" (initChannel(
+// "whatsapp_native", ...)). Without this remap, a Reload that enables WhatsApp produces
+// added=["whatsapp"] while m.channels only has "whatsapp_native" — so the Reload
+// added-start loop dereferences a nil channel and crashes the gateway.
+//
+// Keeping channelHashes / compareChannels / toChannelConfig all keyed by the REGISTERED
+// name means StartAll and Reload agree, and m.channels[name] always resolves.
+var configKeyToChannelName = map[string]string{
+	"whatsapp": "whatsapp_native",
+}
+
+// channelNameForConfigKey returns the registered channel name for a channels config
+// JSON key, applying configKeyToChannelName. Keys without an entry map to themselves.
+func channelNameForConfigKey(configKey string) string {
+	if name, ok := configKeyToChannelName[configKey]; ok {
+		return name
+	}
+	return configKey
+}
+
 func toChannelHashes(cfg *config.Config) map[string]string {
 	result := make(map[string]string)
 	ch := cfg.Channels
@@ -50,7 +75,11 @@ func toChannelHashes(cfg *config.Config) map[string]string {
 			valueBytes = []byte("{}")
 		}
 		hash := md5.Sum(valueBytes)
-		result[key] = hex.EncodeToString(hash[:])
+		// Key the hash map by the REGISTERED channel name, not the raw config key,
+		// so compareChannels' added/removed lists (and m.channelHashes) line up with
+		// m.channels — which initChannels populates under the registered name. For all
+		// channels except WhatsApp these are identical; see channelNameForConfigKey.
+		result[channelNameForConfigKey(key)] = hex.EncodeToString(hash[:])
 	}
 
 	return result
@@ -99,9 +128,14 @@ func toChannelConfig(cfg *config.Config, list []string) (*config.ChannelsConfig,
 	temp := make(map[string]map[string]any, 0)
 
 	for key, value := range channelConfig {
+		// `list` holds REGISTERED channel names (the output of toChannelHashes /
+		// compareChannels), while `key` is the config JSON key. Translate the key to
+		// its registered name before matching so a list entry like "whatsapp_native"
+		// still selects the "whatsapp" config block. See channelNameForConfigKey.
+		registeredName := channelNameForConfigKey(key)
 		found := false
 		for _, s := range list {
-			if key == s {
+			if registeredName == s {
 				found = true
 				break
 			}

--- a/pkg/channels/manager_channel_test.go
+++ b/pkg/channels/manager_channel_test.go
@@ -49,3 +49,45 @@ func TestToChannelHashes(t *testing.T) {
 	assert.Equal(t, "", cc.Telegram.TokenRef)
 	assert.Equal(t, false, cc.Telegram.Enabled)
 }
+
+// TestToChannelHashes_WhatsAppMapsToNativeName is the function-level regression
+// guard for the gateway-crash bug: the WhatsApp config lives under the JSON key
+// "whatsapp", but initChannels registers the channel in m.channels under the
+// REGISTERED name "whatsapp_native". The reload diff (compareChannels) must emit
+// the registered name so m.channels[name] resolves — otherwise the Reload
+// added-start loop dereferences a nil channel and crashes the whole gateway.
+//
+// This asserts purely at the function level (toChannelHashes / compareChannels /
+// toChannelConfig) so it needs no real whatsmeow connection or network.
+func TestToChannelHashes_WhatsAppMapsToNativeName(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Channels.WhatsApp.Enabled = true
+
+	hashes := toChannelHashes(cfg)
+
+	// The hash map must be keyed by the REGISTERED name, never the config key.
+	if _, ok := hashes["whatsapp_native"]; !ok {
+		t.Fatalf("toChannelHashes must key enabled WhatsApp under the registered name "+
+			"\"whatsapp_native\"; got keys: %v", hashes)
+	}
+	if _, ok := hashes["whatsapp"]; ok {
+		t.Fatalf("toChannelHashes must NOT key WhatsApp under the raw config key "+
+			"\"whatsapp\" (that name has no channel in m.channels); got keys: %v", hashes)
+	}
+
+	// A reload that enables WhatsApp (empty old map → enabled new map) must produce
+	// added = ["whatsapp_native"] and NO phantom "whatsapp" added / "whatsapp_native"
+	// removed split.
+	added, removed := compareChannels(map[string]string{}, hashes)
+	assert.EqualValues(t, []string{"whatsapp_native"}, added,
+		"enabling WhatsApp must add the registered name, not the config key")
+	assert.EqualValues(t, []string(nil), removed,
+		"enabling WhatsApp must not mark anything removed")
+
+	// toChannelConfig must still select the WhatsApp config block when the list
+	// holds the REGISTERED name — otherwise initChannels would never see it enabled.
+	cc, err := toChannelConfig(cfg, added)
+	assert.NoError(t, err)
+	assert.True(t, cc.WhatsApp.Enabled,
+		"toChannelConfig must populate WhatsApp.Enabled when list holds \"whatsapp_native\"")
+}

--- a/pkg/channels/manager_test.go
+++ b/pkg/channels/manager_test.go
@@ -20,6 +20,7 @@ import (
 // mockChannel is a test double that delegates Send to a configurable function.
 type mockChannel struct {
 	BaseChannel
+	mu                sync.Mutex // guards the recorded-call fields for concurrent Send/SendPlaceholder/EditMessage
 	sendFn            func(ctx context.Context, msg bus.OutboundMessage) error
 	sentMessages      []bus.OutboundMessage
 	placeholdersSent  int
@@ -28,7 +29,9 @@ type mockChannel struct {
 }
 
 func (m *mockChannel) Send(ctx context.Context, msg bus.OutboundMessage) error {
+	m.mu.Lock()
 	m.sentMessages = append(m.sentMessages, msg)
+	m.mu.Unlock()
 	return m.sendFn(ctx, msg)
 }
 
@@ -36,13 +39,18 @@ func (m *mockChannel) Start(ctx context.Context) error { return nil }
 func (m *mockChannel) Stop(ctx context.Context) error  { return nil }
 
 func (m *mockChannel) SendPlaceholder(ctx context.Context, chatID string) (string, error) {
+	const id = "mock-ph-123"
+	m.mu.Lock()
 	m.placeholdersSent++
-	m.lastPlaceholderID = "mock-ph-123"
-	return m.lastPlaceholderID, nil
+	m.lastPlaceholderID = id
+	m.mu.Unlock()
+	return id, nil
 }
 
 func (m *mockChannel) EditMessage(ctx context.Context, chatID, messageID, content string) error {
+	m.mu.Lock()
 	m.editedMessages++
+	m.mu.Unlock()
 	return nil
 }
 
@@ -53,7 +61,9 @@ type mockMediaChannel struct {
 }
 
 func (m *mockMediaChannel) SendMedia(ctx context.Context, msg bus.OutboundMediaMessage) error {
+	m.mu.Lock()
 	m.sentMediaMessages = append(m.sentMediaMessages, msg)
+	m.mu.Unlock()
 	if m.sendMediaFn != nil {
 		return m.sendMediaFn(ctx, msg)
 	}

--- a/pkg/channels/manager_test.go
+++ b/pkg/channels/manager_test.go
@@ -2171,3 +2171,183 @@ func TestReload_NoRaceWithReaders(t *testing.T) {
 		t.Fatalf("expected mock channel to be removed after Reload")
 	}
 }
+
+// withFactory registers a channel factory for the duration of a test and restores
+// the previous registration (if any) on cleanup, so package-global factory state
+// does not leak between tests.
+func withFactory(t *testing.T, name string, f ChannelFactory) {
+	t.Helper()
+	factoriesMu.Lock()
+	prev, had := factories[name]
+	factories[name] = f
+	factoriesMu.Unlock()
+	t.Cleanup(func() {
+		factoriesMu.Lock()
+		if had {
+			factories[name] = prev
+		} else {
+			delete(factories, name)
+		}
+		factoriesMu.Unlock()
+	})
+}
+
+// removeFactoryForTest ensures no factory is registered under name for the duration
+// of a test, restoring any previous registration on cleanup.
+func removeFactoryForTest(t *testing.T, name string) {
+	t.Helper()
+	factoriesMu.Lock()
+	prev, had := factories[name]
+	delete(factories, name)
+	factoriesMu.Unlock()
+	t.Cleanup(func() {
+		factoriesMu.Lock()
+		if had {
+			factories[name] = prev
+		} else {
+			delete(factories, name)
+		}
+		factoriesMu.Unlock()
+	})
+}
+
+// TestReload_AddedChannelMissingFromMap_NoPanic is the regression guard for the
+// gateway-crash bug (part 1: defense-in-depth). It drives a real Reload that
+// enables WhatsApp while NO factory is registered for "whatsapp_native", so
+// initChannels records a failure and does NOT construct the channel — yet the
+// reload diff still lists "whatsapp_native" in `added`. Before the fix, the
+// added-start loop did `m.channels["whatsapp_native"].Start(ctx)` on a nil
+// channel and panicked, crashing the whole gateway. The nil guard must instead
+// record a degraded failure and return cleanly.
+func TestReload_AddedChannelMissingFromMap_NoPanic(t *testing.T) {
+	// Ensure no factory is registered for the WhatsApp native name for this test, and
+	// restore whatever was there afterward. unregisterFactory removes the entry; the
+	// cleanup runs even though we never set a replacement.
+	removeFactoryForTest(t, "whatsapp_native")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	m := &Manager{
+		channels:      make(map[string]Channel),
+		workers:       make(map[string]*channelWorker),
+		bus:           bus.NewMessageBus(),
+		config:        &config.Config{},
+		channelHashes: make(map[string]string),
+	}
+	if err := m.StartAll(ctx); err != nil {
+		t.Fatalf("StartAll: %v", err)
+	}
+
+	cfg := config.DefaultConfig()
+	cfg.Channels.WhatsApp.Enabled = true
+
+	// This Reload MUST NOT panic. recover() turns a panic into a test failure with a
+	// clear message instead of crashing the test binary (mirrors the gateway crash).
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("Reload panicked on an added channel missing from m.channels "+
+					"(the gateway-crash regression): %v", r)
+			}
+		}()
+		if err := m.Reload(ctx, cfg, credentials.SecretBundle{}); err != nil {
+			t.Fatalf("Reload returned error: %v", err)
+		}
+	}()
+
+	// The missing channel must be recorded as a degraded failure, not started.
+	if _, ok := m.GetChannel("whatsapp_native"); ok {
+		t.Fatalf("whatsapp_native must not be registered when its factory is missing")
+	}
+	failed := m.FailedChannels()
+	found := false
+	for _, f := range failed {
+		if f.Name == "whatsapp_native" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected a recorded channel failure for whatsapp_native, got: %+v", failed)
+	}
+}
+
+// TestReload_EnableWhatsApp_StartsNativeChannel is the regression guard for the
+// root fix (part 2: name consistency). It registers a mock factory under the
+// REGISTERED name "whatsapp_native" (no real whatsmeow / network), enables the
+// "whatsapp" config key, and asserts the Reload diff resolves the config key to
+// the registered name so the channel is actually constructed, started, and
+// registered under "whatsapp_native" — and that no phantom "whatsapp" entry
+// lingers. Before the fix, `added` held "whatsapp" (config key), which never
+// matched m.channels and so never started.
+func TestReload_EnableWhatsApp_StartsNativeChannel(t *testing.T) {
+	started := make(chan struct{}, 1)
+	withFactory(t, "whatsapp_native", func(*config.Config, credentials.SecretBundle, *bus.MessageBus) (Channel, error) {
+		return &mockChannelStartSignal{started: started}, nil
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	m := &Manager{
+		channels:      make(map[string]Channel),
+		workers:       make(map[string]*channelWorker),
+		bus:           bus.NewMessageBus(),
+		config:        &config.Config{},
+		channelHashes: make(map[string]string),
+	}
+	if err := m.StartAll(ctx); err != nil {
+		t.Fatalf("StartAll: %v", err)
+	}
+
+	cfg := config.DefaultConfig()
+	cfg.Channels.WhatsApp.Enabled = true
+
+	if err := m.Reload(ctx, cfg, credentials.SecretBundle{}); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+
+	// The channel must be registered under the REGISTERED name, not the config key.
+	if _, ok := m.GetChannel("whatsapp_native"); !ok {
+		t.Fatalf("expected whatsapp_native to be registered after enabling WhatsApp")
+	}
+	if _, ok := m.GetChannel("whatsapp"); ok {
+		t.Fatalf("a phantom \"whatsapp\" channel must not be registered")
+	}
+
+	// Start must have been called on the constructed channel.
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("whatsapp_native channel was never Start()ed after Reload")
+	}
+
+	// The committed hash must be keyed by the registered name so subsequent reloads
+	// are stable (no spurious add/remove churn).
+	m.mu.RLock()
+	_, hasNative := m.channelHashes["whatsapp_native"]
+	_, hasPhantom := m.channelHashes["whatsapp"]
+	m.mu.RUnlock()
+	if !hasNative {
+		t.Fatalf("channelHashes must be keyed by \"whatsapp_native\"; got %v", m.channelHashes)
+	}
+	if hasPhantom {
+		t.Fatalf("channelHashes must not contain the phantom \"whatsapp\" key")
+	}
+}
+
+// mockChannelStartSignal is a mockChannel whose Start signals a channel, letting a
+// test confirm the manager actually started it.
+type mockChannelStartSignal struct {
+	mockChannel
+	started chan struct{}
+}
+
+func (m *mockChannelStartSignal) Start(context.Context) error {
+	select {
+	case m.started <- struct{}{}:
+	default:
+	}
+	return nil
+}


### PR DESCRIPTION
## What
Enabling the WhatsApp channel through the UI (Save & Enable triggers a config **reload**) **crashed the entire gateway** with a nil-pointer panic in `Manager.Reload` (`manager.go:1700`, `channel.Start` on a nil `m.channels[n]`). This was also the real cause of the **"WhatsApp QR never renders"** report — the gateway was dying on enable.

Regression introduced by the always-native WhatsApp change in #308 (already merged to this branch); found during a live non-technical-user review.

## Root cause
The reload channel diff is built from config JSON keys (`toChannelHashes` keys by the `whatsapp` struct tag), but `m.channels` is keyed by the **registered** name `whatsapp_native` (always-native init). So a reload enabling WhatsApp produced `added=["whatsapp"]` while `m.channels` only had `whatsapp_native` → nil → panic. `StartAll` was unaffected (it ranges `m.channels` directly).

## Fix (two parts)
1. **Defense-in-depth:** the Reload added-start and removed-stop loops now nil-guard `m.channels[n]` → `recordChannelFailure` + continue. A missing/mismatched channel degrades gracefully and can **never crash the gateway**.
2. **Name consistency:** a `configKeyToChannelName` map (`whatsapp → whatsapp_native`); `toChannelHashes` keys by the registered name and `toChannelConfig` translates back — so `added=["whatsapp_native"]` resolves and WhatsApp actually **starts** on reload (no phantom add/remove). Other channels (config key == registered name) unaffected.

## Tests
- `TestReload_AddedChannelMissingFromMap_NoPanic` (part 1)
- `TestReload_EnableWhatsApp_StartsNativeChannel` + `TestToChannelHashes_WhatsAppMapsToNativeName` (part 2)
- All three **verified to fail when the fix is reverted**.

## Verification
gofmt clean · `go test ./pkg/channels/...` ok · `-race` clean · golangci-lint 0 · build 0. **Live repro:** on the fixed binary, enable WhatsApp + `/reload` keeps the gateway alive (`state: 200`, 0 panics); the old binary returned `state: 000` (crashed).

Base is `hotfix/v0.1.0`.