### PR TITLE
feat(ui): shadcn date/time picker — replace all native date inputs (ADR-030 section 10)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "katex": "^0.17.0",
         "mermaid": "^11.15.0",
         "qrcode.react": "^4.2.0",
+        "react-day-picker": "^9.14.0",
         "react-markdown": "^10.1.0",
         "react-shiki": "^0.10.1",
         "rehype-katex": "^7.0.1",
@@ -871,6 +872,12 @@
       "engines": {
         "node": ">17.0.0"
       }
+    },
+    "node_modules/@date-fns/tz": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.5.0.tgz",
+      "integrity": "sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg==",
+      "license": "MIT"
     },
     "node_modules/@dnd-kit/accessibility": {
       "version": "3.1.1",
@@ -7202,6 +7209,15 @@
         "node": "^12.20 || >=14.13"
       }
     },
+    "node_modules/@tabby_ai/hijri-converter": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@tabby_ai/hijri-converter/-/hijri-converter-1.0.5.tgz",
+      "integrity": "sha512-r5bClKrcIusDoo049dSL8CawnHR6mRdDwhlQuIgZRNty68q0x8k3Lf1BtPAMxRf/GgnHBnIO4ujd3+GQdLWzxQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.0.tgz",
@@ -9951,6 +9967,22 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/date-fns": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/date-fns-jalali": {
+      "version": "4.1.0-0",
+      "resolved": "https://registry.npmjs.org/date-fns-jalali/-/date-fns-jalali-4.1.0-0.tgz",
+      "integrity": "sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==",
+      "license": "MIT"
     },
     "node_modules/dayjs": {
       "version": "1.11.21",
@@ -14670,6 +14702,28 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-day-picker": {
+      "version": "9.14.0",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-9.14.0.tgz",
+      "integrity": "sha512-tBaoDWjPwe0M5pGrum4H0SR6Lyk+BO9oHnp9JbKpGKW2mlraNPgP9BMfsg5pWpwrssARmeqk7YBl2oXutZTaHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@date-fns/tz": "^1.4.1",
+        "@tabby_ai/hijri-converter": "1.0.5",
+        "date-fns": "^4.1.0",
+        "date-fns-jalali": "4.1.0-0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/gpbl"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "katex": "^0.17.0",
     "mermaid": "^11.15.0",
     "qrcode.react": "^4.2.0",
+    "react-day-picker": "^9.14.0",
     "react-markdown": "^10.1.0",
     "react-shiki": "^0.10.1",
     "rehype-katex": "^7.0.1",

--- a/src/components/calendar/MilestoneDatePopover.test.tsx
+++ b/src/components/calendar/MilestoneDatePopover.test.tsx
@@ -9,14 +9,46 @@
  * Strategy: mount MilestoneDatePopover wrapped in QueryClientProvider + mock
  * updateMilestone / addToast. Fire submit/cancel interactions with RTL and assert
  * on API calls, toast variant, and dialog open/closed state.
+ *
+ * The date field is a shadcn DatePicker (Popover + Calendar), not a native
+ * `<input type="date">` (ADR-030 §10) — days are picked via react-day-picker's
+ * `data-day="YYYY-MM-DD"` day-cell attribute rather than by typing into an input.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, waitFor, act } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { render, screen, waitFor, act, fireEvent } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { MilestoneDatePopover } from './MilestoneDatePopover'
 import type { MilestoneTarget } from './types'
+
+// Click a react-day-picker day cell (data-day="YYYY-MM-DD") inside the open DatePicker popover.
+function clickDay(isoDate: string) {
+  const btn = document.querySelector(`[data-day="${isoDate}"] button`)
+  if (!btn) throw new Error(`no day button for ${isoDate}`)
+  fireEvent.click(btn)
+}
+
+// The DatePicker trigger — queried by its DOM id (DatePicker forwards `id` to the
+// trigger <Button>, same identifier the old native input used).
+function dateTrigger(): HTMLElement {
+  const el = document.getElementById('milestone-date-input')
+  if (!el) throw new Error('date trigger not found')
+  return el
+}
+
+// When no value is set, the calendar opens on the real "today" month (react-day-picker's
+// own default), not the target month — navigate forward/back via the Nav buttons so the
+// target day is on-screen regardless of when the suite happens to run.
+function navigateToMonth(isoDate: string) {
+  const [y, m] = isoDate.split('-').map(Number)
+  const target = new Date(y, m - 1, 1)
+  const now = new Date()
+  const diff = (target.getFullYear() - now.getFullYear()) * 12 + (target.getMonth() - now.getMonth())
+  const label = diff >= 0 ? /go to the next month/i : /go to the previous month/i
+  for (let i = 0; i < Math.abs(diff); i++) {
+    fireEvent.click(screen.getByRole('button', { name: label }))
+  }
+}
 
 // ── 1. Mock @/lib/api ─────────────────────────────────────────────────────────
 
@@ -106,22 +138,20 @@ describe('MilestoneDatePopover — prefill (spec §9 #18 / FR-009 / C-5)', () =>
     // Traces to: workspace-calendar-fullcalendar-spec.md §9 #18 / US-5/AS-2 / C-5
     // BDD: Given the dialog opens with milestone.due_date = "2026-06-25",
     // When the dialog renders,
-    // Then the date input value is "2026-06-25".
+    // Then the DatePicker trigger shows "Jun 25, 2026".
 
     renderPopover({ milestone: makeMilestone({ due_date: '2026-06-25' }) })
 
-    const input = screen.getByTestId('milestone-date-input') as HTMLInputElement
-    expect(input.value).toBe('2026-06-25')
+    expect(dateTrigger()).toHaveTextContent('Jun 25, 2026')
   })
 
   it('prefills empty string when milestone.due_date is null', async () => {
     // Traces to: workspace-calendar-fullcalendar-spec.md §9 #18 / C-5
-    // BDD: Given milestone.due_date is null, the input starts empty.
+    // BDD: Given milestone.due_date is null, the DatePicker starts empty (placeholder shown).
 
     renderPopover({ milestone: makeMilestone({ due_date: null }) })
 
-    const input = screen.getByTestId('milestone-date-input') as HTMLInputElement
-    expect(input.value).toBe('')
+    expect(dateTrigger()).toHaveTextContent('Pick a date')
   })
 
   it('differentiation: two different milestone.due_dates prefill two different values', async () => {
@@ -132,16 +162,14 @@ describe('MilestoneDatePopover — prefill (spec §9 #18 / FR-009 / C-5)', () =>
     const { unmount: unmount1 } = renderPopover({
       milestone: makeMilestone({ id: 'ms-A', due_date: '2026-06-01' }),
     })
-    const input1 = screen.getByTestId('milestone-date-input') as HTMLInputElement
-    expect(input1.value).toBe('2026-06-01')
+    expect(dateTrigger()).toHaveTextContent('Jun 1, 2026')
     unmount1()
 
     // Second render: ms-B with due_date "2026-07-15"
     renderPopover({
       milestone: makeMilestone({ id: 'ms-B', due_date: '2026-07-15' }),
     })
-    const input2 = screen.getByTestId('milestone-date-input') as HTMLInputElement
-    expect(input2.value).toBe('2026-07-15')
+    expect(dateTrigger()).toHaveTextContent('Jul 15, 2026')
   })
 })
 
