### PR TITLE
fix(agent): re-wire memory audit logger + rate limiter on config reload

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -202,6 +202,18 @@ type AgentLoop struct {
 	// system tools are not registered (graceful degradation in tests without a store).
 	sysagentDeps *systools.Deps
 
+	// memoryRateLimiter is the shared MemoryRateLimiter (v0.2 #155 item 6),
+	// built once in NewAgentLoop and applied to every agent's remember/
+	// run_retrospective tools via wireMemoryRateLimiterOn. Stored here (rather
+	// than left a bare local, as it originally was) so ReloadProviderAndConfig
+	// can re-wire the SAME limiter instance onto the freshly-built registry on
+	// hot reload — constructing a new limiter on every reload would reset
+	// every agent's sliding-window rate-limit buckets on any unrelated config
+	// change. Like tier13Deps/sysagentDeps, this field is only ever written
+	// during NewAgentLoop (single-threaded) or ReloadProviderAndConfig, which
+	// the gateway serializes via its own reloadMu — no dedicated lock needed.
+	memoryRateLimiter *tools.MemoryRateLimiter
+
 	// contextBuilderRegistry is a broadcast channel for config-change
 	// invalidation (FR-061). REST config-write handlers call
 	// InvalidateAllContextBuilders so every agent's next turn rebuilds the
@@ -581,42 +593,13 @@ func NewAgentLoop(
 				},
 			})
 
-			// Wire audit logger into all agent tool registries.
-			for _, agentID := range registry.ListAgentIDs() {
-				if agent, ok := registry.GetAgent(agentID); ok {
-					agent.Tools.SetAuditLogger(auditLogger)
-					// Memory tools carry their own audit-logger reference for
-					// structured per-entry events (content_sha256 etc.).
-					// SetAuditLogger on the registry propagates via auditLoggerAware,
-					// but the explicit cast below documents the dependency clearly.
-					if t, ok := agent.Tools.Get("remember"); ok {
-						if rt, ok := t.(*tools.RememberTool); ok {
-							rt.SetAuditLogger(auditLogger)
-						} else {
-							// SF4: wrong type registered for "remember" — surface the
-							// registration-order bug so it doesn't silently skip audit wiring.
-							logger.WarnCF("agent",
-								"'remember' tool is not a *tools.RememberTool; audit wiring skipped",
-								map[string]any{
-									"agent_id":  agentID,
-									"tool_type": fmt.Sprintf("%T", t),
-								})
-						}
-					}
-					if t, ok := agent.Tools.Get("run_retrospective"); ok {
-						if rt, ok := t.(*tools.RetrospectiveTool); ok {
-							rt.SetAuditLogger(auditLogger)
-						} else {
-							logger.WarnCF("agent",
-								"'run_retrospective' tool is not a *tools.RetrospectiveTool; audit wiring skipped",
-								map[string]any{
-									"agent_id":  agentID,
-									"tool_type": fmt.Sprintf("%T", t),
-								})
-						}
-					}
-				}
-			}
+			// Wire audit logger into all agent tool registries. Factored out into
+			// wireMemoryAuditLoggerOn so ReloadProviderAndConfig can re-apply the
+			// same wiring against a freshly-built registry on hot reload (see that
+			// method's doc comment) — without this, every agent's remember/
+			// run_retrospective tools would silently lose audit logging (SEC-15)
+			// the first time config reloads.
+			al.wireMemoryAuditLoggerOn(registry, auditLogger)
 		}
 	}
 
