### PR TITLE
fix(evals): surface gateway stdout in nightly eval CI logs

### DIFF
--- a/evals/cmd/eval-runner/main.go
+++ b/evals/cmd/eval-runner/main.go
@@ -300,7 +300,7 @@ func startGateway(ctx context.Context, omnipusBin, homeDir string) (*gatewayHand
 		"OMNIPUS_HOME="+homeDir,
 		"OMNIPUS_BEARER_TOKEN=",
 	)
-	cmd.Stdout = io.Discard
+	cmd.Stdout = os.Stderr
 	cmd.Stderr = os.Stderr
 	if err := cmd.Start(); err != nil {
 		return nil, fmt.Errorf("start gateway: %w", err)
@@ -321,7 +321,7 @@ func startGateway(ctx context.Context, omnipusBin, homeDir string) (*gatewayHand
 	}
 	if port == "" {
 		cmd.Process.Kill() //nolint:errcheck
-		return nil, fmt.Errorf("gateway did not write port file within 30s")
+		return nil, fmt.Errorf("gateway did not write port file within 60s")
 	}
 
 	baseURL := "http://127.0.0.1:" + port


### PR DESCRIPTION
## Summary

- Routes gateway `stdout` to `os.Stderr` (was `io.Discard`) in the nightly eval runner so all gateway output appears in CI logs when startup fails
- Fixes a stale error message: the port-file timeout is 60 seconds, not 30 as the error string claimed

The nightly eval job has been failing with `gateway did not write port file within 30s` since the v0.1.0 release merge. Because stdout was discarded, the actual cause (whatever the gateway prints before crashing or hanging) was invisible. This change makes the next failure diagnosable without any other code changes.

## Test plan

- [x] `CGO_ENABLED=0 go build ./evals/cmd/eval-runner/...` passes
- [ ] Next nightly run at 02:00 UTC will show gateway logs on failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)