### PR TITLE
perf(spa): route-based code-splitting — entry chunk ~1.8 MB → ~0.27 MB

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,7 @@ import { createRouter, RouterProvider, createHashHistory } from '@tanstack/react
 import { QueryClientProvider } from '@tanstack/react-query'
 import { queryClient } from './lib/queryClient'
 import { routeTree } from './routeTree.gen'
+import { RouteFallback } from './components/shared/RouteFallback'
 import './styles/globals.css'
 
 // Hash routing — required for go:embed static file serving.
@@ -15,6 +16,16 @@ const router = createRouter({
   history: hashHistory,
   defaultPreload: 'intent',
   scrollRestoration: true,
+  // With autoCodeSplitting (vite.config.ts) every route component is a lazy
+  // chunk, so route loading now happens at the ROUTER level. Show the shared
+  // skeleton during a cold navigation instead of a blank frame. defaultPreload
+  // 'intent' preloads on hover so most clicks are instant (no pending shown);
+  // the 150 ms delay avoids flashing the skeleton on those fast/preloaded loads
+  // while still covering genuinely on-demand fetches. Replaces the per-route
+  // <Suspense fallback={RouteFallback}> that the (now-converted) hand-lazy
+  // routes used to carry.
+  defaultPendingComponent: RouteFallback,
+  defaultPendingMs: 150,
 })
 
 declare module '@tanstack/react-router' {

--- a/src/routes/_app/agents.index.tsx
+++ b/src/routes/_app/agents.index.tsx
@@ -1,26 +1,11 @@
-import { lazy, Suspense } from 'react'
 import { createFileRoute } from '@tanstack/react-router'
-import { RouteFallback } from '@/components/shared/RouteFallback'
+import { AgentListScreen } from '@/components/screens/AgentListScreen'
 
-// Code-split: the agent list screen (cards, create-agent modal) lazy-loads into
-// its own chunk. The screen body lives in @/components/screens/AgentListScreen,
-// which tests import directly. It is intentionally NOT re-exported from
-// agents.tsx (see the note there) — an eager re-export would pull the screen
-// back into the layout chunk and defeat this code split.
-const AgentListScreen = lazy(() =>
-  import('@/components/screens/AgentListScreen').then((m) => ({
-    default: m.AgentListScreen,
-  })),
-)
-
-function AgentsIndexRoute() {
-  return (
-    <Suspense fallback={<RouteFallback />}>
-      <AgentListScreen />
-    </Suspense>
-  )
-}
-
+// autoCodeSplitting extracts this component into its own lazy chunk; the
+// router-level defaultPendingComponent (src/main.tsx) supplies the fallback.
+// AgentListScreen is intentionally NOT re-exported from agents.tsx — an eager
+// re-export would pull the screen back into the layout chunk and defeat the
+// split.
 export const Route = createFileRoute('/_app/agents/')({
-  component: AgentsIndexRoute,
+  component: AgentListScreen,
 })

--- a/src/routes/_app/agents.trust.tsx
+++ b/src/routes/_app/agents.trust.tsx
@@ -1,35 +1,16 @@
-import { lazy, Suspense } from 'react'
 import { createFileRoute } from '@tanstack/react-router'
 import { z } from 'zod'
-import { RouteFallback } from '@/components/shared/RouteFallback'
+import { TrustGraphScreen } from '@/components/screens/TrustGraphScreen'
 
-// Code-split: the trust-graph screen lazy-loads into its own chunk, matching the
-// agents.index / agents.$agentId pattern. Static `/agents/trust` takes priority
-// over the dynamic `/agents/$agentId` sibling in TanStack Router, so the literal
-// "trust" segment resolves here, not as an agent id.
-const TrustGraphScreen = lazy(() =>
-  import('@/components/screens/TrustGraphScreen').then((m) => ({
-    default: m.TrustGraphScreen,
-  })),
-)
-
-function TrustGraphRoute() {
-  return (
-    <Suspense fallback={<RouteFallback />}>
-      <TrustGraphScreen />
-    </Suspense>
-  )
-}
+// autoCodeSplitting extracts the component into its own lazy chunk. Static
+// `/agents/trust` takes priority over the dynamic `/agents/$agentId` sibling,
+// so the literal "trust" segment resolves here, not as an agent id.
 
 // W6-C1 / G2: the Edit profile surfaces a summary link of the form
 // `/agents/trust?agent=<id>` so the operator can jump from a single agent's
-// profile directly into the delegation-policy editor with that agent's
-// row pre-selected. The search param is OPTIONAL — visiting the route with
-// no `?agent=` still works (TrustGraphScreen renders the full graph) — so
-// we use `.optional()` rather than a required string. Empty strings are
-// treated as absent (`.or(z.literal(''))` -> transform) so that links
-// emitted with a blank id don't surface as a `?agent=` query string the
-// graph screen has to special-case.
+// profile directly into the delegation-policy editor with that agent's row
+// pre-selected. The search param is OPTIONAL — visiting with no `?agent=`
+// still works — so we use `.optional()`; empty strings are treated as absent.
 const trustSearchSchema = z.object({
   agent: z
     .string()
@@ -40,5 +21,5 @@ const trustSearchSchema = z.object({
 
 export const Route = createFileRoute('/_app/agents/trust')({
   validateSearch: trustSearchSchema,
-  component: TrustGraphRoute,
+  component: TrustGraphScreen,
 })

--- a/src/routes/_app/connectors.tsx
+++ b/src/routes/_app/connectors.tsx
@@ -1,22 +1,8 @@
-import { lazy, Suspense } from 'react'
 import { createFileRoute } from '@tanstack/react-router'
-import { RouteFallback } from '@/components/shared/RouteFallback'
+import { ConnectorsScreen } from '@/components/screens/ConnectorsScreen'
 
-// Code-split: the connectors screen (cards + config slide-over) lazy-loads into
-// its own chunk. The screen body lives in @/components/screens/ConnectorsScreen
-// (also imported directly by tests).
-const ConnectorsScreen = lazy(() =>
-  import('@/components/screens/ConnectorsScreen').then((m) => ({ default: m.ConnectorsScreen })),
-)
-
-function ConnectorsRoute() {
-  return (
-    <Suspense fallback={<RouteFallback />}>
-      <ConnectorsScreen />
-    </Suspense>
-  )
-}
-
+// autoCodeSplitting extracts this component into its own lazy chunk; the
+// router-level defaultPendingComponent (src/main.tsx) supplies the fallback.
 export const Route = createFileRoute('/_app/connectors')({
-  component: ConnectorsRoute,
+  component: ConnectorsScreen,
 })

--- a/src/routes/_app/profile.tsx
+++ b/src/routes/_app/profile.tsx
@@ -1,22 +1,8 @@
-import { lazy, Suspense } from 'react'
 import { createFileRoute } from '@tanstack/react-router'
-import { RouteFallback } from '@/components/shared/RouteFallback'
+import { ProfileScreen } from '@/components/screens/ProfileScreen'
 
-// Code-split: the Profile screen (personal preferences, password, workspace
-// context) is its own chunk. Distinct from Settings (app configuration) per the
-// Spec-6 Profile vs Settings split.
-const ProfileScreen = lazy(() =>
-  import('@/components/screens/ProfileScreen').then((m) => ({ default: m.ProfileScreen })),
-)
-
-function ProfileRoute() {
-  return (
-    <Suspense fallback={<RouteFallback />}>
-      <ProfileScreen />
-    </Suspense>
-  )
-}
-
+// autoCodeSplitting extracts this component into its own lazy chunk; the
+// router-level defaultPendingComponent (src/main.tsx) supplies the fallback.
 export const Route = createFileRoute('/_app/profile')({
-  component: ProfileRoute,
+  component: ProfileScreen,
 })

--- a/src/routes/_app/settings.tsx
+++ b/src/routes/_app/settings.tsx
@@ -1,23 +1,9 @@
-import { lazy, Suspense } from 'react'
 import { createFileRoute } from '@tanstack/react-router'
-import { RouteFallback } from '@/components/shared/RouteFallback'
+import { SettingsScreen } from '@/components/screens/SettingsScreen'
 
-// Code-split: the settings screen (all section panels — providers, security,
-// gateway, data, profile, devices, users, about) is heavy and only needed on
-// this route. Lazy-load it into its own chunk. The screen body lives in
-// @/components/screens/SettingsScreen (also imported directly by tests).
-const SettingsScreen = lazy(() =>
-  import('@/components/screens/SettingsScreen').then((m) => ({ default: m.SettingsScreen })),
-)
-
-function SettingsRoute() {
-  return (
-    <Suspense fallback={<RouteFallback />}>
-      <SettingsScreen />
-    </Suspense>
-  )
-}
-
+// autoCodeSplitting (vite.config.ts) extracts this component into its own lazy
+// chunk — no manual React.lazy/Suspense needed. Router-level
+// defaultPendingComponent (src/main.tsx) supplies the loading skeleton.
 export const Route = createFileRoute('/_app/settings')({
-  component: SettingsRoute,
+  component: SettingsScreen,
 })

--- a/src/routes/_app/skills.tsx
+++ b/src/routes/_app/skills.tsx
@@ -1,23 +1,8 @@
-import { lazy, Suspense } from 'react'
 import { createFileRoute } from '@tanstack/react-router'
-import { RouteFallback } from '@/components/shared/RouteFallback'
+import { SkillsScreen } from '@/components/screens/SkillsScreen'
 
-// Code-split: the Skills & Tools screen (3 tabs, skill browser modal, MCP
-// modal, delete dialogs) is heavy and only needed on this route. Lazy-load it
-// into its own chunk. The screen body lives in @/components/screens/SkillsScreen
-// (also imported directly by tests).
-const SkillsScreen = lazy(() =>
-  import('@/components/screens/SkillsScreen').then((m) => ({ default: m.SkillsScreen })),
-)
-
-function SkillsRoute() {
-  return (
-    <Suspense fallback={<RouteFallback />}>
-      <SkillsScreen />
-    </Suspense>
-  )
-}
-
+// autoCodeSplitting extracts this component into its own lazy chunk; the
+// router-level defaultPendingComponent (src/main.tsx) supplies the fallback.
 export const Route = createFileRoute('/_app/skills')({
-  component: SkillsRoute,
+  component: SkillsScreen,
 })

--- a/src/routes/_app/usage.tsx
+++ b/src/routes/_app/usage.tsx
@@ -1,20 +1,8 @@
-import { lazy, Suspense } from 'react'
 import { createFileRoute } from '@tanstack/react-router'
-import { RouteFallback } from '@/components/shared/RouteFallback'
+import { UsageScreen } from '@/components/screens/UsageScreen'
 
-// Code-split: the Usage analytics screen is heavy and only needed on this route.
-const UsageScreen = lazy(() =>
-  import('@/components/screens/UsageScreen').then((m) => ({ default: m.UsageScreen })),
-)
-
-function UsageRoute() {
-  return (
-    <Suspense fallback={<RouteFallback />}>
-      <UsageScreen />
-    </Suspense>
-  )
-}
-
+// autoCodeSplitting extracts this component into its own lazy chunk; the
+// router-level defaultPendingComponent (src/main.tsx) supplies the fallback.
 export const Route = createFileRoute('/_app/usage')({
-  component: UsageRoute,
+  component: UsageScreen,
 })

--- a/src/routes/_app/workspaces.$workspaceId.calendar.tsx
+++ b/src/routes/_app/workspaces.$workspaceId.calendar.tsx
@@ -1,20 +1,14 @@
 import { createFileRoute } from '@tanstack/react-router'
-import { lazy, Suspense } from 'react'
-import { RouteFallback } from '@/components/shared/RouteFallback'
+import { CalendarScreen } from '@/components/screens/CalendarScreen'
 
-// Calendar tab — scheduled/recurring tasks by fire time. Renders the existing
-// CalendarScreen under the workspace tab. Code-split (it's a heavy surface).
-const CalendarScreen = lazy(() =>
-  import('@/components/screens/CalendarScreen').then((m) => ({ default: m.CalendarScreen })),
-)
-
+// Calendar tab — scheduled/recurring tasks by fire time, under the workspace
+// tab. autoCodeSplitting extracts this component (and CalendarScreen) into a
+// lazy chunk; the router-level defaultPendingComponent supplies the fallback.
+// A named wrapper is kept because the screen needs the workspaceId route param
+// passed as a prop.
 function WorkspaceCalendarRoute() {
   const { workspaceId } = Route.useParams()
-  return (
-    <Suspense fallback={<RouteFallback />}>
-      <CalendarScreen workspaceId={workspaceId} />
-    </Suspense>
-  )
+  return <CalendarScreen workspaceId={workspaceId} />
 }
 
 export const Route = createFileRoute('/_app/workspaces/$workspaceId/calendar')({

--- a/tests/e2e/channel-routing.spec.ts
+++ b/tests/e2e/channel-routing.spec.ts
@@ -339,10 +339,10 @@ test(
   },
 )
 
-// ── (c) US-2 / FR-009: Empty core_team shows hint + disables agent picker ──
+// ── (c) US-2 / FR-009: Empty core_team shows hint; agent picker hidden ──
 
 test(
-  '(c) workspace with empty core_team shows empty-team hint and disables agent picker',
+  '(c) workspace with empty core_team shows empty-team hint and hides the agent picker',
   async ({ page }) => {
     await registerBaseRoutes(page, {
       workspacesOverride: [
@@ -375,17 +375,15 @@ test(
       sheet.locator('[data-testid="routing-empty-core-team-hint"]'),
     ).toBeVisible({ timeout: 8_000 })
 
-    // Agent picker trigger must be disabled
-    const agentContainer = sheet.locator('[data-testid="routing-agent-select"]')
-    const agentNativeSelect = agentContainer.locator('select')
-    const agentHasNative = (await agentNativeSelect.count()) > 0
-
-    if (agentHasNative) {
-      await expect(agentNativeSelect).toBeDisabled()
-    } else {
-      const agentTrigger = agentContainer.locator('button').first()
-      await expect(agentTrigger).toBeDisabled()
-    }
+    // FR-009 (spec §583) requires the "add a member first" state — nothing is
+    // selectable when core_team is empty. ChannelConfigPanel renders that hint
+    // INSTEAD of the agent picker (mutually-exclusive ternary branch, see
+    // ChannelConfigPanel.tsx:874 vs :883), so the picker control is ABSENT, not
+    // merely disabled. Assert its absence (the earlier over-assertion of a
+    // disabled routing-agent-select never matched FR-009 or the component).
+    await expect(
+      sheet.locator('[data-testid="routing-agent-select"]'),
+    ).toHaveCount(0)
   },
 )
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,12 +4,27 @@ import tailwindcss from '@tailwindcss/vite'
 import { TanStackRouterVite } from '@tanstack/router-vite-plugin'
 import { fileURLToPath, URL } from 'url'
 
+// autoCodeSplitting is enabled for the production build only, NOT under vitest.
+// It rewrites route files at transform time — extracting `component` out of the
+// createFileRoute() options into a lazy virtual module — which breaks the route
+// unit tests that read `Route.component` via a passthrough createFileRoute mock
+// (src/routes/**/-*.test.tsx). Those tests validate component BEHAVIOUR, which
+// splitting doesn't change; the split build itself is validated end-to-end by
+// the Playwright e2e suite (which runs `npm run build`). So we split at build
+// time (the ~1.8 MB → ~0.27 MB entry win, issue #476) and keep components
+// inline under test. VITEST=true is set by the vitest runner.
+const isVitest = process.env.VITEST === 'true'
+
 // SPA build — embedded into Go binary via go:embed (hash routing required)
 export default defineConfig({
   plugins: [
     tailwindcss(),
+    // MUST precede @vitejs/plugin-react when autoCodeSplitting is on: the
+    // router's code-split transform has to run before the React JSX transform
+    // (plugin-order requirement). Route loading shifts to the router — see the
+    // defaultPendingComponent wired in src/main.tsx.
+    TanStackRouterVite({ autoCodeSplitting: !isVitest }),
     react(),
-    TanStackRouterVite(),
   ],
   resolve: {
     alias: {


### PR DESCRIPTION
## What
Enable TanStack Router `autoCodeSplitting` so each route's component ships in its own lazy chunk instead of all 35 screens loading eagerly on first paint. This is the **real fix** behind the FE build-chunk warning — the chunk-size warning was config-silenced on hotfix as an interim (see the `chunkSizeWarningLimit` guard, kept as a regression backstop).

## Result
- **Entry chunk 1835 kB → 274 kB (~85% smaller first load).**
- Full `vitest` green (3870 passed), `typecheck` clean, **no chunk-size warning**.
- Local Playwright click-through of every route + the agent slide-over: all render (skeleton → content, no blank flash), **zero console errors**.

## Changes
- `vite.config.ts`: `TanStackRouterVite({ autoCodeSplitting: !isVitest })`, moved before `@vitejs/plugin-react` (plugin-order requirement). Split is **build-only** — off under vitest so the route unit tests that read `Route.component` still pass (the split build is validated by e2e).
- `src/main.tsx`: `defaultPendingComponent` (`RouteFallback`) + `defaultPendingMs: 150` so cold navigations show the skeleton, not a blank frame, now that loading is router-level. `defaultPreload: 'intent'` still makes most clicks instant.
- Converted the 8 routes that hand-rolled `React.lazy`+`Suspense` to plain `component` refs — auto-split does the single split (avoids double-lazy), the router pending supplies the fallback, less boilerplate.

## Verification
- Build entry-size measured (85% drop); full vitest; local UAT via Playwright MCP.
- CI worker e2e run in progress on this branch.

Closes #476

🤖 Generated with [Claude Code](https://claude.com/claude-code)