@@ -770,16 +753,18 @@ func NewAgentLoop(
 	// to tune them and exposing knobs invites footguns. The constructor accepts
 	// a MemoryRateLimitConfig so a future config-backed override can be wired
 	// in without a structural change.
-	memRL := tools.NewMemoryRateLimiter(tools.MemoryRateLimitConfig{})
-	for _, agentID := range registry.ListAgentIDs() {
-		if agentInst, ok := registry.GetAgent(agentID); ok {
-			agentInst.Tools.SetMemoryRateLimiter(memRL)
-		}
-	}
+	//
+	// Stashed on al.memoryRateLimiter (not a bare local) so hot-reload
+	// (ReloadProviderAndConfig) can re-apply the SAME limiter instance onto
+	// the freshly-built registry via wireMemoryRateLimiterOn — constructing a
+	// new limiter on every reload would reset every agent's sliding-window
+	// buckets on any unrelated config change.
+	al.memoryRateLimiter = tools.NewMemoryRateLimiter(tools.MemoryRateLimitConfig{})
+	al.wireMemoryRateLimiterOn(registry, al.memoryRateLimiter)
 	logger.InfoCF("agent", "Memory write rate limiter initialized",
 		map[string]any{
-			"per_agent_per_minute":  memRL.PerAgentLimit(),
-			"per_caller_per_minute": memRL.PerCallerLimit(),
+			"per_agent_per_minute":  al.memoryRateLimiter.PerAgentLimit(),
+			"per_caller_per_minute": al.memoryRateLimiter.PerCallerLimit(),
 		})
 
 	// Register shared tools to all agents (now that al is created)
@@ -1320,6 +1305,74 @@ func (al *AgentLoop) wireTier13DepsLocked(registry *AgentRegistry, deps Tier13De
 		"egress_proxy_ready":        deps.EgressProxy != nil,
 		"workspace_shell_enabled":   resolveBoolWithDefault(cfg.Sandbox.Experimental.WorkspaceShellEnabled, false),
 	})
+}
+
+// wireMemoryAuditLoggerOn wires auditLogger into every agent's tool registry
+// in registry (SEC-15), including the direct RememberTool/RetrospectiveTool
+// cast so memory tools can emit their own structured per-entry audit events
+// (content_sha256 etc.). Factored out of NewAgentLoop's boot-time wiring so
+// ReloadProviderAndConfig can re-apply the identical wiring against a
+// freshly-built registry on hot reload — without this, NewAgentRegistry's
+// brand-new RememberTool/RetrospectiveTool instances would silently lose
+// audit logging the first time config reloads (e.g. onboarding completion,
+// any agent PUT, token rotation — every TriggerReload call site).
+func (al *AgentLoop) wireMemoryAuditLoggerOn(registry *AgentRegistry, auditLogger *audit.Logger) {
+	if registry == nil || auditLogger == nil {
+		return
+	}
+	for _, agentID := range registry.ListAgentIDs() {
+		if agent, ok := registry.GetAgent(agentID); ok {
+			agent.Tools.SetAuditLogger(auditLogger)
+			// Memory tools carry their own audit-logger reference for
+			// structured per-entry events (content_sha256 etc.).
+			// SetAuditLogger on the registry propagates via auditLoggerAware,
+			// but the explicit cast below documents the dependency clearly.
+			if t, ok := agent.Tools.Get("remember"); ok {
+				if rt, ok := t.(*tools.RememberTool); ok {
+					rt.SetAuditLogger(auditLogger)
+				} else {
+					// SF4: wrong type registered for "remember" — surface the
+					// registration-order bug so it doesn't silently skip audit wiring.
+					logger.WarnCF("agent",
+						"'remember' tool is not a *tools.RememberTool; audit wiring skipped",
+						map[string]any{
+							"agent_id":  agentID,
+							"tool_type": fmt.Sprintf("%T", t),
+						})
+				}
+			}
+			if t, ok := agent.Tools.Get("run_retrospective"); ok {
+				if rt, ok := t.(*tools.RetrospectiveTool); ok {
+					rt.SetAuditLogger(auditLogger)
+				} else {
+					logger.WarnCF("agent",
+						"'run_retrospective' tool is not a *tools.RetrospectiveTool; audit wiring skipped",
+						map[string]any{
+							"agent_id":  agentID,
+							"tool_type": fmt.Sprintf("%T", t),
+						})
+				}
+			}
+		}
+	}
+}
+
+// wireMemoryRateLimiterOn propagates the shared MemoryRateLimiter (v0.2 #155
+// item 6) onto every agent's tool registry in registry. Factored out of
+// NewAgentLoop's boot-time wiring so ReloadProviderAndConfig can re-apply the
+// SAME limiter instance against a freshly-built registry on hot reload —
+// see the al.memoryRateLimiter field comment for why the limiter itself must
+// never be reconstructed here (that would reset every agent's sliding-window
+// rate-limit buckets on any unrelated config change).
+func (al *AgentLoop) wireMemoryRateLimiterOn(registry *AgentRegistry, limiter *tools.MemoryRateLimiter) {
+	if registry == nil || limiter == nil {
+		return
+	}
+	for _, agentID := range registry.ListAgentIDs() {
+		if agentInst, ok := registry.GetAgent(agentID); ok {
+			agentInst.Tools.SetMemoryRateLimiter(limiter)
+		}
+	}
 }
 
 // resolveBoolWithDefault returns the bool value from a *bool, falling back to