@@ -159,7 +187,8 @@ describe('MilestoneDatePopover — empty date disables Save (spec §9 #18)', () 
   it('Save button is disabled after clearing a non-null due_date (clear-to-null path is unreachable via UI)', async () => {
     // Traces to: workspace-calendar-fullcalendar-spec.md §9 #18 / FR-009 / C-5
     // BDD: Given the dialog opens with a non-null due_date ("2026-06-25"),
-    // When the user clears the input to empty,
+    // When the user clears the date by clicking the already-selected day again
+    // (react-day-picker single-select deselects on a repeat click),
     // Then the Save button is DISABLED — confirming the clear-to-null path is
     // intentionally unreachable via normal UI interaction (Save is gated on !dateValue).
     //
@@ -170,12 +199,12 @@ describe('MilestoneDatePopover — empty date disables Save (spec §9 #18)', () 
 
     renderPopover({ milestone: makeMilestone({ due_date: '2026-06-25' }) })
 
-    const input = screen.getByTestId('milestone-date-input') as HTMLInputElement
     // Prefilled with "2026-06-25" — Save is enabled
     expect(screen.getByTestId('milestone-date-save')).not.toBeDisabled()
 
-    // Clear the input — simulates the user selecting all and deleting
-    await userEvent.clear(input)
+    // Clear the date — open the picker and click the already-selected day to deselect it.
+    fireEvent.click(dateTrigger())
+    clickDay('2026-06-25')
 
     // After clearing, dateValue is '' → Save must be disabled (button disabled={!dateValue})
     expect(screen.getByTestId('milestone-date-save')).toBeDisabled()
@@ -188,8 +217,9 @@ describe('MilestoneDatePopover — empty date disables Save (spec §9 #18)', () 
 
     renderPopover({ milestone: makeMilestone({ due_date: null }) })
 
-    const input = screen.getByTestId('milestone-date-input')
-    await userEvent.type(input, '2026-08-01')
+    fireEvent.click(dateTrigger())
+    navigateToMonth('2026-08-01')
+    clickDay('2026-08-01')
 
     const saveBtn = screen.getByTestId('milestone-date-save')
     expect(saveBtn).not.toBeDisabled()
@@ -217,10 +247,10 @@ describe('MilestoneDatePopover — Save success (spec §9 #18 / FR-010 / I-5)', 
       onRescheduled,
     })
 
-    // Change the date value to something new
-    const input = screen.getByTestId('milestone-date-input') as HTMLInputElement
-    await userEvent.clear(input)
-    await userEvent.type(input, '2026-06-28')
+    // Change the date value to something new — same month as the prefill (June 2026),
+    // so no calendar navigation is needed.
+    fireEvent.click(dateTrigger())
+    clickDay('2026-06-28')
 
     await act(async () => {
       screen.getByTestId('milestone-date-save').click()
@@ -260,9 +290,8 @@ describe('MilestoneDatePopover — Save success (spec §9 #18 / FR-010 / I-5)', 
       onClose: onClose1,
     })
 
-    const input1 = screen.getByTestId('milestone-date-input') as HTMLInputElement
-    await userEvent.clear(input1)
-    await userEvent.type(input1, '2026-06-10')
+    fireEvent.click(dateTrigger())
+    clickDay('2026-06-10')
     await act(async () => {
       screen.getByTestId('milestone-date-save').click()
     })
@@ -281,9 +310,8 @@ describe('MilestoneDatePopover — Save success (spec §9 #18 / FR-010 / I-5)', 
       onClose: onClose2,
     })
 
-    const input2 = screen.getByTestId('milestone-date-input') as HTMLInputElement
-    await userEvent.clear(input2)
-    await userEvent.type(input2, '2026-07-20')
+    fireEvent.click(dateTrigger())
+    clickDay('2026-07-20')
     await act(async () => {
       screen.getByTestId('milestone-date-save').click()
     })
@@ -342,7 +370,7 @@ describe('MilestoneDatePopover — closed when milestone is null', () => {
 
     renderPopover({ milestone: null })
 
-    // The dialog should be closed — no date input visible
-    expect(screen.queryByTestId('milestone-date-input')).not.toBeInTheDocument()
+    // The dialog should be closed — no DatePicker trigger visible
+    expect(document.getElementById('milestone-date-input')).not.toBeInTheDocument()
   })
 })

--- a/src/components/calendar/MilestoneDatePopover.tsx
+++ b/src/components/calendar/MilestoneDatePopover.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useMutation } from '@tanstack/react-query'
 import {
   Dialog,
@@ -8,8 +8,10 @@ import {
   DialogFooter,
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
+import { DatePicker } from '@/components/ui/date-picker'
 import { updateMilestone } from '@/lib/api'
 import { useUiStore } from '@/store/ui'
+import { parseLocalDate, formatLocalDate } from '@/lib/calendar/eventMapping'
 import type { MilestoneDatePopoverProps } from './types'
 
 /**
@@ -35,7 +37,6 @@ export function MilestoneDatePopover({
   onRescheduled,
 }: MilestoneDatePopoverProps) {
   const addToast = useUiStore((s) => s.addToast)
-  const inputRef = useRef<HTMLInputElement>(null)
 
   // Local date string state — YYYY-MM-DD
   const [dateValue, setDateValue] = useState<string>('')
@@ -48,14 +49,16 @@ export function MilestoneDatePopover({
     }
   }, [milestone])
 
-  // Focus the date input on open. This setTimeout is LOAD-BEARING: without it Radix's
-  // focus trap would land on the first tabbable element (the Cancel button). Moving focus
-  // explicitly to the input lets the user start editing immediately (C-4).
+  // Focus the date picker trigger on open. This setTimeout is LOAD-BEARING: without it
+  // Radix's focus trap would land on the first tabbable element (the Cancel button).
+  // Moving focus explicitly to the trigger lets the user start editing immediately (C-4).
+  // DatePicker's trigger is a plain <Button> (no ref forwarding), so focus is driven via
+  // the DOM id it renders with rather than a React ref.
   useEffect(() => {
     if (milestone != null) {
       // Small defer so the dialog animation does not fight focus management.
       const id = setTimeout(() => {
-        inputRef.current?.focus()
+        document.getElementById('milestone-date-input')?.focus()
       }, 50)
       return () => clearTimeout(id)
     }
@@ -149,24 +152,10 @@ export function MilestoneDatePopover({
             >
               Due date
             </label>
-            <input
-              ref={inputRef}
+            <DatePicker
               id="milestone-date-input"
-              type="date"
-              value={dateValue}
-              onChange={(e) => setDateValue(e.target.value)}
-              data-testid="milestone-date-input"
-              className={[
-                'h-10 w-full rounded-md border border-[var(--color-border)]',
-                'bg-[var(--color-surface-2)] px-3 py-2',
-                'text-sm text-[var(--color-secondary)]',
-                'placeholder:text-[var(--color-muted)]',
-                'focus:outline-none focus:ring-2 focus:ring-[var(--color-accent)] focus:ring-offset-2',
-                'focus:ring-offset-[var(--color-surface-1)]',
-                'disabled:cursor-not-allowed disabled:opacity-50',
-                // date inputs in Chromium need explicit color-scheme to honour dark bg
-                '[color-scheme:dark]',
-              ].join(' ')}
+              value={parseLocalDate(dateValue)}
+              onChange={(d) => setDateValue(d ? formatLocalDate(d) : '')}
               disabled={mutation.isPending}
               aria-label="New due date"
             />

--- a/src/components/calendar/MilestoneDatePopover.tsx
+++ b/src/components/calendar/MilestoneDatePopover.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useMutation } from '@tanstack/react-query'
 import {
   Dialog,
@@ -41,6 +41,10 @@ export function MilestoneDatePopover({
   // Local date string state — YYYY-MM-DD
   const [dateValue, setDateValue] = useState<string>('')
 
+  // DatePicker forwards its ref to the trigger <Button>, so focus can be
+  // driven directly via a ref instead of a DOM id lookup.
+  const inputRef = useRef<HTMLButtonElement>(null)
+
   // Prefill the date input whenever the dialog opens (milestone becomes non-null).
   // Controlled-open prefill ownership is the dialog's: it reads milestone.due_date.
   useEffect(() => {
@@ -52,13 +56,11 @@ export function MilestoneDatePopover({
   // Focus the date picker trigger on open. This setTimeout is LOAD-BEARING: without it
   // Radix's focus trap would land on the first tabbable element (the Cancel button).
   // Moving focus explicitly to the trigger lets the user start editing immediately (C-4).
-  // DatePicker's trigger is a plain <Button> (no ref forwarding), so focus is driven via
-  // the DOM id it renders with rather than a React ref.
   useEffect(() => {
     if (milestone != null) {
       // Small defer so the dialog animation does not fight focus management.
       const id = setTimeout(() => {
-        document.getElementById('milestone-date-input')?.focus()
+        inputRef.current?.focus()
       }, 50)
       return () => clearTimeout(id)
     }
@@ -153,6 +155,7 @@ export function MilestoneDatePopover({
               Due date
             </label>
             <DatePicker
+              ref={inputRef}
               id="milestone-date-input"
               value={parseLocalDate(dateValue)}
               onChange={(d) => setDateValue(d ? formatLocalDate(d) : '')}

--- a/src/components/command-center/ScheduleFormSheet.test.tsx
+++ b/src/components/command-center/ScheduleFormSheet.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ScheduleFormSheet } from './ScheduleFormSheet'
@@ -592,5 +592,87 @@ describe('ScheduleFormSheet — workers excluded from the owner picker', () => {
     const body = vi.mocked(createSchedule).mock.calls[0][0]
     // The first non-worker agent (Mia) is chosen, NOT the default:true worker.
     expect(body.owner_agent_id).toBe('mia')
+  })
+})
+
+// ── DateTimePicker round-trip for "Run at" (kind:'at') ─────────────────────
+//
+// The "Once" trigger's date/time is picked via the shadcn DateTimePicker
+// (Popover + Calendar + Hour/Minute <Select>s), not a native
+// `<input type="datetime-local">`. This exercises the full pick → submit →
+// payload path end to end (complementing the pure-function coverage in
+// taskFormFields.test.ts and cronRoundTrip.test.ts).
+
+describe('ScheduleFormSheet — DateTimePicker round-trip for "Run at" (kind:\'at\')', () => {
+  beforeAll(() => {
+    if (!Element.prototype.hasPointerCapture) {
+      Element.prototype.hasPointerCapture = () => false
+    }
+    if (!Element.prototype.scrollIntoView) {
+      Element.prototype.scrollIntoView = () => {}
+    }
+    if (typeof window !== 'undefined' && !window.ResizeObserver) {
+      window.ResizeObserver = class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      } as unknown as typeof ResizeObserver
+    }
+  })
+
+  function runAtTrigger(): HTMLElement {
+    const el = document.getElementById('schedule-at')
+    if (!el) throw new Error('Run at trigger not found')
+    return el
+  }
+
+  function clickDay(isoDate: string) {
+    const btn = document.querySelector(`[data-day="${isoDate}"] button`)
+    if (!btn) throw new Error(`no day button for ${isoDate}`)
+    fireEvent.click(btn)
+  }
+
+  function selectOption(comboboxName: string, optionName: string) {
+    fireEvent.click(screen.getByRole('combobox', { name: comboboxName }))
+    const option = screen.getByRole('option', { name: optionName })
+    fireEvent.pointerDown(option, { pointerId: 1, button: 0 })
+    fireEvent.click(option)
+  }
+
+  // The calendar opens on real "today" (react-day-picker's own default) when
+  // no value is set yet — navigate to the target month regardless of when
+  // the suite happens to run (same pattern as date-time-picker.test.tsx).
+  function navigateToMonth(isoDate: string) {
+    const [y, m] = isoDate.split('-').map(Number)
+    const target = new Date(y, m - 1, 1)
+    const now = new Date()
+    const diff = (target.getFullYear() - now.getFullYear()) * 12 + (target.getMonth() - now.getMonth())
+    const label = diff >= 0 ? /go to the next month/i : /go to the previous month/i
+    for (let i = 0; i < Math.abs(diff); i++) {
+      fireEvent.click(screen.getByRole('button', { name: label }))
+    }
+  }
+
+  it('picking a date + time in the "Run at" picker submits the matching at_ms', async () => {
+    renderForm({ defaultOwnerAgentId: 'mia' })
+    await screen.findByText('New schedule')
+
+    fireEvent.change(screen.getByPlaceholderText(/Daily PR summary/i), { target: { value: 'T' } })
+    fireEvent.change(screen.getByPlaceholderText(/Summarize today/i), { target: { value: 'M' } })
+
+    // Default trigger mode is already "Once" (AC4) — open the "Run at"
+    // DateTimePicker directly and pick a specific date + time.
+    fireEvent.click(runAtTrigger())
+    navigateToMonth('2026-09-10')
+    clickDay('2026-09-10')
+    selectOption('Hour', '12')
+    selectOption('Minute', '30')
+
+    fireEvent.click(screen.getByRole('button', { name: /create schedule/i }))
+
+    await waitFor(() => expect(createSchedule).toHaveBeenCalledTimes(1))
+    const body = vi.mocked(createSchedule).mock.calls[0][0]
+    expect(body.trigger.kind).toBe('at')
+    expect(body.trigger.at_ms).toBe(new Date(2026, 8, 10, 12, 30).getTime())
   })
 })

--- a/src/components/command-center/ScheduleFormSheet.tsx
+++ b/src/components/command-center/ScheduleFormSheet.tsx
@@ -24,7 +24,7 @@ import {
 } from '@/lib/api'
 import type { Schedule, ScheduleCreate, ScheduleUpdate, ScheduleTrigger } from '@/lib/api/generated/openapi-types'
 import { useUiStore } from '@/store/ui'
-import { toDatetimeLocalValue } from '@/components/workspaces/taskFormFields'
+import { datetimeLocalToDate, dateToDatetimeLocal } from '@/components/workspaces/taskFormFields'
 import { triggerSummary } from './SchedulesList'
 import {
   UNIT_MS,
@@ -672,8 +672,8 @@ function WhenSection({ form, setValue, triggerServerError }: WhenSectionProps) {
         <Field label="Run at" htmlFor="schedule-at">
           <DateTimePicker
             id="schedule-at"
-            value={form.atLocal ? new Date(form.atLocal) : null}
-            onChange={(d) => setValue('atLocal', d ? toDatetimeLocalValue(d.getTime()) : '')}
+            value={datetimeLocalToDate(form.atLocal)}
+            onChange={(d) => setValue('atLocal', dateToDatetimeLocal(d))}
           />
         </Field>
       )}

--- a/src/components/command-center/ScheduleFormSheet.tsx
+++ b/src/components/command-center/ScheduleFormSheet.tsx
@@ -14,6 +14,7 @@ import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
 import { Textarea } from '@/components/ui/textarea'
 import { SmartSelect } from '@/components/ui/smart-select'
+import { DateTimePicker } from '@/components/ui/date-time-picker'
 import {
   fetchAgents,
   createSchedule,
@@ -23,6 +24,7 @@ import {
 } from '@/lib/api'
 import type { Schedule, ScheduleCreate, ScheduleUpdate, ScheduleTrigger } from '@/lib/api/generated/openapi-types'
 import { useUiStore } from '@/store/ui'
+import { toDatetimeLocalValue } from '@/components/workspaces/taskFormFields'
 import { triggerSummary } from './SchedulesList'
 import {
   UNIT_MS,
@@ -668,12 +670,10 @@ function WhenSection({ form, setValue, triggerServerError }: WhenSectionProps) {
       {/* Once */}
       {form.friendlyMode === 'once' && (
         <Field label="Run at" htmlFor="schedule-at">
-          <Input
+          <DateTimePicker
             id="schedule-at"
-            type="datetime-local"
-            value={form.atLocal}
-            onChange={(e) => setValue('atLocal', e.target.value)}
-            className="text-xs"
+            value={form.atLocal ? new Date(form.atLocal) : null}
+            onChange={(d) => setValue('atLocal', d ? toDatetimeLocalValue(d.getTime()) : '')}
           />
         </Field>
       )}

--- a/src/components/command-center/TaskDetailPanel.test.tsx
+++ b/src/components/command-center/TaskDetailPanel.test.tsx
@@ -9,11 +9,12 @@
  * the 7-state lifecycle: inbox/next/planning/in_progress/blocked/done/failed.
  */
 
+import { useState } from 'react'
 import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest'
 import { render, screen, fireEvent, act, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { TaskDetailPanel } from './TaskDetailPanel'
-import type { Task } from '@/lib/api'
+import type { Task, TaskUpdateRequest } from '@/lib/api'
 
 // DateTimePicker (shadcn Calendar + Select) needs these jsdom polyfills to open
 // (same gap noted in date-time-picker.test.tsx).
@@ -497,6 +498,32 @@ describe('TaskDetailPanel — editable trigger', () => {
     const arg = lastUpdateArg(updateTask)
     expect(arg.trigger?.config.cron_expr).toBe('15 6 * * *')
   })
+
+  it('picking a date + time for the "Once" trigger PATCHes trigger.config.at_ms', async () => {
+    // Note: triggerKind (and therefore whether the "Once" DateTimePicker is
+    // rendered at all) is derived straight from `task.trigger?.type`, not
+    // from any local echo of a SmartSelect pick — this test's `task` prop
+    // (via renderPanel) is static, so it starts already on the "once" kind
+    // with no at_ms yet (mirrors a freshly-created once-trigger task), rather
+    // than switching kinds through the SmartSelect mid-test.
+    const { updateTask } = await import('@/lib/api')
+    renderPanel(makeTask({ id: 'task-trig-once', status: 'next', trigger: { type: 'once', config: {} } }))
+
+    fireEvent.click(await screen.findByRole('button', { name: /trigger date and time/i }))
+    navigateToMonth('2026-09-10')
+    clickDay('2026-09-10')
+    selectOption('Hour', '08')
+    selectOption('Minute', '15')
+
+    const expectedAtMs = new Date('2026-09-10T08:15').getTime()
+    // Debounced autosave — poll the LAST recorded PATCH until it reflects the
+    // fully-composed pick (robust regardless of how many PATCHes preceded it).
+    await waitFor(() => {
+      const arg = lastUpdateArg(updateTask)
+      expect(arg.trigger?.type).toBe('once')
+      expect(arg.trigger?.config.at_ms).toBe(expectedAtMs)
+    }, { timeout: 3000 })
+  })
 })
 
 describe('TaskDetailPanel — editable due date', () => {
@@ -506,9 +533,91 @@ describe('TaskDetailPanel — editable due date', () => {
 
     await pickDueDateTime({ isoDate: '2026-09-10', hour: '12', minute: '30' })
 
-    await waitFor(() => expect(vi.mocked(updateTask)).toHaveBeenCalled())
+    // Debounced autosave (~500ms after the last pick) — give it room beyond
+    // the default waitFor timeout so this isn't a timing-flaky assertion.
+    await waitFor(() => expect(vi.mocked(updateTask)).toHaveBeenCalled(), { timeout: 3000 })
     const arg = lastUpdateArg(updateTask)
     expect(arg.due).toBe(new Date('2026-09-10T12:30').toISOString())
+  })
+
+  it('a day→hour→minute pick sequence results in a single PATCH carrying the final composed value', async () => {
+    // Reviewer fix: day, hour, and minute each fire a separate onChange from
+    // the DateTimePicker. Before debouncing, each one PATCHed independently —
+    // 3 sequential requests with intermediate (partially-composed) values,
+    // and a risk of them resolving out of order. Now they coalesce into ONE
+    // PATCH carrying the final, fully-composed date.
+    const { updateTask } = await import('@/lib/api')
+    renderPanel(makeTask({ id: 'task-due-single-patch', status: 'next' }))
+
+    await pickDueDateTime({ isoDate: '2026-09-10', hour: '12', minute: '30' })
+
+    await waitFor(() => expect(vi.mocked(updateTask)).toHaveBeenCalled(), { timeout: 3000 })
+    // Give any (incorrect) extra debounced PATCHes a moment to have fired too.
+    await new Promise((resolve) => setTimeout(resolve, 200))
+
+    expect(vi.mocked(updateTask)).toHaveBeenCalledTimes(1)
+    const arg = lastUpdateArg(updateTask)
+    expect(arg.due).toBe(new Date('2026-09-10T12:30').toISOString())
+  })
+})
+
+// ── CRITICAL data-loss regression: due-date autosave must not wipe an
+// unsaved prompt edit ──────────────────────────────────────────────────────
+//
+// TaskDetailPanel's `task` prop is not query-owned by this component — the
+// real host screen re-renders it with a NEW `task` object whenever the tasks
+// query refetches (e.g. because TaskDetailPanel's own due/trigger autosave
+// PATCH invalidated it). Before the fix, a single resync useEffect keyed
+// partly on task?.due / task?.trigger?.config?.at_ms re-fired on that resync
+// and reset promptDraft/editingPrompt — silently discarding whatever the
+// user had typed. This harness reproduces that resync by having the mocked
+// updateTask feed the patched fields back into a task object held in local
+// state, exactly mirroring the parent's useQuery→find(task.id) round trip.
+describe('TaskDetailPanel — prompt draft survives a due-date autosave (data-loss regression)', () => {
+  it('editing the prompt then picking a due date does not wipe the unsaved prompt text', async () => {
+    const { updateTask } = await import('@/lib/api')
+
+    const baseTask = makeTask({ id: 'task-preserve-prompt', status: 'next', prompt: 'Original prompt' })
+    let applyPatch: (patch: TaskUpdateRequest) => void = () => {}
+
+    function Harness() {
+      const [task, setTask] = useState<Task>(baseTask)
+      applyPatch = (patch) => setTask((prev) => ({ ...prev, ...patch }))
+      return (
+        <QueryClientProvider client={makeClient()}>
+          <TaskDetailPanel task={task} onClose={vi.fn()} />
+        </QueryClientProvider>
+      )
+    }
+
+    vi.mocked(updateTask).mockImplementation(async (_id: string, patch: TaskUpdateRequest) => {
+      // Mirrors the real flow: the PATCH succeeds, the tasks query is
+      // invalidated, and the parent hands TaskDetailPanel a NEW task object
+      // (same id/prompt/workspace_id, updated due) — done here synchronously
+      // via the harness's own state instead of a real query round trip.
+      applyPatch(patch)
+      return { ...baseTask, ...patch } as Task
+    })
+
+    render(<Harness />)
+
+    // Start editing the prompt — unsaved.
+    fireEvent.click(await screen.findByLabelText(/edit prompt/i))
+    const promptBox = document.querySelector('textarea') as HTMLTextAreaElement
+    expect(promptBox).toBeTruthy()
+    fireEvent.change(promptBox, { target: { value: 'Unsaved draft text' } })
+
+    // Now pick a due date — the resulting (debounced) PATCH feeds a new task
+    // object back in via applyPatch, same id/prompt/workspace_id, new due.
+    await pickDueDateTime({ isoDate: '2026-09-10', hour: '12', minute: '30' })
+
+    await waitFor(() => expect(vi.mocked(updateTask)).toHaveBeenCalled(), { timeout: 3000 })
+
+    // The unsaved prompt edit must survive: still in edit mode, still showing
+    // the draft text — NOT reset to the (stale) saved prompt.
+    const promptBoxAfter = document.querySelector('textarea') as HTMLTextAreaElement | null
+    expect(promptBoxAfter).toBeTruthy()
+    expect(promptBoxAfter).toHaveValue('Unsaved draft text')
   })
 })
 

--- a/src/components/command-center/TaskDetailPanel.test.tsx
+++ b/src/components/command-center/TaskDetailPanel.test.tsx
@@ -9,11 +9,67 @@
  * the 7-state lifecycle: inbox/next/planning/in_progress/blocked/done/failed.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest'
 import { render, screen, fireEvent, act, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { TaskDetailPanel } from './TaskDetailPanel'
 import type { Task } from '@/lib/api'
+
+// DateTimePicker (shadcn Calendar + Select) needs these jsdom polyfills to open
+// (same gap noted in date-time-picker.test.tsx).
+beforeAll(() => {
+  if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = () => false
+  }
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = () => {}
+  }
+  if (typeof window !== 'undefined' && !window.ResizeObserver) {
+    window.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver
+  }
+})
+
+// Click a react-day-picker day cell (data-day="YYYY-MM-DD") inside an open DateTimePicker popover.
+function clickDay(isoDate: string) {
+  const btn = document.querySelector(`[data-day="${isoDate}"] button`)
+  if (!btn) throw new Error(`no day button for ${isoDate}`)
+  fireEvent.click(btn)
+}
+
+// Pick an option from an open DateTimePicker's Hour/Minute <Select>.
+function selectOption(comboboxName: string, optionName: string) {
+  fireEvent.click(screen.getByRole('combobox', { name: comboboxName }))
+  const option = screen.getByRole('option', { name: optionName })
+  fireEvent.pointerDown(option, { pointerId: 1, button: 0 })
+  fireEvent.click(option)
+}
+
+// When no value is set, the calendar opens on the real "today" month (react-day-picker's
+// own default), not the target month — navigate forward/back via the Nav buttons so the
+// target day is on-screen regardless of when the suite happens to run.
+function navigateToMonth(isoDate: string) {
+  const [y, m] = isoDate.split('-').map(Number)
+  const target = new Date(y, m - 1, 1)
+  const now = new Date()
+  const diff = (target.getFullYear() - now.getFullYear()) * 12 + (target.getMonth() - now.getMonth())
+  const label = diff >= 0 ? /go to the next month/i : /go to the previous month/i
+  for (let i = 0; i < Math.abs(diff); i++) {
+    fireEvent.click(screen.getByRole('button', { name: label }))
+  }
+}
+
+// Open the "Due date" DateTimePicker and pick a full date + time.
+async function pickDueDateTime({ isoDate, hour, minute }: { isoDate: string; hour: string; minute: string }) {
+  fireEvent.click(await screen.findByRole('button', { name: /due date/i }))
+  navigateToMonth(isoDate)
+  clickDay(isoDate)
+  selectOption('Hour', hour)
+  selectOption('Minute', minute)
+}
 
 // ── Mocks ─────────────────────────────────────────────────────────────────────
 
