### PR TITLE
fix(ci): green the Go-triggered workflows on hotfix (E2E build, macOS matrix, realgw flake)

### DIFF
--- a/.github/workflows/evals-nightly.yml
+++ b/.github/workflows/evals-nightly.yml
@@ -29,7 +29,8 @@ jobs:
           cp -r dist/spa pkg/gateway/spa
 
       - name: Build omnipus
-        run: CGO_ENABLED=0 go build -o omnipus ./cmd/omnipus/
+        # -tags goolm,stdjson required — main.go is //go:build stdjson gated.
+        run: CGO_ENABLED=0 go build -tags goolm,stdjson -o omnipus ./cmd/omnipus/
 
       - name: Run evals
         env:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -568,7 +568,11 @@ jobs:
         # user-crud) that use setup.ts DEFAULT_OMNIPUS_BINARY find it. Also
         # keep a copy as ./omnipus for the global-setup gateway.
         run: |
-          CGO_ENABLED=0 go build -o /tmp/omnipus-ci ./cmd/omnipus/
+          # -tags goolm,stdjson is required: cmd/omnipus/main.go is gated
+          # //go:build stdjson as a deliberate fail-fast against tag-less builds
+          # ("function main is undeclared" otherwise). Matches the canonical
+          # build tags (cross-platform.yml, Makefile).
+          CGO_ENABLED=0 go build -tags goolm,stdjson -o /tmp/omnipus-ci ./cmd/omnipus/
           cp /tmp/omnipus-ci ./omnipus
 
       - name: Prepare gateway home directory

--- a/pkg/clidetect/clidetect_test.go
+++ b/pkg/clidetect/clidetect_test.go
@@ -17,6 +17,24 @@ import (
 	"testing"
 )
 