@@ -3214,6 +3267,27 @@ func (al *AgentLoop) ReloadProviderAndConfig(
 	// Re-wire system.* tools on the new registry (FR-001, FR-002).
 	if al.sysagentDeps != nil {
 		al.wireSysagentDepsLocked(registry, al.sysagentDeps)
+	}
+
+	// Re-wire the audit logger onto remember/run_retrospective tools on the
+	// new registry (SEC-15). Without this, hot reload would silently drop
+	// memory-tool audit logging: NewAgentRegistry above built brand-new
+	// RememberTool/RetrospectiveTool instances that never learned about
+	// al.auditLogger. Mirrors the boot-time guard (cfg.Sandbox.AuditLog) —
+	// al.auditLogger is only non-nil when audit logging was actually enabled.
+	if al.auditLogger != nil {
+		al.wireMemoryAuditLoggerOn(registry, al.auditLogger)
+	}
+
+	// Re-wire the shared memory-write rate limiter (v0.2 #155 item 6) onto
+	// the new registry, re-applying the SAME instance built once in
+	// NewAgentLoop — never a freshly constructed one, so per-agent/per-caller
+	// sliding-window buckets survive config reloads. al.memoryRateLimiter is
+	// unconditionally constructed in NewAgentLoop today, so this is always
+	// non-nil in practice; the guard is defensive symmetry with the other
+	// re-wiring steps above in case that ever becomes conditional.
+	if al.memoryRateLimiter != nil {
+		al.wireMemoryRateLimiterOn(registry, al.memoryRateLimiter)
 	}
 
 	// Re-wire per-turn delegation injectors on the new registry so that the

--- a/pkg/agent/memory_reload_wiring_test.go
+++ b/pkg/agent/memory_reload_wiring_test.go
@@ -1,0 +1,199 @@
+// Omnipus - Ultra-lightweight personal AI agent
+// License: MIT
+//
+// Copyright (c) 2026 Omnipus contributors
+
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapicom-ai/omnipus/pkg/bus"
+	"github.com/dapicom-ai/omnipus/pkg/config"
+	"github.com/dapicom-ai/omnipus/pkg/coreagent"
+	"github.com/dapicom-ai/omnipus/pkg/tools"
+)
+
+// ---------------------------------------------------------------------------
+// Regression tests for the memory-tool reload-wiring gap.
+//
+// Before the fix, NewAgentLoop wired the audit logger and a shared
+// MemoryRateLimiter onto every agent's remember/run_retrospective tools at
+// boot, but ReloadProviderAndConfig (called by ~10 REST endpoints, including
+// onboarding completion) rebuilds the registry via NewAgentRegistry — which
+// constructs brand-new RememberTool/RetrospectiveTool instances that never
+// learned about either dependency. The rate limiter was additionally a bare
+// local variable (memRL), never stored on *AgentLoop, so there was no way to
+// even re-attach "the same limiter" later.
+//
+// These tests exercise the real ReloadProviderAndConfig path (not a unit
+// stub) and assert the POST-RELOAD tool instances functionally behave as if
+// wired — reading unexported AgentLoop/tool-registry state is not enough,
+// since the bug was precisely that the registry-level field could be
+// populated while the individual tool instances were not.
+// ---------------------------------------------------------------------------
+
+// memReloadTestLoop builds a real AgentLoop with audit logging enabled and the
+// core agent roster seeded (ava, mia, jim, ray), rooted at a fresh OMNIPUS_HOME
+// so agent workspaces and the audit log resolve under a hermetic temp dir.
+// Returns the loop and the path audit.jsonl will be written to.
+func memReloadTestLoop(t *testing.T) (*AgentLoop, string) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("OMNIPUS_HOME", home)
+
+	cfg := config.DefaultConfig()
+	coreagent.SeedConfig(cfg)
+	cfg.Agents.Defaults.ModelName = "test-model"
+	cfg.Agents.Defaults.MaxTokens = 4096
+	cfg.Sandbox.AuditLog = true
+
+	msgBus := bus.NewMessageBus()
+	t.Cleanup(func() { msgBus.Close() })
+	al, err := NewAgentLoop(cfg, msgBus, &mockProvider{})
+	require.NoError(t, err)
+	t.Cleanup(func() { al.Close() })
+
+	auditPath := filepath.Join(home, "system", "audit.jsonl")
+	return al, auditPath
+}
+
+// reloadWithSameAgents drives ReloadProviderAndConfig with a fresh Config
+// carrying the same Agents.Defaults/List/Sandbox.AuditLog as the live config —
+// the same shape a real REST handler builds via safeUpdateConfigJSON before
+// calling TriggerReload. A fresh *config.Config is built (not a struct copy of
+// al.cfg, which holds a sync.RWMutex) per the established test pattern in
+// global_policy_hot_update_test.go.
+func reloadWithSameAgents(t *testing.T, al *AgentLoop) {
+	t.Helper()
+	liveCfg := al.GetConfig()
+	newCfg := &config.Config{}
+	newCfg.Agents.Defaults = liveCfg.Agents.Defaults
+	newCfg.Agents.List = make([]config.AgentConfig, len(liveCfg.Agents.List))
+	copy(newCfg.Agents.List, liveCfg.Agents.List)
+	newCfg.Sandbox.AuditLog = liveCfg.Sandbox.AuditLog
+	require.NoError(t, al.ReloadProviderAndConfig(context.Background(), &mockProvider{}, newCfg),
+		"ReloadProviderAndConfig must succeed")
+}
+
+// readAuditEvents reads and parses audit.jsonl, tolerating a not-yet-created
+// file (no writes yet).
+func readAuditEvents(t *testing.T, path string) []map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		t.Fatalf("read audit log %s: %v", path, err)
+	}
+	var out []map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		if line == "" {
+			continue
+		}
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal([]byte(line), &parsed), "audit line must be valid JSON: %s", line)
+		out = append(out, parsed)
+	}
+	return out
+}
+
+// TestReloadWiring_MemoryAuditLogger_PersistsAcrossReload proves the audit-
+// logger half of the fix: after ReloadProviderAndConfig rebuilds the registry,
+// the fresh RememberTool instance for a live agent must still emit its
+// structured "memory.remember" audit event (SEC-15) — i.e. it was not left
+// with a nil audit logger.
+func TestReloadWiring_MemoryAuditLogger_PersistsAcrossReload(t *testing.T) {
+	al, auditPath := memReloadTestLoop(t)
+	require.NotNil(t, al.auditLogger,
+		"audit logging was enabled via cfg.Sandbox.AuditLog; al.auditLogger must be set at boot")
+
+	reloadWithSameAgents(t, al)
+
+	// al.auditLogger itself is never reassigned by ReloadProviderAndConfig
+	// (only the registry is rebuilt) — that is exactly the trap the original
+	// bug exploited: the AgentLoop-level field stays populated while the
+	// freshly-constructed RememberTool instance never received it. Prove the
+	// wiring functionally rather than just checking the field.
+	const agentID = "mia"
+	inst, ok := al.GetRegistry().GetAgent(agentID)
+	require.True(t, ok, "agent %q must exist in the post-reload registry", agentID)
+
+	ctx := tools.WithAgentID(context.Background(), agentID)
+	result := inst.Tools.ExecuteWithContext(ctx, "remember", map[string]any{
+		"content":  "reload wiring regression check",
+		"category": "reference",
+	}, "", "", nil)
+	require.False(t, result.IsError, "remember call must succeed: %+v", result)
+
+	events := readAuditEvents(t, auditPath)
+	found := false
+	for _, e := range events {
+		if e["event"] == "memory.remember" && e["agent_id"] == agentID {
+			found = true
+			break
+		}
+	}
+	require.True(t, found,
+		"expected a memory.remember audit entry for agent %q after reload; its absence means the "+
+			"post-reload RememberTool instance has a nil audit logger (the reload-wiring gap)", agentID)
+}
+
+// TestReloadWiring_MemoryRateLimiter_SameInstancePersistsAcrossReload proves
+// the rate-limiter half of the fix: the shared MemoryRateLimiter built once in
+// NewAgentLoop must be the SAME instance re-wired onto the fresh registry on
+// every reload — not reconstructed (which would reset every agent's
+// sliding-window budget on any unrelated config change) and not dropped
+// entirely (which would silently disable the SEC #155 item 6 rate limiter,
+// as it did before this fix, since memRL was a bare local never stored on
+// *AgentLoop).
+func TestReloadWiring_MemoryRateLimiter_SameInstancePersistsAcrossReload(t *testing.T) {
+	al, _ := memReloadTestLoop(t)
+
+	limiterBefore := al.memoryRateLimiter
+	require.NotNil(t, limiterBefore, "NewAgentLoop must construct a shared memory rate limiter")
+
+	const agentID = "ava"
+	// Exhaust the per-agent budget directly against the limiter object that
+	// is (or should be) wired onto ava's remember tool. "<local>" mirrors the
+	// caller identity callerIdentity(ctx) derives when no channel/chatID is
+	// set (empty channel + empty chatID -> "<local>"), matching the
+	// ExecuteWithContext(ctx, ..., "", "", nil) call below.
+	for i := 0; i < limiterBefore.PerAgentLimit(); i++ {
+		decision := limiterBefore.Allow(agentID, "<local>")
+		require.True(t, decision.Allowed, "pre-exhaustion call %d should be allowed", i)
+	}
+	sanity := limiterBefore.Allow(agentID, "<local>")
+	require.False(t, sanity.Allowed, "sanity check: the per-agent budget must be exhausted before reload")
+
+	reloadWithSameAgents(t, al)
+
+	limiterAfter := al.memoryRateLimiter
+	require.Same(t, limiterBefore, limiterAfter,
+		"the SAME MemoryRateLimiter instance must persist across reload, not be reconstructed "+
+			"(a fresh limiter would silently reset every agent's rate-limit budget on any unrelated "+
+			"config change)")
+
+	inst, ok := al.GetRegistry().GetAgent(agentID)
+	require.True(t, ok, "agent %q must exist in the post-reload registry", agentID)
+
+	ctx := tools.WithAgentID(context.Background(), agentID)
+	result := inst.Tools.ExecuteWithContext(ctx, "remember", map[string]any{
+		"content":  "should be rate limited",
+		"category": "reference",
+	}, "", "", nil)
+
+	require.True(t, result.IsError,
+		"post-reload remember call for the exhausted agent must be rate-limited; if it succeeds, the "+
+			"post-reload RememberTool instance is either missing the rate limiter entirely (nil) or was "+
+			"wired to a freshly-constructed one whose budget was never exhausted")
+	require.Contains(t, result.ForLLM, "rate limit", "error message must indicate a rate-limit rejection")
+}