@@ -444,13 +500,11 @@ describe('TaskDetailPanel — editable trigger', () => {
 })
 
 describe('TaskDetailPanel — editable due date', () => {
-  it('setting a due date PATCHes due as RFC3339 on blur', async () => {
+  it('setting a due date PATCHes due as RFC3339', async () => {
     const { updateTask } = await import('@/lib/api')
     renderPanel(makeTask({ id: 'task-due', status: 'next' }))
 
-    const due = await screen.findByLabelText(/due date/i)
-    fireEvent.change(due, { target: { value: '2026-09-10T12:30' } })
-    fireEvent.blur(due)
+    await pickDueDateTime({ isoDate: '2026-09-10', hour: '12', minute: '30' })
 
     await waitFor(() => expect(vi.mocked(updateTask)).toHaveBeenCalled())
     const arg = lastUpdateArg(updateTask)
@@ -525,11 +579,15 @@ describe('TaskDetailPanel — editable todos checklist', () => {
 describe('TaskDetailPanel — clearing a due date (clear_due)', () => {
   it('PATCHes clear_due:true and never sends due:"" when the field is cleared', async () => {
     const { updateTask } = await import('@/lib/api')
-    renderPanel(makeTask({ id: 'task-clear-due', status: 'next', due: '2026-09-10T12:30:00Z' }))
+    const dueIso = '2026-09-10T12:30:00Z'
+    renderPanel(makeTask({ id: 'task-clear-due', status: 'next', due: dueIso }))
 
-    const due = await screen.findByLabelText(/due date/i)
-    fireEvent.change(due, { target: { value: '' } })
-    fireEvent.blur(due)
+    // Clear by clicking the already-selected day again — react-day-picker's single-select
+    // mode (required=false, the default) deselects and fires onSelect(undefined).
+    fireEvent.click(await screen.findByRole('button', { name: /due date/i }))
+    const selectedDate = new Date(dueIso)
+    const localIso = `${selectedDate.getFullYear()}-${String(selectedDate.getMonth() + 1).padStart(2, '0')}-${String(selectedDate.getDate()).padStart(2, '0')}`
+    clickDay(localIso)
 
     // Clears via the unambiguous flag; never sends the broken empty string.
     await vi.waitFor(() => {
@@ -595,9 +653,7 @@ describe('TaskDetailPanel — autosave indicator', () => {
     vi.mocked(updateTask).mockResolvedValue({} as never)
     renderPanel(makeTask({ id: 'task-autosave', status: 'next' }))
 
-    const due = await screen.findByLabelText(/due date/i)
-    fireEvent.change(due, { target: { value: '2026-09-10T12:30' } })
-    fireEvent.blur(due)
+    await pickDueDateTime({ isoDate: '2026-09-10', hour: '12', minute: '30' })
 
     await waitFor(() => expect(vi.mocked(updateTask)).toHaveBeenCalled())
     await screen.findByText(/saved/i)

--- a/src/components/command-center/TaskDetailPanel.tsx
+++ b/src/components/command-center/TaskDetailPanel.tsx
@@ -56,9 +56,10 @@ import { cn } from '@/lib/utils'
 import {
   type TriggerKind,
   buildTrigger,
-  toDatetimeLocalValue,
   datetimeLocalToMs,
   datetimeLocalToIso,
+  datetimeLocalToDate,
+  dateToDatetimeLocal,
 } from '@/components/workspaces/taskFormFields'
 
 // ── Status config ──────────────────────────────────────────────────────────────
@@ -125,12 +126,20 @@ export function TaskDetailPanel({ task, onClose, onTaskSelect }: TaskDetailPanel
   const [triggerAtDraft, setTriggerAtDraft] = useState<Date | null>(
     typeof task?.trigger?.config?.at_ms === 'number' ? new Date(task.trigger.config.at_ms) : null,
   )
-  const [dueDraft, setDueDraft] = useState<Date | null>(task?.due ? new Date(task.due) : null)
+  const [dueDraft, setDueDraft] = useState<Date | null>(datetimeLocalToDate(task?.due))
   // Autosave indicator — every field change fires an immediate mutation; this
   // mirrors the AgentProfile / Gateway pattern so the user sees Saving…/Saved.
   const [saveStatus, setSaveStatus] = useState<AutoSaveStatus>('idle')
   const [saveError, setSaveError] = useState<string | undefined>(undefined)
 
+  // Resync everything EXCEPT the due/trigger-at drafts when the task's identity
+  // (id/prompt/workspace_id) actually changes — i.e. a different task was
+  // selected, or the prompt was saved elsewhere. Deliberately NOT keyed on
+  // task?.due / task?.trigger?.config?.at_ms: a due/trigger autosave PATCH
+  // invalidates the tasks query, which hands this component a new `task`
+  // object with the SAME id/prompt/workspace_id — if this effect also fired
+  // on that resync, it would wipe an in-progress, unsaved prompt edit out from
+  // under the user (data loss). See the sibling effect below for due/trigger.
   useEffect(() => {
     setPromptDraft(task?.prompt ?? '')
     setEditingPrompt(false)
@@ -139,11 +148,19 @@ export function TaskDetailPanel({ task, onClose, onTaskSelect }: TaskDetailPanel
     setTriggerError('')
     setDueError('')
     setStatusError('')
-    setTriggerAtDraft(typeof task?.trigger?.config?.at_ms === 'number' ? new Date(task.trigger.config.at_ms) : null)
-    setDueDraft(task?.due ? new Date(task.due) : null)
     setSaveStatus('idle')
     setSaveError(undefined)
-  }, [task?.id, task?.prompt, task?.workspace_id, task?.due, task?.trigger?.config?.at_ms])
+  }, [task?.id, task?.prompt, task?.workspace_id])
+
+  // Resync ONLY the due/trigger-at drafts when the task's due date or
+  // one-time trigger changes — including the same-identity resync described
+  // above (a due/trigger PATCH's own success should still reflect the saved
+  // value once the query refetches). Split out from the effect above so this
+  // resync can never touch promptDraft/editingPrompt/todos/errors.
+  useEffect(() => {
+    setTriggerAtDraft(typeof task?.trigger?.config?.at_ms === 'number' ? new Date(task.trigger.config.at_ms) : null)
+    setDueDraft(datetimeLocalToDate(task?.due))
+  }, [task?.id, task?.due, task?.trigger?.config?.at_ms])
 
   const { data: agents = [] } = useQuery({ queryKey: ['agents'], queryFn: fetchAgents })
 
@@ -181,6 +198,29 @@ export function TaskDetailPanel({ task, onClose, onTaskSelect }: TaskDetailPanel
   // linger between unrelated edits.
   const savedFadeRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   useEffect(() => () => { if (savedFadeRef.current) clearTimeout(savedFadeRef.current) }, [])
+
+  // Debounce the due/trigger-at DateTimePicker autosave: day, hour, and minute
+  // are three separate onChange firings for a single logical edit, so PATCHing
+  // on every one of them sends 3 sequential requests with intermediate
+  // (partially-composed) values — chatty, and a race if they resolve out of
+  // order. Coalesce into ONE PATCH per field ~500ms after the user stops
+  // picking (cancel-in-flight: each new pick within the window replaces the
+  // pending commit). Keyed per field (not a single shared timer) so editing
+  // due and trigger-at close together doesn't drop one of them.
+  const dateCommitTimers = useRef<Partial<Record<'due' | 'triggerAt', ReturnType<typeof setTimeout>>>>({})
+  useEffect(() => () => {
+    Object.values(dateCommitTimers.current).forEach((t) => { if (t) clearTimeout(t) })
+  }, [])
+
+  function scheduleDateCommit(field: 'due' | 'triggerAt', commit: () => void) {
+    const timers = dateCommitTimers.current
+    const pending = timers[field]
+    if (pending) clearTimeout(pending)
+    timers[field] = setTimeout(() => {
+      delete timers[field]
+      commit()
+    }, 500)
+  }
 
   const { mutate: doUpdate } = useMutation({
     mutationFn: (data: TaskUpdateRequest) => {
@@ -612,7 +652,7 @@ export function TaskDetailPanel({ task, onClose, onTaskSelect }: TaskDetailPanel
             value={triggerAtDraft}
             onChange={(d) => {
               setTriggerAtDraft(d)
-              handleTriggerAtChange(d ? toDatetimeLocalValue(d.getTime()) : '')
+              scheduleDateCommit('triggerAt', () => handleTriggerAtChange(dateToDatetimeLocal(d)))
             }}
             className="mt-1.5"
           />
@@ -713,7 +753,7 @@ export function TaskDetailPanel({ task, onClose, onTaskSelect }: TaskDetailPanel
           value={dueDraft}
           onChange={(d) => {
             setDueDraft(d)
-            handleDueChange(d ? toDatetimeLocalValue(d.getTime()) : '')
+            scheduleDateCommit('due', () => handleDueChange(dateToDatetimeLocal(d)))
           }}
         />
         {dueError && (

--- a/src/components/command-center/TaskDetailPanel.tsx
+++ b/src/components/command-center/TaskDetailPanel.tsx
@@ -27,6 +27,7 @@ import {
 import { SmartSelect } from '@/components/ui/smart-select'
 import { Textarea } from '@/components/ui/textarea'
 import { Input } from '@/components/ui/input'
+import { DateTimePicker } from '@/components/ui/date-time-picker'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
@@ -117,6 +118,14 @@ export function TaskDetailPanel({ task, onClose, onTaskSelect }: TaskDetailPanel
   const [triggerError, setTriggerError] = useState('')
   const [dueError, setDueError] = useState('')
   const [statusError, setStatusError] = useState('')
+  // DateTimePicker is fully controlled (value/onChange) — day, hour, and minute
+  // picks each fire a separate onChange that must compose on top of the prior
+  // pick, so these hold the in-progress edit and are re-synced from the task
+  // whenever the server value changes (e.g. after a successful autosave PATCH).
+  const [triggerAtDraft, setTriggerAtDraft] = useState<Date | null>(
+    typeof task?.trigger?.config?.at_ms === 'number' ? new Date(task.trigger.config.at_ms) : null,
+  )
+  const [dueDraft, setDueDraft] = useState<Date | null>(task?.due ? new Date(task.due) : null)
   // Autosave indicator — every field change fires an immediate mutation; this
   // mirrors the AgentProfile / Gateway pattern so the user sees Saving…/Saved.
   const [saveStatus, setSaveStatus] = useState<AutoSaveStatus>('idle')
@@ -130,9 +139,11 @@ export function TaskDetailPanel({ task, onClose, onTaskSelect }: TaskDetailPanel
     setTriggerError('')
     setDueError('')
     setStatusError('')
+    setTriggerAtDraft(typeof task?.trigger?.config?.at_ms === 'number' ? new Date(task.trigger.config.at_ms) : null)
+    setDueDraft(task?.due ? new Date(task.due) : null)
     setSaveStatus('idle')
     setSaveError(undefined)
-  }, [task?.id, task?.prompt, task?.workspace_id])
+  }, [task?.id, task?.prompt, task?.workspace_id, task?.due, task?.trigger?.config?.at_ms])
 
   const { data: agents = [] } = useQuery({ queryKey: ['agents'], queryFn: fetchAgents })
 
@@ -596,12 +607,14 @@ export function TaskDetailPanel({ task, onClose, onTaskSelect }: TaskDetailPanel
           ]}
         />
         {triggerKind === 'once' && (
-          <Input
+          <DateTimePicker
             aria-label="Trigger date and time"
-            type="datetime-local"
-            defaultValue={toDatetimeLocalValue(typeof triggerCfg.at_ms === 'number' ? triggerCfg.at_ms : undefined)}
-            onBlur={(e) => handleTriggerAtChange(e.target.value)}
-            className="mt-1.5 text-xs"
+            value={triggerAtDraft}
+            onChange={(d) => {
+              setTriggerAtDraft(d)
+              handleTriggerAtChange(d ? toDatetimeLocalValue(d.getTime()) : '')
+            }}
+            className="mt-1.5"
           />
         )}
         {triggerKind === 'every' && (
@@ -695,13 +708,13 @@ export function TaskDetailPanel({ task, onClose, onTaskSelect }: TaskDetailPanel
 
       {/* Due date (editable) */}
       <Field label="Due date">
-        <Input
+        <DateTimePicker
           aria-label="Due date"
-          type="datetime-local"
-          defaultValue={toDatetimeLocalValue(task.due)}
-          key={task.id + (task.due ?? '')}
-          onBlur={(e) => handleDueChange(e.target.value)}
-          className="text-xs"
+          value={dueDraft}
+          onChange={(d) => {
+            setDueDraft(d)
+            handleDueChange(d ? toDatetimeLocalValue(d.getTime()) : '')
+          }}
         />
         {dueError && (
           <p className="text-xs text-[var(--color-error)] mt-1.5">{dueError}</p>

--- a/src/components/ui/calendar.test.tsx
+++ b/src/components/ui/calendar.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * calendar.test.tsx — Sovereign Deep themed wrapper around react-day-picker v9.
+ *
+ * Traces to: ADR-030 §10 (native date/time inputs → shadcn-style pickers).
+ * Strategy: DayPicker renders inline (no portal), so it mounts directly in
+ * jsdom. Days are queried by the `data-day="YYYY-MM-DD"` attribute
+ * react-day-picker puts on each grid cell (verified against the installed
+ * v9.14.0 source — see DayPicker.js's `data-day: day.isoDate`).
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import { Calendar } from './calendar'
+
+function dayCell(isoDate: string): HTMLElement | null {
+  return document.querySelector(`[data-day="${isoDate}"]`)
+}
+
+function dayButton(isoDate: string): HTMLElement {
+  const cell = dayCell(isoDate)
+  const btn = cell?.querySelector('button')
+  if (!btn) throw new Error(`no day button for ${isoDate}`)
+  return btn as HTMLElement
+}
+
+describe('Calendar — render', () => {
+  it('renders a month grid with the weekday header and 7 columns', () => {
+    const { container } = render(<Calendar mode="single" defaultMonth={new Date(2026, 5, 1)} />)
+    // 7 weekday header cells (Sun..Sat by default locale). jsdom's implicit-ARIA
+    // role computation does not map `th[scope=col]` to "columnheader" inside a
+    // `<table role="grid">` (react-day-picker's MonthGrid), so query the DOM
+    // directly rather than via role.
+    expect(container.querySelectorAll('th')).toHaveLength(7)
+    // June 2026 has 30 days — each should have a grid cell.
+    for (let d = 1; d <= 30; d++) {
+      const iso = `2026-06-${d.toString().padStart(2, '0')}`
+      expect(dayCell(iso)).toBeTruthy()
+    }
+  })
+
+  it('marks the selected day with data-selected and no other day', () => {
+    render(<Calendar mode="single" selected={new Date(2026, 5, 15)} defaultMonth={new Date(2026, 5, 1)} />)
+    expect(dayCell('2026-06-15')?.getAttribute('data-selected')).toBe('true')
+    expect(dayCell('2026-06-14')?.getAttribute('data-selected')).toBeNull()
+    expect(dayCell('2026-06-16')?.getAttribute('data-selected')).toBeNull()
+  })
+
+  it('renders no selected day when selected is undefined', () => {
+    render(<Calendar mode="single" defaultMonth={new Date(2026, 5, 1)} />)
+    for (let d = 1; d <= 30; d++) {
+      const iso = `2026-06-${d.toString().padStart(2, '0')}`
+      expect(dayCell(iso)?.getAttribute('data-selected')).toBeNull()
+    }
+  })
+})
+
+describe('Calendar — selection', () => {
+  it('clicking a day calls onSelect with that Date', () => {
+    const onSelect = vi.fn()
+    render(<Calendar mode="single" defaultMonth={new Date(2026, 5, 1)} onSelect={onSelect} />)
+    dayButton('2026-06-20').click()
+    expect(onSelect).toHaveBeenCalledOnce()
+    const [selected] = onSelect.mock.calls[0]
+    expect(selected.getFullYear()).toBe(2026)
+    expect(selected.getMonth()).toBe(5)
+    expect(selected.getDate()).toBe(20)
+  })
+
+  it('differentiation: clicking two different days produces two different onSelect payloads', () => {
+    const onSelect = vi.fn()
+    render(<Calendar mode="single" defaultMonth={new Date(2026, 5, 1)} onSelect={onSelect} />)
+    dayButton('2026-06-05').click()
+    dayButton('2026-06-25').click()
+    expect(onSelect).toHaveBeenCalledTimes(2)
+    expect((onSelect.mock.calls[0][0] as Date).getDate()).toBe(5)
+    expect((onSelect.mock.calls[1][0] as Date).getDate()).toBe(25)
+  })
+
+  it('disabled days are not interactive and do not fire onSelect', () => {
+    const onSelect = vi.fn()
+    render(
+      <Calendar
+        mode="single"
+        defaultMonth={new Date(2026, 5, 1)}
+        onSelect={onSelect}
+        disabled={{ before: new Date(2026, 5, 10) }}
+      />,
+    )
+    expect(dayCell('2026-06-05')?.getAttribute('data-disabled')).toBe('true')
+    const btn = dayButton('2026-06-05') as HTMLButtonElement
+    expect(btn.disabled).toBe(true)
+    btn.click()
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+})
+
+describe('Calendar — outside days', () => {
+  it('marks days from the adjacent month as outside', () => {
+    render(<Calendar mode="single" defaultMonth={new Date(2026, 5, 1)} showOutsideDays />)
+    // May 31 2026 is a Sunday and June 1 2026 is a Monday — May 31 is the
+    // outside leading day shown to fill the first week's row.
+    expect(dayCell('2026-05-31')?.getAttribute('data-outside')).toBe('true')
+  })
+})

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -1,0 +1,75 @@
+import { DayPicker } from 'react-day-picker'
+import type { DayPickerProps } from 'react-day-picker'
+import { CaretLeft, CaretRight } from '@phosphor-icons/react'
+import { cn } from '@/lib/utils'
+
+// Calendar — Sovereign Deep themed wrapper around react-day-picker v9.
+//
+// Fully Tailwind-themed (no react-day-picker/style.css import, no companion
+// CSS file): react-day-picker merges any classNames we pass over its own
+// `rdp-*` defaults (unstyled without the stock stylesheet), so every visual
+// rule lives here as utility classes. Selection/today/outside/disabled state
+// is exposed by react-day-picker as `data-*` attributes on the day <td>
+// (`data-selected`, `data-today`, `data-outside`, `data-disabled`) — the day
+// <td> is marked `group` so the inner day <button> can react to those via
+// Tailwind's `group-data-[...]` variant instead of a second stylesheet.
+export type CalendarProps = DayPickerProps
+
+const DAY_BASE =
+  'inline-flex h-9 w-9 items-center justify-center rounded-md p-0 text-sm font-normal font-inter ' +
+  'text-[var(--color-secondary)] transition-colors ' +
+  'hover:bg-[var(--color-surface-2)] ' +
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] ' +
+  'disabled:pointer-events-none disabled:opacity-40 aria-disabled:pointer-events-none aria-disabled:opacity-40 ' +
+  'group-data-[today=true]:font-semibold group-data-[today=true]:text-[var(--color-accent)] ' +
+  'group-data-[outside=true]:text-[var(--color-muted)] group-data-[outside=true]:opacity-50 ' +
+  'group-data-[disabled=true]:text-[var(--color-muted)] group-data-[disabled=true]:opacity-40 ' +
+  'group-data-[selected=true]:bg-[var(--color-accent)] group-data-[selected=true]:text-[var(--color-primary)] ' +
+  'group-data-[selected=true]:font-semibold group-data-[selected=true]:hover:bg-[var(--color-accent-hover)] ' +
+  'group-data-[selected=true]:hover:text-[var(--color-primary)]'
+
+const NAV_BUTTON =
+  'inline-flex h-7 w-7 items-center justify-center rounded-md border border-[var(--color-border)] ' +
+  'bg-transparent p-0 text-[var(--color-secondary)] opacity-80 transition-colors ' +
+  'hover:opacity-100 hover:bg-[var(--color-surface-2)] ' +
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] ' +
+  'aria-disabled:pointer-events-none aria-disabled:opacity-30'
+
+function Calendar({ className, classNames, showOutsideDays = true, ...props }: CalendarProps) {
+  return (
+    <DayPicker
+      showOutsideDays={showOutsideDays}
+      className={cn('p-3 font-inter', className)}
+      classNames={{
+        months: 'relative flex flex-col gap-4',
+        month: 'space-y-1',
+        nav: 'absolute inset-x-1 top-1 flex items-center justify-between z-10',
+        button_previous: NAV_BUTTON,
+        button_next: NAV_BUTTON,
+        chevron: 'h-3.5 w-3.5',
+        month_caption: 'flex h-9 items-center justify-center',
+        caption_label: 'text-sm font-medium font-outfit text-[var(--color-secondary)]',
+        month_grid: 'w-full border-collapse mt-1',
+        weekdays: 'flex',
+        weekday: 'w-9 text-center text-[0.7rem] font-normal font-inter text-[var(--color-muted)]',
+        weeks: '',
+        week: 'flex w-full mt-1',
+        day: 'group relative h-9 w-9 p-0 text-center text-sm focus-within:relative focus-within:z-20',
+        day_button: DAY_BASE,
+        ...classNames,
+      }}
+      components={{
+        Chevron: ({ orientation, className: chevronClassName }) =>
+          orientation === 'right' ? (
+            <CaretRight weight="bold" className={chevronClassName} />
+          ) : (
+            <CaretLeft weight="bold" className={chevronClassName} />
+          ),
+      }}
+      {...props}
+    />
+  )
+}
+Calendar.displayName = 'Calendar'
+
+export { Calendar }

--- a/src/components/ui/date-picker.test.tsx
+++ b/src/components/ui/date-picker.test.tsx
@@ -66,4 +66,15 @@ describe('DatePicker — selection', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Due date' }))
     expect(document.querySelector('[data-day="2026-09-03"]')).toBeInTheDocument()
   })
+
+  it('clicking the already-selected day clears the value (react-day-picker single-select deselects on reclick)', () => {
+    const onChange = vi.fn()
+    render(<DatePicker value={new Date(2026, 5, 15)} onChange={onChange} aria-label="Due date" />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Due date' }))
+    clickDay('2026-06-15')
+
+    expect(onChange).toHaveBeenCalledOnce()
+    expect(onChange).toHaveBeenCalledWith(null)
+  })
 })

--- a/src/components/ui/date-picker.test.tsx
+++ b/src/components/ui/date-picker.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * date-picker.test.tsx — date-only picker replacing native `<input type="date">`
+ * (ADR-030 §10).
+ *
+ * Radix Popover renders inline in jsdom (no special handling needed). Day
+ * cells are targeted via react-day-picker's `data-day="YYYY-MM-DD"` attribute
+ * (see calendar.test.tsx for the source citation).
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { DatePicker } from './date-picker'
+
+function clickDay(isoDate: string) {
+  const btn = document.querySelector(`[data-day="${isoDate}"] button`)
+  if (!btn) throw new Error(`no day button for ${isoDate}`)
+  fireEvent.click(btn)
+}
+
+describe('DatePicker — trigger render', () => {
+  it('shows the placeholder when value is null', () => {
+    render(<DatePicker value={null} onChange={vi.fn()} placeholder="Pick a date" aria-label="Due date" />)
+    expect(screen.getByRole('button', { name: 'Due date' })).toHaveTextContent('Pick a date')
+  })
+
+  it('shows the formatted date when value is set', () => {
+    render(<DatePicker value={new Date(2026, 5, 22)} onChange={vi.fn()} aria-label="Due date" />)
+    const trigger = screen.getByRole('button', { name: 'Due date' })
+    expect(trigger).toHaveTextContent('Jun 22, 2026')
+  })
+
+  it('differentiation: two different values render two different labels', () => {
+    const { unmount } = render(<DatePicker value={new Date(2026, 0, 5)} onChange={vi.fn()} aria-label="Due date" />)
+    expect(screen.getByRole('button', { name: 'Due date' })).toHaveTextContent('Jan 5, 2026')
+    unmount()
+    render(<DatePicker value={new Date(2026, 10, 30)} onChange={vi.fn()} aria-label="Due date" />)
+    expect(screen.getByRole('button', { name: 'Due date' })).toHaveTextContent('Nov 30, 2026')
+  })
+
+  it('is disabled when disabled=true', () => {
+    render(<DatePicker value={null} onChange={vi.fn()} disabled aria-label="Due date" />)
+    expect(screen.getByRole('button', { name: 'Due date' })).toBeDisabled()
+  })
+})
+
+describe('DatePicker — selection', () => {
+  it('opens the popover, selecting a day calls onChange with that Date and closes', async () => {
+    const onChange = vi.fn()
+    render(<DatePicker value={new Date(2026, 5, 15)} onChange={onChange} aria-label="Due date" />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Due date' }))
+    clickDay('2026-06-20')
+
+    expect(onChange).toHaveBeenCalledOnce()
+    const [selected] = onChange.mock.calls[0] as [Date]
+    expect(selected.getFullYear()).toBe(2026)
+    expect(selected.getMonth()).toBe(5)
+    expect(selected.getDate()).toBe(20)
+
+    // Popover closes after a selection — content is unmounted from the DOM.
+    expect(document.querySelector('[data-day="2026-06-20"]')).not.toBeInTheDocument()
+  })
+
+  it('opens on the value\'s own month when a value is already set', () => {
+    render(<DatePicker value={new Date(2026, 8, 3)} onChange={vi.fn()} aria-label="Due date" />)
+    fireEvent.click(screen.getByRole('button', { name: 'Due date' }))
+    expect(document.querySelector('[data-day="2026-09-03"]')).toBeInTheDocument()
+  })
+})

--- a/src/components/ui/date-picker.tsx
+++ b/src/components/ui/date-picker.tsx
@@ -1,0 +1,83 @@
+import * as React from 'react'
+import { CalendarBlank } from '@phosphor-icons/react'
+import { Button } from '@/components/ui/button'
+import { Calendar } from '@/components/ui/calendar'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { cn } from '@/lib/utils'
+
+// Date-only picker — replaces native `<input type="date">` (ADR-030 §10).
+//
+// The trigger is a <Button> styled to be pixel-identical to <Input> (same
+// height/border/background/padding/focus-ring — see DATE_TRIGGER_CLASSNAME)
+// so a DatePicker sitting next to a plain <Input> in a form is visually
+// indistinguishable as a "box", while still being a real button that opens
+// a themed react-day-picker calendar in a Popover.
+export const DATE_TRIGGER_CLASSNAME = cn(
+  'flex h-11 sm:h-9 w-full items-center gap-2 rounded-md border border-[var(--color-border)]',
+  'bg-[var(--color-surface-1)] px-3 py-1 text-sm text-[var(--color-secondary)] shadow-sm transition-colors',
+  'justify-start text-left font-normal whitespace-nowrap',
+  'hover:bg-[var(--color-surface-1)]',
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:border-[var(--color-accent)]',
+  'disabled:cursor-not-allowed disabled:opacity-50',
+)
+
+export interface DatePickerProps {
+  value: Date | null
+  onChange: (date: Date | null) => void
+  placeholder?: string
+  id?: string
+  'aria-label'?: string
+  disabled?: boolean
+  className?: string
+}
+
+function formatDateDisplay(date: Date): string {
+  return date.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
+}
+
+function DatePicker({
+  value,
+  onChange,
+  placeholder = 'Pick a date',
+  id,
+  'aria-label': ariaLabel,
+  disabled,
+  className,
+}: DatePickerProps) {
+  const [open, setOpen] = React.useState(false)
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          id={id}
+          aria-label={ariaLabel}
+          variant="outline"
+          disabled={disabled}
+          className={cn(DATE_TRIGGER_CLASSNAME, className)}
+        >
+          <CalendarBlank size={16} className="shrink-0 opacity-70" aria-hidden="true" />
+          <span className={cn('truncate', !value && 'text-[var(--color-muted)]')}>
+            {value ? formatDateDisplay(value) : placeholder}
+          </span>
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-auto p-0" align="start">
+        <Calendar
+          mode="single"
+          selected={value ?? undefined}
+          defaultMonth={value ?? undefined}
+          onSelect={(date) => {
+            onChange(date ?? null)
+            setOpen(false)
+          }}
+          autoFocus
+        />
+      </PopoverContent>
+    </Popover>
+  )
+}
+DatePicker.displayName = 'DatePicker'
+
+export { DatePicker }

--- a/src/components/ui/date-picker.tsx
+++ b/src/components/ui/date-picker.tsx
@@ -17,9 +17,46 @@ export const DATE_TRIGGER_CLASSNAME = cn(
   'bg-[var(--color-surface-1)] px-3 py-1 text-sm text-[var(--color-secondary)] shadow-sm transition-colors',
   'justify-start text-left font-normal whitespace-nowrap',
   'hover:bg-[var(--color-surface-1)]',
-  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:border-[var(--color-accent)]',
+  // ring-offset-0 keeps the focus ring flush against the border — <Button>'s base
+  // variant sets ring-offset-2 (an offset gap meant for buttons sitting on a flat
+  // background), which tailwind-merge does not strip; without the override this
+  // trigger's focus ring floats off the border instead of matching <Input> pixel-for-pixel.
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-offset-0 focus-visible:border-[var(--color-accent)]',
   'disabled:cursor-not-allowed disabled:opacity-50',
 )
+
+// Shared trigger button for DatePicker + DateTimePicker — both pickers open
+// their Popover from an identical icon + truncated-label <Button> styled to
+// match <Input> (DATE_TRIGGER_CLASSNAME). Extracted here so the block isn't
+// duplicated between the two picker files.
+// Extends the native button attributes (rather than a fixed id/aria-label/
+// disabled list) so that Radix's `PopoverTrigger asChild` — which clones this
+// element and injects its own onClick/onPointerDown/aria-expanded/data-state
+// props to wire up the popover open/close — passes straight through via
+// `...rest`. A fixed prop allowlist would silently drop those injected
+// handlers and the trigger would stop opening the popover.
+export interface DateTriggerButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  /** Whether a value is currently selected — drives the muted placeholder styling. */
+  hasValue: boolean
+}
+
+export const DateTriggerButton = React.forwardRef<HTMLButtonElement, DateTriggerButtonProps>(
+  ({ className, hasValue, children, ...rest }, ref) => (
+    <Button
+      ref={ref}
+      type="button"
+      variant="outline"
+      className={cn(DATE_TRIGGER_CLASSNAME, className)}
+      {...rest}
+    >
+      <CalendarBlank size={16} className="shrink-0 opacity-70" aria-hidden="true" />
+      <span className={cn('truncate', !hasValue && 'text-[var(--color-muted)]')}>
+        {children}
+      </span>
+    </Button>
+  ),
+)
+DateTriggerButton.displayName = 'DateTriggerButton'
 
 export interface DatePickerProps {
   value: Date | null
@@ -35,33 +72,33 @@ function formatDateDisplay(date: Date): string {
   return date.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
 }
 
-function DatePicker({
-  value,
-  onChange,
-  placeholder = 'Pick a date',
-  id,
-  'aria-label': ariaLabel,
-  disabled,
-  className,
-}: DatePickerProps) {
+const DatePicker = React.forwardRef<HTMLButtonElement, DatePickerProps>(function DatePicker(
+  {
+    value,
+    onChange,
+    placeholder = 'Pick a date',
+    id,
+    'aria-label': ariaLabel,
+    disabled,
+    className,
+  },
+  ref,
+) {
   const [open, setOpen] = React.useState(false)
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
-        <Button
-          type="button"
+        <DateTriggerButton
+          ref={ref}
           id={id}
           aria-label={ariaLabel}
-          variant="outline"
           disabled={disabled}
-          className={cn(DATE_TRIGGER_CLASSNAME, className)}
+          className={className}
+          hasValue={!!value}
         >
-          <CalendarBlank size={16} className="shrink-0 opacity-70" aria-hidden="true" />
-          <span className={cn('truncate', !value && 'text-[var(--color-muted)]')}>
-            {value ? formatDateDisplay(value) : placeholder}
-          </span>
-        </Button>
+          {value ? formatDateDisplay(value) : placeholder}
+        </DateTriggerButton>
       </PopoverTrigger>
       <PopoverContent className="w-auto p-0" align="start">
         <Calendar
@@ -77,7 +114,7 @@ function DatePicker({
       </PopoverContent>
     </Popover>
   )
-}
+})
 DatePicker.displayName = 'DatePicker'
 
 export { DatePicker }

--- a/src/components/ui/date-time-picker.test.tsx
+++ b/src/components/ui/date-time-picker.test.tsx
@@ -1,0 +1,160 @@
+/**
+ * date-time-picker.test.tsx — date + time picker replacing native
+ * `<input type="datetime-local">` (ADR-030 §10).
+ *
+ * Radix Popover renders inline in jsdom. The hour/minute <Select>s use Radix
+ * Select, which needs `hasPointerCapture` / `scrollIntoView` / `ResizeObserver`
+ * polyfills to open in jsdom (same gap noted in
+ * ScheduleFormSheet.test.tsx and model-selector.test.tsx) — verified working
+ * here with `fireEvent.click` (trigger) + `fireEvent.pointerDown` +
+ * `fireEvent.click` (item).
+ */
+
+import { describe, it, expect, vi, beforeAll } from 'vitest'
+import { render, screen, fireEvent, within } from '@testing-library/react'
+import { DateTimePicker } from './date-time-picker'
+
+beforeAll(() => {
+  if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = () => false
+  }
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = () => {}
+  }
+  if (typeof window !== 'undefined' && !window.ResizeObserver) {
+    window.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver
+  }
+})
+
+function clickDay(isoDate: string) {
+  const btn = document.querySelector(`[data-day="${isoDate}"] button`)
+  if (!btn) throw new Error(`no day button for ${isoDate}`)
+  fireEvent.click(btn)
+}
+
+function selectOption(comboboxName: string, optionName: string) {
+  fireEvent.click(screen.getByRole('combobox', { name: comboboxName }))
+  const option = screen.getByRole('option', { name: optionName })
+  fireEvent.pointerDown(option, { pointerId: 1, button: 0 })
+  fireEvent.click(option)
+}
+
+describe('DateTimePicker — trigger render', () => {
+  it('shows the placeholder when value is null', () => {
+    render(
+      <DateTimePicker value={null} onChange={vi.fn()} placeholder="Pick a date and time" aria-label="Trigger at" />,
+    )
+    expect(screen.getByRole('button', { name: 'Trigger at' })).toHaveTextContent('Pick a date and time')
+  })
+
+  it('shows the formatted date + time when value is set', () => {
+    render(<DateTimePicker value={new Date(2026, 5, 22, 14, 30)} onChange={vi.fn()} aria-label="Trigger at" />)
+    const trigger = screen.getByRole('button', { name: 'Trigger at' })
+    expect(trigger).toHaveTextContent('Jun 22, 2026')
+    expect(trigger).toHaveTextContent('02:30 PM')
+  })
+
+  it('is disabled when disabled=true', () => {
+    render(<DateTimePicker value={null} onChange={vi.fn()} disabled aria-label="Trigger at" />)
+    expect(screen.getByRole('button', { name: 'Trigger at' })).toBeDisabled()
+  })
+})
+
+describe('DateTimePicker — day selection', () => {
+  it('picking a day preserves the existing time-of-day', () => {
+    const onChange = vi.fn()
+    render(<DateTimePicker value={new Date(2026, 5, 15, 9, 30)} onChange={onChange} aria-label="Trigger at" />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Trigger at' }))
+    clickDay('2026-06-20')
+
+    expect(onChange).toHaveBeenCalledOnce()
+    const [next] = onChange.mock.calls[0] as [Date]
+    expect(next.getFullYear()).toBe(2026)
+    expect(next.getMonth()).toBe(5)
+    expect(next.getDate()).toBe(20)
+    expect(next.getHours()).toBe(9)
+    expect(next.getMinutes()).toBe(30)
+  })
+
+  it('popover stays open after picking a day (so hour/minute can still be adjusted)', () => {
+    const onChange = vi.fn()
+    render(<DateTimePicker value={new Date(2026, 5, 15, 9, 30)} onChange={onChange} aria-label="Trigger at" />)
+    fireEvent.click(screen.getByRole('button', { name: 'Trigger at' }))
+    clickDay('2026-06-20')
+    expect(screen.getByRole('combobox', { name: 'Hour' })).toBeInTheDocument()
+  })
+})
+
+describe('DateTimePicker — hour/minute selects', () => {
+  it('changing the hour updates the time and keeps the date', () => {
+    const onChange = vi.fn()
+    render(<DateTimePicker value={new Date(2026, 5, 15, 9, 30)} onChange={onChange} aria-label="Trigger at" />)
+    fireEvent.click(screen.getByRole('button', { name: 'Trigger at' }))
+
+    selectOption('Hour', '14')
+
+    expect(onChange).toHaveBeenCalledOnce()
+    const [next] = onChange.mock.calls[0] as [Date]
+    expect(next.getHours()).toBe(14)
+    expect(next.getMinutes()).toBe(30)
+    expect(next.getDate()).toBe(15)
+  })
+
+  it('changing the minute updates the time and keeps the date/hour', () => {
+    const onChange = vi.fn()
+    render(<DateTimePicker value={new Date(2026, 5, 15, 9, 30)} onChange={onChange} aria-label="Trigger at" />)
+    fireEvent.click(screen.getByRole('button', { name: 'Trigger at' }))
+
+    selectOption('Minute', '45')
+
+    expect(onChange).toHaveBeenCalledOnce()
+    const [next] = onChange.mock.calls[0] as [Date]
+    expect(next.getMinutes()).toBe(45)
+    expect(next.getHours()).toBe(9)
+    expect(next.getDate()).toBe(15)
+  })
+
+  it('offers an out-of-step existing minute (e.g. :37) as a selectable option instead of dropping it', () => {
+    render(<DateTimePicker value={new Date(2026, 5, 15, 9, 37)} onChange={vi.fn()} aria-label="Trigger at" />)
+    fireEvent.click(screen.getByRole('button', { name: 'Trigger at' }))
+    fireEvent.click(screen.getByRole('combobox', { name: 'Minute' }))
+    expect(screen.getByRole('option', { name: '37' })).toBeInTheDocument()
+  })
+
+  it('differentiation: two different minute changes produce two different payloads', () => {
+    const onChange = vi.fn()
+    const { unmount } = render(
+      <DateTimePicker value={new Date(2026, 5, 15, 9, 30)} onChange={onChange} aria-label="Trigger at" />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Trigger at' }))
+    selectOption('Minute', '15')
+    expect((onChange.mock.calls[0][0] as Date).getMinutes()).toBe(15)
+    unmount()
+
+    render(<DateTimePicker value={new Date(2026, 5, 15, 9, 30)} onChange={onChange} aria-label="Trigger at" />)
+    fireEvent.click(screen.getByRole('button', { name: 'Trigger at' }))
+    selectOption('Minute', '50')
+    expect((onChange.mock.calls[1][0] as Date).getMinutes()).toBe(50)
+  })
+})
+
+describe('DateTimePicker — Done button', () => {
+  it('is disabled until a value exists, and closes the popover once enabled', () => {
+    render(<DateTimePicker value={null} onChange={vi.fn()} aria-label="Trigger at" />)
+    fireEvent.click(screen.getByRole('button', { name: 'Trigger at' }))
+    const popover = screen.getByRole('dialog')
+    expect(within(popover).getByRole('button', { name: 'Done' })).toBeDisabled()
+  })
+
+  it('clicking Done closes the popover once a value is set', () => {
+    render(<DateTimePicker value={new Date(2026, 5, 15, 9, 30)} onChange={vi.fn()} aria-label="Trigger at" />)
+    fireEvent.click(screen.getByRole('button', { name: 'Trigger at' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Done' }))
+    expect(document.querySelector('[data-day="2026-06-15"]')).not.toBeInTheDocument()
+  })
+})

--- a/src/components/ui/date-time-picker.test.tsx
+++ b/src/components/ui/date-time-picker.test.tsx
@@ -88,6 +88,44 @@ describe('DateTimePicker — day selection', () => {
     clickDay('2026-06-20')
     expect(screen.getByRole('combobox', { name: 'Hour' })).toBeInTheDocument()
   })
+
+  it('clicking the already-selected day clears the value (react-day-picker single-select deselects on reclick)', () => {
+    const onChange = vi.fn()
+    render(<DateTimePicker value={new Date(2026, 5, 15, 9, 30)} onChange={onChange} aria-label="Trigger at" />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Trigger at' }))
+    clickDay('2026-06-15')
+
+    expect(onChange).toHaveBeenCalledOnce()
+    expect(onChange).toHaveBeenCalledWith(null)
+  })
+
+  it('picking a day with no prior value defaults the time to a deterministic midnight, not "now"', () => {
+    // Fix: handleDaySelect used to fall back to `now.getHours()/getMinutes()`
+    // for a fresh (value=null) day-only pick — nondeterministic and surprising
+    // for a due date. It must default to 00:00 regardless of the wall-clock
+    // time the pick happens to occur at.
+    vi.useFakeTimers()
+    try {
+      // "Now" is deliberately NOT midnight — proves the picked time doesn't leak in.
+      vi.setSystemTime(new Date(2026, 5, 15, 14, 45))
+
+      const onChange = vi.fn()
+      render(<DateTimePicker value={null} onChange={onChange} aria-label="Trigger at" />)
+      fireEvent.click(screen.getByRole('button', { name: 'Trigger at' }))
+      clickDay('2026-06-15')
+
+      expect(onChange).toHaveBeenCalledOnce()
+      const [next] = onChange.mock.calls[0] as [Date]
+      expect(next.getFullYear()).toBe(2026)
+      expect(next.getMonth()).toBe(5)
+      expect(next.getDate()).toBe(15)
+      expect(next.getHours()).toBe(0)
+      expect(next.getMinutes()).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
 })
 
 describe('DateTimePicker — hour/minute selects', () => {
@@ -116,6 +154,20 @@ describe('DateTimePicker — hour/minute selects', () => {
     const [next] = onChange.mock.calls[0] as [Date]
     expect(next.getMinutes()).toBe(45)
     expect(next.getHours()).toBe(9)
+    expect(next.getDate()).toBe(15)
+  })
+
+  it('selecting hour 00 sets getHours() to exactly 0 (midnight is not falsy-skipped)', () => {
+    const onChange = vi.fn()
+    render(<DateTimePicker value={new Date(2026, 5, 15, 9, 30)} onChange={onChange} aria-label="Trigger at" />)
+    fireEvent.click(screen.getByRole('button', { name: 'Trigger at' }))
+
+    selectOption('Hour', '00')
+
+    expect(onChange).toHaveBeenCalledOnce()
+    const [next] = onChange.mock.calls[0] as [Date]
+    expect(next.getHours()).toBe(0)
+    expect(next.getMinutes()).toBe(30)
     expect(next.getDate()).toBe(15)
   })
 

--- a/src/components/ui/date-time-picker.tsx
+++ b/src/components/ui/date-time-picker.tsx
@@ -1,16 +1,16 @@
 import * as React from 'react'
-import { CalendarBlank, Clock } from '@phosphor-icons/react'
+import { Clock } from '@phosphor-icons/react'
 import { Button } from '@/components/ui/button'
 import { Calendar } from '@/components/ui/calendar'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
-import { DATE_TRIGGER_CLASSNAME } from '@/components/ui/date-picker'
-import { cn } from '@/lib/utils'
+import { DateTriggerButton } from '@/components/ui/date-picker'
 
 // Date + time picker — replaces native `<input type="datetime-local">`
-// (ADR-030 §10). Same Input-matched trigger as DatePicker; the popover adds
-// two shadcn <Select> dropdowns (hour 00–23, minute 00–59 by `minuteStep`)
-// below the calendar instead of a native `<input type="time">`.
+// (ADR-030 §10). Same Input-matched trigger as DatePicker (shared via
+// DateTriggerButton); the popover adds two shadcn <Select> dropdowns (hour
+// 00–23, minute 00–59 by `minuteStep`) below the calendar instead of a
+// native `<input type="time">`.
 export interface DateTimePickerProps {
   value: Date | null
   onChange: (date: Date | null) => void
@@ -52,16 +52,19 @@ function formatDateTimeDisplay(date: Date): string {
   })
 }
 
-function DateTimePicker({
-  value,
-  onChange,
-  placeholder = 'Pick a date and time',
-  id,
-  'aria-label': ariaLabel,
-  disabled,
-  className,
-  minuteStep = 5,
-}: DateTimePickerProps) {
+const DateTimePicker = React.forwardRef<HTMLButtonElement, DateTimePickerProps>(function DateTimePicker(
+  {
+    value,
+    onChange,
+    placeholder = 'Pick a date and time',
+    id,
+    'aria-label': ariaLabel,
+    disabled,
+    className,
+    minuteStep = 5,
+  },
+  ref,
+) {
   const [open, setOpen] = React.useState(false)
   const minutes = React.useMemo(
     () => minuteOptions(minuteStep, value ? value.getMinutes() : null),
@@ -73,9 +76,12 @@ function DateTimePicker({
       onChange(null)
       return
     }
-    const now = new Date()
-    const hours = value ? value.getHours() : now.getHours()
-    const mins = value ? value.getMinutes() : now.getMinutes()
+    // A day-only pick with no prior value defaults the time-of-day to
+    // midnight (00:00) — deterministic, not "now". A due date or a one-time
+    // trigger picked by day alone should mean "the start of that day", not
+    // whatever wall-clock time happened to be showing when the user clicked.
+    const hours = value ? value.getHours() : 0
+    const mins = value ? value.getMinutes() : 0
     onChange(new Date(day.getFullYear(), day.getMonth(), day.getDate(), hours, mins, 0, 0))
   }
 
@@ -94,19 +100,16 @@ function DateTimePicker({
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
-        <Button
-          type="button"
+        <DateTriggerButton
+          ref={ref}
           id={id}
           aria-label={ariaLabel}
-          variant="outline"
           disabled={disabled}
-          className={cn(DATE_TRIGGER_CLASSNAME, className)}
+          className={className}
+          hasValue={!!value}
         >
-          <CalendarBlank size={16} className="shrink-0 opacity-70" aria-hidden="true" />
-          <span className={cn('truncate', !value && 'text-[var(--color-muted)]')}>
-            {value ? formatDateTimeDisplay(value) : placeholder}
-          </span>
-        </Button>
+          {value ? formatDateTimeDisplay(value) : placeholder}
+        </DateTriggerButton>
       </PopoverTrigger>
       <PopoverContent className="w-auto p-0" align="start">
         <Calendar
@@ -151,7 +154,7 @@ function DateTimePicker({
       </PopoverContent>
     </Popover>
   )
-}
+})
 DateTimePicker.displayName = 'DateTimePicker'
 
 export { DateTimePicker }

--- a/src/components/ui/date-time-picker.tsx
+++ b/src/components/ui/date-time-picker.tsx
@@ -1,0 +1,157 @@
+import * as React from 'react'
+import { CalendarBlank, Clock } from '@phosphor-icons/react'
+import { Button } from '@/components/ui/button'
+import { Calendar } from '@/components/ui/calendar'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { DATE_TRIGGER_CLASSNAME } from '@/components/ui/date-picker'
+import { cn } from '@/lib/utils'
+
+// Date + time picker — replaces native `<input type="datetime-local">`
+// (ADR-030 §10). Same Input-matched trigger as DatePicker; the popover adds
+// two shadcn <Select> dropdowns (hour 00–23, minute 00–59 by `minuteStep`)
+// below the calendar instead of a native `<input type="time">`.
+export interface DateTimePickerProps {
+  value: Date | null
+  onChange: (date: Date | null) => void
+  placeholder?: string
+  id?: string
+  'aria-label'?: string
+  disabled?: boolean
+  className?: string
+  /** Minute increment offered in the minute select. Defaults to 5. */
+  minuteStep?: number
+}
+
+function pad2(n: number): string {
+  return n.toString().padStart(2, '0')
+}
+
+const HOURS: string[] = Array.from({ length: 24 }, (_, h) => pad2(h))
+
+function minuteOptions(step: number, current: number | null): string[] {
+  const out: number[] = []
+  for (let m = 0; m < 60; m += step) out.push(m)
+  // Preserve an existing minute that doesn't land on the step grid (e.g. a
+  // value produced before this picker existed, or by another client) instead
+  // of silently rounding it away.
+  if (current != null && !out.includes(current)) {
+    out.push(current)
+    out.sort((a, b) => a - b)
+  }
+  return out.map(pad2)
+}
+
+function formatDateTimeDisplay(date: Date): string {
+  return date.toLocaleString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+function DateTimePicker({
+  value,
+  onChange,
+  placeholder = 'Pick a date and time',
+  id,
+  'aria-label': ariaLabel,
+  disabled,
+  className,
+  minuteStep = 5,
+}: DateTimePickerProps) {
+  const [open, setOpen] = React.useState(false)
+  const minutes = React.useMemo(
+    () => minuteOptions(minuteStep, value ? value.getMinutes() : null),
+    [minuteStep, value],
+  )
+
+  function handleDaySelect(day: Date | undefined) {
+    if (!day) {
+      onChange(null)
+      return
+    }
+    const now = new Date()
+    const hours = value ? value.getHours() : now.getHours()
+    const mins = value ? value.getMinutes() : now.getMinutes()
+    onChange(new Date(day.getFullYear(), day.getMonth(), day.getDate(), hours, mins, 0, 0))
+  }
+
+  function handleHourChange(hourStr: string) {
+    const hour = parseInt(hourStr, 10)
+    const base = value ?? new Date()
+    onChange(new Date(base.getFullYear(), base.getMonth(), base.getDate(), hour, base.getMinutes(), 0, 0))
+  }
+
+  function handleMinuteChange(minuteStr: string) {
+    const minute = parseInt(minuteStr, 10)
+    const base = value ?? new Date()
+    onChange(new Date(base.getFullYear(), base.getMonth(), base.getDate(), base.getHours(), minute, 0, 0))
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          id={id}
+          aria-label={ariaLabel}
+          variant="outline"
+          disabled={disabled}
+          className={cn(DATE_TRIGGER_CLASSNAME, className)}
+        >
+          <CalendarBlank size={16} className="shrink-0 opacity-70" aria-hidden="true" />
+          <span className={cn('truncate', !value && 'text-[var(--color-muted)]')}>
+            {value ? formatDateTimeDisplay(value) : placeholder}
+          </span>
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-auto p-0" align="start">
+        <Calendar
+          mode="single"
+          selected={value ?? undefined}
+          defaultMonth={value ?? undefined}
+          onSelect={handleDaySelect}
+          autoFocus
+        />
+        <div className="flex items-center gap-2 border-t border-[var(--color-border)] p-3">
+          <Clock size={14} className="shrink-0 text-[var(--color-muted)]" aria-hidden="true" />
+          <Select value={value ? pad2(value.getHours()) : undefined} onValueChange={handleHourChange}>
+            <SelectTrigger aria-label="Hour" className="h-8 w-[4.5rem] text-xs">
+              <SelectValue placeholder="HH" />
+            </SelectTrigger>
+            <SelectContent>
+              {HOURS.map((h) => (
+                <SelectItem key={h} value={h} className="text-xs">
+                  {h}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <span className="text-[var(--color-muted)]">:</span>
+          <Select value={value ? pad2(value.getMinutes()) : undefined} onValueChange={handleMinuteChange}>
+            <SelectTrigger aria-label="Minute" className="h-8 w-[4.5rem] text-xs">
+              <SelectValue placeholder="MM" />
+            </SelectTrigger>
+            <SelectContent>
+              {minutes.map((m) => (
+                <SelectItem key={m} value={m} className="text-xs">
+                  {m}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <div className="flex-1" />
+          <Button type="button" size="sm" onClick={() => setOpen(false)} disabled={!value}>
+            Done
+          </Button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}
+DateTimePicker.displayName = 'DateTimePicker'
+
+export { DateTimePicker }

--- a/src/components/workspaces/CreateMilestoneSlideOver.test.tsx
+++ b/src/components/workspaces/CreateMilestoneSlideOver.test.tsx
@@ -1,0 +1,238 @@
+/**
+ * CreateMilestoneSlideOver.test.tsx
+ *
+ * Unit/integration tests for CreateMilestoneSlideOver, focused on the
+ * due-date round trip: the date field is a shadcn DatePicker (Popover +
+ * Calendar), not a native `<input type="date">` (ADR-030 §10) — days are
+ * picked via react-day-picker's `data-day="YYYY-MM-DD"` day-cell attribute.
+ * Mirrors the pattern in MilestoneDatePopover.test.tsx.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { CreateMilestoneSlideOver } from './CreateMilestoneSlideOver'
+
+// Click a react-day-picker day cell (data-day="YYYY-MM-DD") inside the open DatePicker popover.
+function clickDay(isoDate: string) {
+  const btn = document.querySelector(`[data-day="${isoDate}"] button`)
+  if (!btn) throw new Error(`no day button for ${isoDate}`)
+  fireEvent.click(btn)
+}
+
+// The DatePicker trigger — queried by its DOM id (DatePicker forwards `id` to the
+// trigger <Button>, same identifier the old native input used).
+function dateTrigger(): HTMLElement {
+  const el = document.getElementById('cm-due')
+  if (!el) throw new Error('date trigger not found')
+  return el
+}
+
+// When no value is set, the calendar opens on the real "today" month (react-day-picker's
+// own default), not the target month — navigate forward/back via the Nav buttons so the
+// target day is on-screen regardless of when the suite happens to run.
+function navigateToMonth(isoDate: string) {
+  const [y, m] = isoDate.split('-').map(Number)
+  const target = new Date(y, m - 1, 1)
+  const now = new Date()
+  const diff = (target.getFullYear() - now.getFullYear()) * 12 + (target.getMonth() - now.getMonth())
+  const label = diff >= 0 ? /go to the next month/i : /go to the previous month/i
+  for (let i = 0; i < Math.abs(diff); i++) {
+    fireEvent.click(screen.getByRole('button', { name: label }))
+  }
+}
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const mockCreateMilestone = vi.fn()
+
+vi.mock('@/lib/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/api')>()
+  return {
+    ...actual,
+    createMilestone: (...args: unknown[]) => mockCreateMilestone(...args),
+  }
+})
+
+const mockAddToast = vi.fn()
+
+vi.mock('@/store/ui', () => ({
+  useUiStore: (selector?: (s: { addToast: ReturnType<typeof vi.fn> }) => unknown) => {
+    const store = { addToast: mockAddToast }
+    return selector ? selector(store) : store
+  },
+}))
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
+  })
+}
+
+function renderSlideOver(props?: Partial<React.ComponentProps<typeof CreateMilestoneSlideOver>>) {
+  return render(
+    <QueryClientProvider client={makeClient()}>
+      <CreateMilestoneSlideOver
+        open={true}
+        onOpenChange={vi.fn()}
+        workspaceId="ws-test-1"
+        {...props}
+      />
+    </QueryClientProvider>,
+  )
+}
+
+beforeEach(() => {
+  mockCreateMilestone.mockReset()
+  mockAddToast.mockReset()
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('CreateMilestoneSlideOver — due-date round trip (mirrors MilestoneDatePopover)', () => {
+  it('picking a day and submitting sends due_date as YYYY-MM-DD', async () => {
+    mockCreateMilestone.mockResolvedValueOnce({ id: 'ms-new', name: 'v1.0 Launch', due_date: '2026-08-01' })
+
+    renderSlideOver()
+    await screen.findByText('New milestone')
+
+    fireEvent.change(screen.getByLabelText(/^name/i), { target: { value: 'v1.0 Launch' } })
+
+    fireEvent.click(dateTrigger())
+    navigateToMonth('2026-08-01')
+    clickDay('2026-08-01')
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /create milestone/i }))
+    })
+
+    await waitFor(() => expect(mockCreateMilestone).toHaveBeenCalledOnce())
+    const [workspaceId, body] = mockCreateMilestone.mock.calls[0]
+    expect(workspaceId).toBe('ws-test-1')
+    expect(body.due_date).toBe('2026-08-01')
+    expect(body.name).toBe('v1.0 Launch')
+  })
+
+  it('differentiation: two different day picks produce two different due_date payloads', async () => {
+    mockCreateMilestone
+      .mockResolvedValueOnce({ id: 'ms-a', due_date: '2026-06-10' })
+      .mockResolvedValueOnce({ id: 'ms-b', due_date: '2026-07-20' })
+
+    const { unmount } = renderSlideOver()
+    await screen.findByText('New milestone')
+    fireEvent.change(screen.getByLabelText(/^name/i), { target: { value: 'Milestone A' } })
+    fireEvent.click(dateTrigger())
+    navigateToMonth('2026-06-10')
+    clickDay('2026-06-10')
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /create milestone/i }))
+    })
+    await waitFor(() => expect(mockCreateMilestone).toHaveBeenCalledTimes(1))
+    expect(mockCreateMilestone.mock.calls[0][1].due_date).toBe('2026-06-10')
+    unmount()
+
+    renderSlideOver()
+    await screen.findByText('New milestone')
+    fireEvent.change(screen.getByLabelText(/^name/i), { target: { value: 'Milestone B' } })
+    fireEvent.click(dateTrigger())
+    navigateToMonth('2026-07-20')
+    clickDay('2026-07-20')
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /create milestone/i }))
+    })
+    await waitFor(() => expect(mockCreateMilestone).toHaveBeenCalledTimes(2))
+    expect(mockCreateMilestone.mock.calls[1][1].due_date).toBe('2026-07-20')
+
+    expect(mockCreateMilestone.mock.calls[0][1].due_date).not.toBe(
+      mockCreateMilestone.mock.calls[1][1].due_date,
+    )
+  })
+
+  it('submitting without picking a date omits due_date (undefined, not an empty string)', async () => {
+    mockCreateMilestone.mockResolvedValueOnce({ id: 'ms-no-date' })
+
+    renderSlideOver()
+    await screen.findByText('New milestone')
+    fireEvent.change(screen.getByLabelText(/^name/i), { target: { value: 'No date yet' } })
+
+    // The DatePicker starts empty — no interaction needed.
+    expect(dateTrigger()).toHaveTextContent('Pick a date')
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /create milestone/i }))
+    })
+
+    await waitFor(() => expect(mockCreateMilestone).toHaveBeenCalledOnce())
+    const body = mockCreateMilestone.mock.calls[0][1]
+    expect(body.due_date).toBeUndefined()
+  })
+
+  it('clicking the already-picked day clears it back to the placeholder (clear-via-reclick)', async () => {
+    renderSlideOver()
+    await screen.findByText('New milestone')
+
+    fireEvent.click(dateTrigger())
+    navigateToMonth('2026-08-01')
+    clickDay('2026-08-01')
+    expect(dateTrigger()).toHaveTextContent('Aug 1, 2026')
+
+    fireEvent.click(dateTrigger())
+    clickDay('2026-08-01')
+    expect(dateTrigger()).toHaveTextContent('Pick a date')
+  })
+
+  it('shows a success toast and closes the slide-over on successful create', async () => {
+    mockCreateMilestone.mockResolvedValueOnce({ id: 'ms-ok', due_date: '2026-08-01' })
+    const onOpenChange = vi.fn()
+
+    renderSlideOver({ onOpenChange })
+    await screen.findByText('New milestone')
+    fireEvent.change(screen.getByLabelText(/^name/i), { target: { value: 'Beta' } })
+    fireEvent.click(dateTrigger())
+    navigateToMonth('2026-08-01')
+    clickDay('2026-08-01')
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /create milestone/i }))
+    })
+
+    await waitFor(() => expect(mockAddToast).toHaveBeenCalledOnce())
+    expect(mockAddToast.mock.calls[0][0].variant).toBe('success')
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it('shows an error toast and keeps the slide-over open when createMilestone rejects', async () => {
+    mockCreateMilestone.mockRejectedValueOnce(new Error('500 Internal Server Error'))
+    const onOpenChange = vi.fn()
+
+    renderSlideOver({ onOpenChange })
+    await screen.findByText('New milestone')
+    fireEvent.change(screen.getByLabelText(/^name/i), { target: { value: 'Will fail' } })
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /create milestone/i }))
+    })
+
+    await waitFor(() => expect(mockAddToast).toHaveBeenCalledOnce())
+    expect(mockAddToast.mock.calls[0][0].variant).toBe('error')
+    expect(onOpenChange).not.toHaveBeenCalledWith(false)
+  })
+})
+
+describe('CreateMilestoneSlideOver — name validation', () => {
+  it('blocks submit and shows an inline error when name is empty', async () => {
+    renderSlideOver()
+    await screen.findByText('New milestone')
+
+    fireEvent.click(screen.getByRole('button', { name: /create milestone/i }))
+
+    expect(await screen.findByText(/name is required/i)).toBeInTheDocument()
+    expect(mockCreateMilestone).not.toHaveBeenCalled()
+  })
+})

--- a/src/components/workspaces/CreateMilestoneSlideOver.tsx
+++ b/src/components/workspaces/CreateMilestoneSlideOver.tsx
@@ -11,8 +11,10 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
+import { DatePicker } from '@/components/ui/date-picker'
 import { createMilestone, milestonesQueryKeys, isApiError } from '@/lib/api'
 import { useUiStore } from '@/store/ui'
+import { parseLocalDate, formatLocalDate } from '@/lib/calendar/eventMapping'
 
 interface CreateMilestoneSlideOverProps {
   open: boolean
@@ -112,12 +114,10 @@ export function CreateMilestoneSlideOver({
             <Label htmlFor="cm-due" className="text-[var(--color-secondary)]">
               Due date
             </Label>
-            <Input
+            <DatePicker
               id="cm-due"
-              type="date"
-              value={form.due_date}
-              onChange={(e) => setForm((s) => ({ ...s, due_date: e.target.value }))}
-              className="bg-[var(--color-surface-2)] border-[var(--color-border)] text-[var(--color-secondary)]"
+              value={parseLocalDate(form.due_date)}
+              onChange={(d) => setForm((s) => ({ ...s, due_date: d ? formatLocalDate(d) : '' }))}
             />
           </div>
 

--- a/src/components/workspaces/CreateTaskSlideOver.initialDue.test.tsx
+++ b/src/components/workspaces/CreateTaskSlideOver.initialDue.test.tsx
@@ -80,33 +80,44 @@ beforeEach(() => {
   mockAddToast.mockReset()
 })
 
+// DateTimePicker's formatted trigger label — matches formatDateTimeDisplay() in date-time-picker.tsx.
+function formatDueLabel(datetimeLocal: string): string {
+  return new Date(datetimeLocal).toLocaleString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe('CreateTaskSlideOver — initialDue prop (F-07)', () => {
   it('seeds the due input when initialDue is provided and slide-over opens', () => {
     // BDD: Given CreateTaskSlideOver opens with initialDue="2026-06-22T00:00",
     // When the component renders,
-    // Then the due date input's value is "2026-06-22T00:00".
+    // Then the due date DateTimePicker trigger shows the formatted seeded value.
     renderSlideOver({ initialDue: '2026-06-22T00:00' })
 
-    const dueInput = screen.getByLabelText(/^due date$/i) as HTMLInputElement
-    expect(dueInput.value).toBe('2026-06-22T00:00')
+    const dueTrigger = screen.getByRole('button', { name: /^due date$/i })
+    expect(dueTrigger).toHaveTextContent(formatDueLabel('2026-06-22T00:00'))
   })
 
   it('leaves the due input empty when initialDue is NOT provided (no regression)', () => {
     // BDD: Given CreateTaskSlideOver opens without an initialDue prop,
     // When the component renders,
-    // Then the due date input is empty (default behavior preserved).
+    // Then the due date DateTimePicker shows its empty placeholder (default behavior preserved).
     renderSlideOver()
 
-    const dueInput = screen.getByLabelText(/^due date$/i) as HTMLInputElement
-    expect(dueInput.value).toBe('')
+    const dueTrigger = screen.getByRole('button', { name: /^due date$/i })
+    expect(dueTrigger).toHaveTextContent('Pick a date and time')
   })
 
   it('updates the due field when the slide-over is reopened with a different initialDue', () => {
     // BDD: Given CreateTaskSlideOver is first opened with initialDue="2026-06-22T00:00",
     // When it is closed then reopened with initialDue="2026-07-04T09:30",
-    // Then the due date input shows "2026-07-04T09:30".
+    // Then the due date DateTimePicker trigger shows the "2026-07-04T09:30" formatting.
     const onOpenChange = vi.fn()
     const { rerender } = render(
       <QueryClientProvider client={makeClient()}>
@@ -120,8 +131,8 @@ describe('CreateTaskSlideOver — initialDue prop (F-07)', () => {
     )
 
     // Verify initial seed
-    let dueInput = screen.getByLabelText(/^due date$/i) as HTMLInputElement
-    expect(dueInput.value).toBe('2026-06-22T00:00')
+    let dueTrigger = screen.getByRole('button', { name: /^due date$/i })
+    expect(dueTrigger).toHaveTextContent(formatDueLabel('2026-06-22T00:00'))
 
     // Close (reset)
     fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
@@ -138,7 +149,7 @@ describe('CreateTaskSlideOver — initialDue prop (F-07)', () => {
       </QueryClientProvider>,
     )
 
-    dueInput = screen.getByLabelText(/^due date$/i) as HTMLInputElement
-    expect(dueInput.value).toBe('2026-07-04T09:30')
+    dueTrigger = screen.getByRole('button', { name: /^due date$/i })
+    expect(dueTrigger).toHaveTextContent(formatDueLabel('2026-07-04T09:30'))
   })
 })

--- a/src/components/workspaces/CreateTaskSlideOver.test.tsx
+++ b/src/components/workspaces/CreateTaskSlideOver.test.tsx
@@ -11,11 +11,70 @@
  *   - Validation label: "Name" → "Title"
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest'
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { CreateTaskSlideOver } from './CreateTaskSlideOver'
+
+// DateTimePicker (shadcn Calendar + Select) needs these jsdom polyfills to open
+// (same gap noted in date-time-picker.test.tsx).
+beforeAll(() => {
+  if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = () => false
+  }
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = () => {}
+  }
+  if (typeof window !== 'undefined' && !window.ResizeObserver) {
+    window.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver
+  }
+})
+
+// Click a react-day-picker day cell (data-day="YYYY-MM-DD") inside an open DateTimePicker/DatePicker popover.
+function clickDay(isoDate: string) {
+  const btn = document.querySelector(`[data-day="${isoDate}"] button`)
+  if (!btn) throw new Error(`no day button for ${isoDate}`)
+  fireEvent.click(btn)
+}
+
+// Pick an option from an open DateTimePicker's Hour/Minute <Select>.
+function selectOption(comboboxName: string, optionName: string) {
+  fireEvent.click(screen.getByRole('combobox', { name: comboboxName }))
+  const option = screen.getByRole('option', { name: optionName })
+  fireEvent.pointerDown(option, { pointerId: 1, button: 0 })
+  fireEvent.click(option)
+}
+
+// When no value is set, the calendar opens on the real "today" month (react-day-picker's
+// own default), not the target month — navigate forward/back via the Nav buttons so the
+// target day is on-screen regardless of when the suite happens to run.
+function navigateToMonth(isoDate: string) {
+  const [y, m] = isoDate.split('-').map(Number)
+  const target = new Date(y, m - 1, 1)
+  const now = new Date()
+  const diff = (target.getFullYear() - now.getFullYear()) * 12 + (target.getMonth() - now.getMonth())
+  const label = diff >= 0 ? /go to the next month/i : /go to the previous month/i
+  for (let i = 0; i < Math.abs(diff); i++) {
+    fireEvent.click(screen.getByRole('button', { name: label }))
+  }
+}
+
+// Open a DateTimePicker (by its aria-label) and pick a full date + time.
+async function pickDateTime(
+  triggerLabel: RegExp,
+  { isoDate, hour, minute }: { isoDate: string; hour: string; minute: string },
+) {
+  fireEvent.click(await screen.findByRole('button', { name: triggerLabel }))
+  navigateToMonth(isoDate)
+  clickDay(isoDate)
+  selectOption('Hour', hour)
+  selectOption('Minute', minute)
+}
 
 // ── API mock ─────────────────────────────────────────────────────────────────
 
@@ -320,9 +379,8 @@ describe('CreateTaskSlideOver — full task UX fields (trigger / depends-on / du
     fireEvent.click(trigCombo)
     fireEvent.click(await screen.findByText(/once \(at a time\)/i))
 
-    // Fill the datetime-local input
-    const dt = await screen.findByLabelText(/trigger date and time/i)
-    fireEvent.change(dt, { target: { value: '2026-07-31T17:00' } })
+    // Pick the date + time via the DateTimePicker (calendar day + Hour/Minute selects)
+    await pickDateTime(/trigger date and time/i, { isoDate: '2026-07-31', hour: '17', minute: '00' })
 
     fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
     await waitFor(() => expect(vi.mocked(createTask)).toHaveBeenCalledOnce())
@@ -384,7 +442,9 @@ describe('CreateTaskSlideOver — full task UX fields (trigger / depends-on / du
     fireEvent.click(await screen.findByText(/once \(at a time\)/i))
 
     fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
-    expect(await screen.findByText(/pick a date and time/i)).toBeInTheDocument()
+    // Two DateTimePicker triggers (Trigger + Due) also show "Pick a date and time" as
+    // their empty placeholder, so match the error paragraph text uniquely.
+    expect(await screen.findByText(/pick a date and time for the one-time trigger/i)).toBeInTheDocument()
     expect(vi.mocked(createTask)).not.toHaveBeenCalled()
     delete (Element.prototype as { scrollIntoView?: () => void }).scrollIntoView
   })
@@ -415,7 +475,7 @@ describe('CreateTaskSlideOver — full task UX fields (trigger / depends-on / du
     renderSlideOver()
 
     fireEvent.change(screen.getByLabelText(/title/i), { target: { value: 'With due' } })
-    fireEvent.change(screen.getByLabelText(/^due date$/i), { target: { value: '2026-08-01T09:00' } })
+    await pickDateTime(/^due date$/i, { isoDate: '2026-08-01', hour: '09', minute: '00' })
 
     fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
     await waitFor(() => expect(vi.mocked(createTask)).toHaveBeenCalledOnce())

--- a/src/components/workspaces/CreateTaskSlideOver.tsx
+++ b/src/components/workspaces/CreateTaskSlideOver.tsx
@@ -22,6 +22,7 @@ import {
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { Checkbox } from '@/components/ui/checkbox'
 import { SmartSelect } from '@/components/ui/smart-select'
+import { DateTimePicker } from '@/components/ui/date-time-picker'
 import {
   createTask,
   updateTask,
@@ -41,6 +42,7 @@ import { PRIORITY_BADGE } from './TaskCard'
 import {
   type TriggerKind,
   buildTrigger,
+  toDatetimeLocalValue,
   datetimeLocalToMs,
   datetimeLocalToIso,
 } from './taskFormFields'
@@ -445,12 +447,14 @@ export function CreateTaskSlideOver({
             </Select>
 
             {form.triggerKind === 'once' && (
-              <Input
+              <DateTimePicker
                 aria-label="Trigger date and time"
-                type="datetime-local"
-                value={form.triggerAt}
-                onChange={(e) => { setForm((s) => ({ ...s, triggerAt: e.target.value })); setTriggerError('') }}
-                className="mt-1 text-xs"
+                value={form.triggerAt ? new Date(form.triggerAt) : null}
+                onChange={(d) => {
+                  setForm((s) => ({ ...s, triggerAt: d ? toDatetimeLocalValue(d.getTime()) : '' }))
+                  setTriggerError('')
+                }}
+                className="mt-1"
               />
             )}
             {form.triggerKind === 'every' && (
@@ -548,13 +552,11 @@ export function CreateTaskSlideOver({
             <Label htmlFor="ct-due" className="text-[var(--color-secondary)]">
               Due date
             </Label>
-            <Input
+            <DateTimePicker
               id="ct-due"
               aria-label="Due date"
-              type="datetime-local"
-              value={form.due}
-              onChange={(e) => setForm((s) => ({ ...s, due: e.target.value }))}
-              className="text-xs"
+              value={form.due ? new Date(form.due) : null}
+              onChange={(d) => setForm((s) => ({ ...s, due: d ? toDatetimeLocalValue(d.getTime()) : '' }))}
             />
           </div>
 

--- a/src/components/workspaces/CreateTaskSlideOver.tsx
+++ b/src/components/workspaces/CreateTaskSlideOver.tsx
@@ -42,9 +42,10 @@ import { PRIORITY_BADGE } from './TaskCard'
 import {
   type TriggerKind,
   buildTrigger,
-  toDatetimeLocalValue,
   datetimeLocalToMs,
   datetimeLocalToIso,
+  datetimeLocalToDate,
+  dateToDatetimeLocal,
 } from './taskFormFields'
 
 interface CreateTaskSlideOverProps {
@@ -449,9 +450,9 @@ export function CreateTaskSlideOver({
             {form.triggerKind === 'once' && (
               <DateTimePicker
                 aria-label="Trigger date and time"
-                value={form.triggerAt ? new Date(form.triggerAt) : null}
+                value={datetimeLocalToDate(form.triggerAt)}
                 onChange={(d) => {
-                  setForm((s) => ({ ...s, triggerAt: d ? toDatetimeLocalValue(d.getTime()) : '' }))
+                  setForm((s) => ({ ...s, triggerAt: dateToDatetimeLocal(d) }))
                   setTriggerError('')
                 }}
                 className="mt-1"
@@ -555,8 +556,8 @@ export function CreateTaskSlideOver({
             <DateTimePicker
               id="ct-due"
               aria-label="Due date"
-              value={form.due ? new Date(form.due) : null}
-              onChange={(d) => setForm((s) => ({ ...s, due: d ? toDatetimeLocalValue(d.getTime()) : '' }))}
+              value={datetimeLocalToDate(form.due)}
+              onChange={(d) => setForm((s) => ({ ...s, due: dateToDatetimeLocal(d) }))}
             />
           </div>
 

--- a/src/components/workspaces/taskFormFields.ts
+++ b/src/components/workspaces/taskFormFields.ts
@@ -58,6 +58,29 @@ export function datetimeLocalToIso(value: string): string | null {
   return Number.isNaN(d.getTime()) ? null : d.toISOString()
 }
 
+/**
+ * Convert a `datetime-local` input value (or any date-ish string, e.g. an
+ * RFC3339 `due` timestamp) to a `Date`, built on `datetimeLocalToMs`.
+ * Returns null when missing/empty/invalid — the inline
+ * `value ? new Date(value) : null` pattern this replaces at DateTimePicker
+ * call sites, minus the risk of silently constructing an Invalid Date.
+ */
+export function datetimeLocalToDate(value?: string | null): Date | null {
+  if (!value) return null
+  const ms = datetimeLocalToMs(value)
+  return ms == null ? null : new Date(ms)
+}
+
+/**
+ * Convert a `Date` (or null) to the `datetime-local` input value a
+ * DateTimePicker's `onChange` hands to form state, built on
+ * `toDatetimeLocalValue`. Returns '' for null — the inline
+ * `d ? toDatetimeLocalValue(d.getTime()) : ''` pattern this replaces.
+ */
+export function dateToDatetimeLocal(date: Date | null): string {
+  return date ? toDatetimeLocalValue(date.getTime()) : ''
+}
+
 /** Human label for a trigger summary line. */
 export function triggerSummary(trigger?: TaskTrigger | null): string {
   if (!trigger || trigger.type === 'manual') return 'Manual (drag to run)'


### PR DESCRIPTION
Replaces the 7 native `<input type="datetime-local"/"date">` inputs with a design-system date/time picker. **Base: `hotfix/v0.1.1`.**

## What
- Add `react-day-picker@9.14.0`; hand-vendored `ui/calendar`, `ui/date-picker`, `ui/date-time-picker` (shadcn hh/mm selects). Trigger reuses the exact `<Input>` classes → pixel-identical box (the reported bug).
- Migrate 7 inputs across CreateTaskSlideOver, ScheduleFormSheet, TaskDetailPanel, MilestoneDatePopover, CreateMilestoneSlideOver. Value contract preserved via existing converters (no `date-fns`).

## Quality
- 3-reviewer gate (TZ round-trips verified clean) + fix wave: fixed a **Critical** prompt-edit data-loss (effect split), focus-ring parity, debounced 1-PATCH autosave, deterministic 00:00 default; added round-trip tests.
- Green: tsc 0 / vitest 3423 / CI `spa` ALL GATES GREEN. No file overlap with in-flight branches.