+// evalTempDir returns a fresh t.TempDir(), symlink-resolved. On macOS,
+// t.TempDir() lives under /var/folders/... but /var is itself a symlink to
+// /private/var; detect()'s resolve() step (clidetect.go) runs every hit
+// through EvalSymlinks, so a path built from the raw (unresolved) temp dir
+// would never equal got.Path on macOS even though the file is identical.
+// Resolving the base here up front keeps both sides of the comparison on the
+// same (canonical) path. EvalSymlinks is a no-op when nothing in the path is
+// a symlink (e.g. Linux CI), so this is safe everywhere.
+func evalTempDir(t *testing.T) string {
+	t.Helper()
+	d := t.TempDir()
+	resolved, err := filepath.EvalSymlinks(d)
+	if err != nil {
+		return d
+	}
+	return resolved
+}
+
 // writeExec writes a regular file with the executable bit set and returns its
 // path. Used to stand in for a real installed binary under a temp well-known dir.
 func writeExec(t *testing.T, dir, name string) string {
@@ -52,7 +70,7 @@ func alwaysMiss(string) (string, error) {
 
 // TestDetect_FoundOnPath: a $PATH hit yields {installed, abs path, source=path}.
 func TestDetect_FoundOnPath(t *testing.T) {
-	tmp := t.TempDir()
+	tmp := evalTempDir(t)
 	bin := writeExec(t, filepath.Join(tmp, "pathbin"), "claude")
 	d := baseDetector("linux", tmp, func(name string) (string, error) {
 		if name == "claude" {
@@ -76,7 +94,7 @@ func TestDetect_FoundOnPath(t *testing.T) {
 // and reports source=well-known. Uses a REAL binary under ~/.local/bin removed
 // from $PATH (spec SC-001 / F-07).
 func TestDetect_WellKnownFallback(t *testing.T) {
-	home := t.TempDir()
+	home := evalTempDir(t)
 	want := writeExec(t, filepath.Join(home, ".local", "bin"), "codex")
 	d := baseDetector("linux", home, alwaysMiss)
 	got := d.detect("codex")
@@ -98,7 +116,7 @@ func TestDetect_PathWinsOverWellKnown(t *testing.T) {
 	// A well-known copy exists...
 	writeExec(t, filepath.Join(home, ".local", "bin"), "opencode")
 	// ...but $PATH resolves first.
-	pathBin := writeExec(t, filepath.Join(t.TempDir(), "pbin"), "opencode")
+	pathBin := writeExec(t, filepath.Join(evalTempDir(t), "pbin"), "opencode")
 	d := baseDetector("linux", home, func(name string) (string, error) {
 		if name == "opencode" {
 			return pathBin, nil
@@ -119,7 +137,7 @@ func TestDetect_SymlinkResolved(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("symlink semantics differ on Windows")
 	}
-	realDir := t.TempDir()
+	realDir := evalTempDir(t)
 	realBin := writeExec(t, realDir, "claude-real")
 	home := t.TempDir()
 	linkDir := filepath.Join(home, ".local", "bin")
@@ -176,7 +194,7 @@ func TestDetect_UnknownCLI(t *testing.T) {
 // TestDetect_HomeUnset: os.UserHomeDir failure falls back to the passwd home so
 // a binary in a passwd-home well-known dir is still found (FR-016 / SC-011).
 func TestDetect_HomeUnset(t *testing.T) {
-	passwdHome := t.TempDir()
+	passwdHome := evalTempDir(t)
 	want := writeExec(t, filepath.Join(passwdHome, ".local", "bin"), "opencode")
 	d := &detector{
 		lookPath:     alwaysMiss,
@@ -219,7 +237,7 @@ func TestDetect_HomeUnset_NoFallbackDoesNotError(t *testing.T) {
 // found via PATHEXT. Runs on Linux CI by forcing goos="windows" and pointing
 // APPDATA at a temp dir (spec is table-driven so Windows cases run cross-OS).
 func TestDetect_WindowsPathext(t *testing.T) {
-	appData := t.TempDir()
+	appData := evalTempDir(t)
 	npmDir := filepath.Join(appData, "npm")
 	want := writeExec(t, npmDir, "claude.cmd")
 	getenv := func(k string) string {

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -390,6 +390,15 @@ func TestStatus_CurrentProcess_NotOmnipusBinary(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("wmic-based name check behaves differently in test binary; skipping")
 	}
+	if runtime.GOOS == "darwin" {
+		// macOS has no /proc, so checkProcess's resolveExeName can't read the
+		// PID's name and conservatively assumes "ours" (daemon_unix.go — a
+		// deliberate fail-safe so we never fail to stop our own gateway on a
+		// name-read error). That makes the "non-omnipus PID is cleaned up"
+		// behavior asserted here Linux-specific; on macOS Status reports the
+		// live-but-unidentifiable PID as running by design.
+		t.Skip("checkProcess name-resolution is /proc-based (Linux only); macOS conservatively assumes 'ours'")
+	}
 
 	home := newHome(t)
 	writePIDFile(t, home, os.Getpid())

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -166,6 +166,7 @@ type services struct {
 	HealthServer     *health.Server
 	manualReloadChan chan struct{}
 	reloading        atomic.Bool
+	reloadTrigger    func() error
 	credStore        *credentials.Store
 	// toolStore owns the on-disk tool-result offload directory. Exposed here
 	// so RunContext can wire its retentionSweep into the nightly sweep loop.
@@ -846,23 +847,13 @@ func RunContextWithOptions(ctx context.Context, opts RunOptions) error {
 		registerSandboxHealthCheck(runningServices.HealthServer, sandboxResult)
 	}
 
-	// Setup manual reload channel for /reload endpoint
-	manualReloadChan := make(chan struct{}, 1)
-	runningServices.manualReloadChan = manualReloadChan
-	reloadTrigger := func() error {
-		if !runningServices.reloading.CompareAndSwap(false, true) {
-			return fmt.Errorf("reload already in progress")
-		}
-		select {
-		case manualReloadChan <- struct{}{}:
-			return nil
-		default:
-			// Should not happen, but reset flag if channel is full
-			runningServices.reloading.Store(false)
-			return fmt.Errorf("reload already queued")
-		}
-	}
-	runningServices.HealthServer.SetReloadFunc(reloadTrigger)
+	// The /reload trigger + manualReloadChan were wired inside
+	// setupAndStartServices BEFORE the listener went live (avoids the
+	// boot-ordering race where /reload could 503 "reload not configured").
+	// Reuse them here for the reload consumer loop, the agent loop, and the
+	// sysagent ReloadFunc — do NOT re-create them.
+	manualReloadChan := runningServices.manualReloadChan
+	reloadTrigger := runningServices.reloadTrigger
 	agentLoop.SetReloadFunc(reloadTrigger)
 
 	// Wire management tool dependencies into the agent loop (FR-001, FR-002).
@@ -1846,6 +1837,31 @@ func setupAndStartServices(
 	if err = runningServices.ChannelManager.WrapHTTPHandler(csrfMW); err != nil {
 		return nil, fmt.Errorf("wrapping HTTP handler with CSRF: %w", err)
 	}
+
+	// Wire the /reload trigger BEFORE StartAll launches the HTTP listener.
+	// Otherwise there is a boot-ordering window where /health already answers
+	// 200 (listener live) but HealthServer.reloadFunc is still nil, so a
+	// concurrent POST /reload returns 503 "reload not configured". The
+	// manualReloadChan is buffered (cap 1) and its consumer loop is started
+	// later by the caller — signaling before the consumer exists is safe. The
+	// caller reuses runningServices.reloadTrigger / .manualReloadChan (it does
+	// NOT re-create them). restartServices reuses this same HealthServer, so
+	// reloadFunc is never reset to nil after this point.
+	runningServices.manualReloadChan = make(chan struct{}, 1)
+	runningServices.reloadTrigger = func() error {
+		if !runningServices.reloading.CompareAndSwap(false, true) {
+			return fmt.Errorf("reload already in progress")
+		}
+		select {
+		case runningServices.manualReloadChan <- struct{}{}:
+			return nil
+		default:
+			// Should not happen, but reset flag if channel is full.
+			runningServices.reloading.Store(false)
+			return fmt.Errorf("reload already queued")
+		}
+	}
+	runningServices.HealthServer.SetReloadFunc(runningServices.reloadTrigger)
 
 	if err = runningServices.ChannelManager.StartAll(context.Background()); err != nil {
 		return nil, fmt.Errorf("error starting channels: %w", err)


### PR DESCRIPTION
## What

Clears the pre-existing failures on hotfix's **Go-triggered CI workflows** (E2E + cross-platform matrix). These only run on Go PRs, so they'd accumulated red unnoticed (frontend PRs skip them; hotfix has no branch protection). Surfaced by #480; none were caused by that PR. Three independent root causes — all fixed at the root, no deferrals:

### 1. E2E — all 5 shards failed at "Build gateway binary"
`pr.yml` (and `evals-nightly.yml`) ran `go build ./cmd/omnipus/` **without** `-tags goolm,stdjson`. `cmd/omnipus/main.go` is `//go:build stdjson`-gated as a deliberate fail-fast against tag-less builds → `function main is undeclared`. Added the canonical tags.

### 2. matrix (macos) — clidetect + daemon
- **clidetect**: `t.TempDir()` returns `/var/folders/...` on macOS, but `detect()` resolves symlinks to `/private/var/...`, so path assertions mismatched. Normalized expected paths with `filepath.EvalSymlinks` (no-op on Linux).
- **daemon**: `TestStatus_CurrentProcess_NotOmnipusBinary` asserts a non-omnipus PID is cleaned up, but `checkProcess` resolves the name via `/proc` (Linux only); macOS conservatively assumes "ours" by design. Skipped on darwin (matching the existing Windows skip).

### 3. matrix (arm64) — realgateway 503 flake — **fixed at the root in production**
`TestRealGW_*` intermittently hit `SeedCLIToken: POST /reload returned 503`. Root cause was a **boot-ordering race in `pkg/gateway`**: the `/reload` trigger was wired (`HealthServer.SetReloadFunc`) in `RunContextWithOptions` *after* `setupAndStartServices` returned — but that function already launched the HTTP listener via `StartAll`. So `/health` answered 200 while `reloadFunc` was still nil, and a `/reload` in that window returned 503.

**Fix:** build `manualReloadChan` + `reloadTrigger` and call `SetReloadFunc` **inside `setupAndStartServices`, immediately before `StartAll`** — before the listener accepts any connection. The caller reuses them; the channel is buffered so an early signal isn't lost; `restartServices` reuses the same HealthServer so `reloadFunc` is never re-niled. The race is eliminated, not masked — **no test-side retry**.

## Verification
- `golangci-lint run --build-tags=goolm,stdjson` (CGO_ENABLED=0) → **0 issues**.
- clidetect + daemon packages pass on Linux; gateway compiles clean.
- macOS / E2E / arm64 (incl. the realgateway race) verified by **this PR's CI** on the real platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)