--- a/pkg/tools/registry.go
+++ b/pkg/tools/registry.go
@@ -590,9 +590,10 @@ func (r *ToolRegistry) Clone() *ToolRegistry {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	clone := &ToolRegistry{
-		tools:       make(map[string]*ToolEntry, len(r.tools)),
-		mediaStore:  r.mediaStore,
-		auditLogger: r.auditLogger,
+		tools:             make(map[string]*ToolEntry, len(r.tools)),
+		mediaStore:        r.mediaStore,
+		auditLogger:       r.auditLogger,
+		memoryRateLimiter: r.memoryRateLimiter,
 	}
 	for name, entry := range r.tools {
 		clone.tools[name] = cloneEntry(entry)
@@ -652,9 +653,10 @@ func (r *ToolRegistry) CloneExcept(tools ...ExcludedTool) *ToolRegistry {
 		}
 	}
 	clone := &ToolRegistry{
-		tools:       make(map[string]*ToolEntry, len(r.tools)),
-		mediaStore:  r.mediaStore,
-		auditLogger: r.auditLogger,
+		tools:             make(map[string]*ToolEntry, len(r.tools)),
+		mediaStore:        r.mediaStore,
+		auditLogger:       r.auditLogger,
+		memoryRateLimiter: r.memoryRateLimiter,
 	}
 	for name, entry := range r.tools {
 		if _, skip := excluded[name]; skip {

--- a/pkg/tools/registry_audit_test.go
+++ b/pkg/tools/registry_audit_test.go
@@ -120,3 +120,75 @@ func TestToolRegistry_AuditLogging(t *testing.T) {
 		assert.NotNil(t, clone.auditLogger, "cloned registry should retain audit logger")
 	})
 }
+
+// mockMemoryRateLimiterAwareTool is a minimal tool implementing
+// memoryRateLimiterAware, used to prove that Clone/CloneExcept propagate the
+// registry's memoryRateLimiter field to tools registered AFTER cloning (the
+// path a delegate sub-turn registry exercises when it registers a fresh
+// RememberTool/RetrospectiveTool for the child turn).
+type mockMemoryRateLimiterAwareTool struct {
+	mockRegistryTool
+	limiter *MemoryRateLimiter
+}
+
+func (m *mockMemoryRateLimiterAwareTool) SetMemoryRateLimiter(limiter *MemoryRateLimiter) {
+	m.limiter = limiter
+}
+
+// TestToolRegistry_CloneAndCloneExcept_PropagateMemoryRateLimiter is the
+// regression test for the Clone()/CloneExcept() memoryRateLimiter gap: both
+// methods copied mediaStore and auditLogger onto the cloned registry but
+// omitted memoryRateLimiter, so any subagent-delegated remember/
+// run_retrospective call (via the delegate tool's sub-turn tool registry)
+// silently bypassed the v0.2 #155 item 6 memory-write rate limiter.
+func TestToolRegistry_CloneAndCloneExcept_PropagateMemoryRateLimiter(t *testing.T) {
+	limiter := NewMemoryRateLimiter(MemoryRateLimitConfig{})
+
+	t.Run("Clone propagates memoryRateLimiter", func(t *testing.T) {
+		reg := NewToolRegistry()
+		reg.SetMemoryRateLimiter(limiter)
+		reg.Register(&mockRegistryTool{
+			name:   "pre_clone_tool",
+			desc:   "registered before cloning",
+			params: map[string]any{"type": "object", "properties": map[string]any{}},
+			result: &ToolResult{ForLLM: "ok", ForUser: "ok"},
+		})
+
+		clone := reg.Clone()
+		require.Same(t, limiter, clone.memoryRateLimiter,
+			"cloned registry must retain the SAME memoryRateLimiter instance")
+
+		// Functional proof: a tool registered on the CLONE after cloning must
+		// pick up the limiter via registerToolLocked's memoryRateLimiterAware
+		// propagation — this is the exact path a delegate sub-turn registry
+		// exercises when it registers a fresh RememberTool for the child turn.
+		post := &mockMemoryRateLimiterAwareTool{
+			mockRegistryTool: mockRegistryTool{name: "post_clone_tool", desc: "registered after cloning"},
+		}
+		clone.Register(post)
+		assert.Same(t, limiter, post.limiter,
+			"a tool registered on the clone after cloning must receive the propagated limiter")
+	})
+
+	t.Run("CloneExcept propagates memoryRateLimiter", func(t *testing.T) {
+		reg := NewToolRegistry()
+		reg.SetMemoryRateLimiter(limiter)
+		reg.Register(&mockRegistryTool{
+			name:   "spawn",
+			desc:   "excluded from the clone",
+			params: map[string]any{"type": "object", "properties": map[string]any{}},
+			result: &ToolResult{ForLLM: "ok", ForUser: "ok"},
+		})
+
+		clone := reg.CloneExcept(ExcludedSpawn)
+		require.Same(t, limiter, clone.memoryRateLimiter,
+			"CloneExcept must retain the SAME memoryRateLimiter instance for the same reason as Clone")
+
+		post := &mockMemoryRateLimiterAwareTool{
+			mockRegistryTool: mockRegistryTool{name: "post_cloneexcept_tool", desc: "registered after cloning"},
+		}
+		clone.Register(post)
+		assert.Same(t, limiter, post.limiter,
+			"a tool registered on the CloneExcept clone after cloning must receive the propagated limiter")
+	})
+}


### PR DESCRIPTION
## Summary

`NewAgentLoop` wires an audit logger and a shared `MemoryRateLimiter` onto every agent's `remember`/`run_retrospective` tools at boot, but `ReloadProviderAndConfig` (called by ~10 REST endpoints, including onboarding completion) rebuilds the whole registry via `NewAgentRegistry` — constructing brand-new `RememberTool`/`RetrospectiveTool` instances that never learn about either dependency. The rate limiter was additionally a bare local variable, never stored on `*AgentLoop`, so there was no way to even re-attach "the same limiter" on a later reload.

**Net effect:** the first time any reload-triggering endpoint fires — which onboarding does unconditionally, on every install — every agent's memory tools silently lose both SEC-15 audit logging and the SEC #155 item 6 memory-write rate limiter, for the rest of the gateway process's life.

Found while investigating an e2e flake (`memory-remember-recall.spec.ts`) on an unrelated branch; confirmed via live pointer-level instrumentation that the `RememberTool.Execute` actually running post-reload used a different pointer than the boot-wired one, with both dependencies nil.

## Fix

Follows this file's own established re-wiring pattern (`tier13Deps`/`sysagentDeps`/delegation injectors already do exactly this for their own dependencies):

- Promote the rate limiter to a persistent `al.memoryRateLimiter` field (previously a bare local `memRL`), so the same instance — not a fresh one — survives across reloads. Reconstructing it on every reload would reset every agent's sliding-window budget on any unrelated config change.
- Extract the audit-logger and rate-limiter wiring loops out of `NewAgentLoop` into `wireMemoryAuditLoggerOn` / `wireMemoryRateLimiterOn`, called from both `NewAgentLoop` (boot) and `ReloadProviderAndConfig` (hot reload) — one implementation of each loop, not two.
- Also fixes a related gap in `pkg/tools/registry.go`: `Clone()`/`CloneExcept()` (used to build delegated-subagent tool registries) copied `mediaStore`/`auditLogger` but omitted `memoryRateLimiter` — so any subagent-delegated `remember`/`run_retrospective` call silently bypassed rate limiting too.

## Testing

Regression tests exercise the real `ReloadProviderAndConfig` path end-to-end (not unit stubs on unexported fields):
- `TestReloadWiring_MemoryAuditLogger_PersistsAcrossReload` — proves a post-reload `remember` call still emits its `memory.remember` audit entry.
- `TestReloadWiring_MemoryRateLimiter_SameInstancePersistsAcrossReload` — exhausts the per-agent rate-limit budget, reloads, and proves the post-reload instance is still rate-limited by the SAME limiter object (`require.Same`).
- `TestToolRegistry_CloneAndCloneExcept_PropagateMemoryRateLimiter` — covers `Clone()`/`CloneExcept()` propagating `memoryRateLimiter`.

All three verified to fail against pre-fix code, pass against the fix.

`gofmt`/`go build`/`go vet`/`golangci-lint` (0 issues) clean. Scoped `pkg/agent`/`pkg/tools` suites green.

## Merge

Per this repo's standing rule, not to be merged without explicit human review and approval — reporting ready for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)