### PR TITLE
fix(agent): auto-approve external-CLI tool calls, tell agents their real working directory

### DIFF
--- a/pkg/agent/context.go
+++ b/pkg/agent/context.go
@@ -76,6 +76,32 @@ type ContextBuilder struct {
 	// wireDelegationInjectors in loop_env.go.
 	delegationInjector func(workspaceID string) string
 
+	// workingDirInjector is an optional per-turn callback that renders a
+	// "## Working Directory" block telling the agent where its file tools
+	// actually operate. Like delegationInjector it runs in buildDynamicContext
+	// (the UN-CACHED path) because CoreTeam membership — and therefore the
+	// agent's re-rooted working directory (pkg/agent/loop.go's filesystem
+	// re-rooting block) — can change at runtime.
+	//
+	// Without this, an agent whose file tools are silently re-rooted to a
+	// Workspace's shared workspaces/<id>/work/ directory has no way to know
+	// it: it will assume its traditional private agents/<id>/ directory,
+	// guess wrong absolute paths, and can report a false file location to the
+	// user (observed: an agent told the user its report was saved under
+	// agents/<id>/ when the file was actually — correctly — written to the
+	// workspace's shared directory). Set via WithWorkingDirInjector; wired by
+	// wireWorkingDirInjectors in loop_env.go.
+	//
+	// The workspaceID argument mirrors delegationInjector's: the turn's
+	// effective workspace (ts.opts.WorkspaceID), threaded through so an agent
+	// that belongs to more than one workspace's CoreTeam is told about the
+	// CURRENT session's workspace, not an arbitrary one — see
+	// workspace.FindForAgentPreferring, which this injector must use (the
+	// SAME resolution steps pkg/agent/loop.go's re-rooting block uses,
+	// including the MkdirAll fallback) so the advertised directory matches
+	// the one actually applied.
+	workingDirInjector func(workspaceID string) string
+
 	// env carries the environment provider + any per-builder env state. Split
 	// into a nested struct so context_env.go owns the mutation surface without
 	// touching the core ContextBuilder definition.
@@ -97,6 +123,16 @@ func (cb *ContextBuilder) WithResourcesInjector(fn func() string) *ContextBuilde
 // block (no delegation section is appended).
 func (cb *ContextBuilder) WithDelegationInjector(fn func(workspaceID string) string) *ContextBuilder {
 	cb.delegationInjector = fn
+	return cb
+}
+
+// WithWorkingDirInjector installs the per-turn working-directory context
+// callback. fn receives the turn's effective workspaceID (ts.opts.WorkspaceID,
+// may be "") and is called on every turn from buildDynamicContext (the
+// UN-CACHED path), returning the "## Working Directory" block text (or "" to
+// omit it). Passing nil disables the block.
+func (cb *ContextBuilder) WithWorkingDirInjector(fn func(workspaceID string) string) *ContextBuilder {
+	cb.workingDirInjector = fn
 	return cb
 }
 
@@ -740,6 +776,15 @@ func (cb *ContextBuilder) buildDynamicContext(workspaceID, channel, chatID, send
 	// enforcement gate resolves, so advertisement == enforcement by construction.
 	if cb.delegationInjector != nil {
 		if block := cb.delegationInjector(workspaceID); block != "" {
+			fmt.Fprintf(&sb, "\n\n%s", block)
+		}
+	}
+
+	// Working-directory block: injected per-turn for the same freshness reason
+	// as the delegation block above — CoreTeam membership (and therefore the
+	// re-rooted working directory) can change at runtime.
+	if cb.workingDirInjector != nil {
+		if block := cb.workingDirInjector(workspaceID); block != "" {
 			fmt.Fprintf(&sb, "\n\n%s", block)
 		}
 	}

--- a/pkg/agent/external_dispatch.go
+++ b/pkg/agent/external_dispatch.go
@@ -17,10 +17,11 @@
 //  2. NewDriver — instantiate the claude-code / codex / opencode driver.
 //  3. Run — drive the CLI with the delegated input + a per-run timeout and turn
 //     cap derived from sub-turn config, with the delegate's own model auto-set.
-//  4. Stream events through ConsentDispatcher: permission-requests route to the
-//     Omnipus consent layer (best-effort post-hoc — a DENY cancels the run); all
-//     events (output/tool-call/diff/error) are written to the sub-agent session
-//     transcript so the SPA renders the run inline.
+//  4. Stream events through ConsentDispatcher: permission-requests are
+//     auto-approved unconditionally (operator decision, 2026-07-05, issue
+//     #488 — see policyApproverConsent's own doc for why); all events
+//     (output/tool-call/diff/error/permission-request) are written to the
+//     sub-agent session transcript so the SPA renders the run inline.
 //
 // No teardown step: the workspace directory is the agent's persistent working
 // tree, not a scratch dir — it is left in place after the run.
@@ -149,16 +150,25 @@ func runExternalCLISubTurn(
 	//    write_file/edit_file confined there could reach either. The work/
 	//    subdirectory keeps them structurally unreachable — os.Root-confined
 	//    tools cannot open a path outside their root, not merely guarded
-	//    against. workspace.FindForAgent keys off agent IDENTITY (CoreTeam
-	//    membership), which is a different, independent signal from the
-	//    channel-bound turn workspace_id that tools.WithWorkspaceID routes
-	//    memory to — see pkg/agent/loop.go's runTurn for the mirrored
-	//    resolution and the divergence discussion. An agent not on any
-	//    workspace's CoreTeam (or an id that fails the traversal guard) is NOT
-	//    an error: it falls back to the agent's own workspace directory exactly
-	//    as before this override existed.
+	//    against. workspace.FindForAgentPreferring keys PRIMARILY off agent
+	//    IDENTITY (CoreTeam membership), which is a different, independent
+	//    signal from the channel-bound turn workspace_id that
+	//    tools.WithWorkspaceID routes memory to — see pkg/agent/loop.go's
+	//    runTurn for the mirrored resolution and the divergence discussion.
+	//    An agent not on any workspace's CoreTeam (or an id that fails the
+	//    traversal guard) is NOT an error: it falls back to the agent's own
+	//    workspace directory exactly as before this override existed.
+	//    FindForAgentPreferring additionally breaks a multi-membership tie in
+	//    favor of childTS.opts.WorkspaceID (the current turn's own
+	//    channel-bound workspace) when the agent is actually a member of that
+	//    specific workspace — in practice this is almost always empty here,
+	//    since subagent_3p is delegation-only and spawnSubTurn never threads
+	//    a workspace_id into a child's processOptions, so this falls straight
+	//    through to FindForAgent's existing behavior; kept for symmetry with
+	//    the native path (pkg/agent/loop.go's runTurn) and in case that
+	//    assumption changes.
 	workDir := strings.TrimSpace(agent.Workspace)
-	if wsID, found := workspace.FindForAgent(omnipusHome(), agent.ID); found {
+	if wsID, found := workspace.FindForAgentPreferring(omnipusHome(), agent.ID, childTS.opts.WorkspaceID); found {
 		if wsDir, wsErr := workspace.SafeWorkDir(omnipusHome(), wsID); wsErr != nil {
 			slog.Warn(
 				"external-cli dispatch: workspace-team dir resolution failed; falling back to agent's own workspace",
@@ -192,13 +202,13 @@ func runExternalCLISubTurn(
 	releaseWorkspaceLock := acquireWorkspaceRunLock(workDir)
 	defer releaseWorkspaceLock()
 
-	// 2. Build the consent handler (wraps the gateway PolicyApprover; deny-by-default
-	//    when no approver is wired — loadToolApprover returns the fail-closed nop).
+	// 2. Build the consent handler. External-CLI permission requests are
+	//    auto-approved unconditionally (issue #488) — see policyApproverConsent's
+	//    type doc for why this is a deliberately different posture from native
+	//    ask-policy tools.
 	consent := &policyApproverConsent{
-		al:        al,
-		agentID:   childTS.agentID,
-		sessionID: childTS.transcriptSessionID,
-		turnID:    childTS.turnID,
+		agentID: childTS.agentID,
+		runID:   runID,
 	}
 
 	// 3. Instantiate the driver for the configured CLI. The factory is a package
@@ -295,7 +305,7 @@ func runExternalCLISubTurn(
 		runner.ConsentDispatcher(runCtx, evCh, driver, runID, childTS.transcriptSessionID, consent, out)
 	}()
 
-	result := drainExternalRun(runCtx, childTS, runID, cli, out, consent)
+	result := drainExternalRun(runCtx, childTS, runID, cli, out)
 	return result, result.Err
 }
 
@@ -303,18 +313,15 @@ func runExternalCLISubTurn(
 // sub-agent session transcript, and aggregates the run's textual output into a
 // tools.ToolResult. It returns when the stream closes (run end/error) or ctx ends.
 //
-// consent carries the post-hoc consent state. A DENY decision cancels the run
-// (the driver kills the process and suppresses its own ctx-cancel error), so the
-// stream can close with runErr==nil and ended==false. Without consulting the
-// consent state we would mis-report that path as success. We therefore treat a
-// recorded denial as a terminal failure: the delegating agent MUST be told the
-// sub-run was aborted, not that it completed (review finding [MAJOR]).
+// External-CLI permission requests are auto-approved unconditionally (issue
+// #488, see policyApproverConsent), so there is no longer a per-run deny path
+// to consult here — a run only ends in failure via a fatal EventKindError or
+// the run context ending.
 func drainExternalRun(
 	ctx context.Context,
 	childTS *turnState,
 	runID, cli string,
 	out <-chan runner.RunEvent,
-	consent *policyApproverConsent,
 ) *tools.ToolResult {
 	var sb strings.Builder
 	var runErr error
@@ -403,43 +410,14 @@ done:
 		childTS.appendAssistantTranscript(output, transcriptModelFor(childTS.agent))
 	}
 
-	// A recorded consent DENY is terminal: the driver cancels the run (and
-	// suppresses its own runCtx-cancel error), so we would otherwise see
-	// runErr==nil, ended==false and wrongly report success. Surface the denial
-	// as the run's outcome so the delegating agent learns the sub-run was aborted.
-	denied, denyReason := consent.lastDeny()
-
 	slog.Info("external-cli dispatch: run finished",
-		"run_id", runID, "cli", cli, "ended", ended, "denied", denied,
+		"run_id", runID, "cli", cli, "ended", ended,
 		"err", runErr, "output_len", len(output))
 
 	if runErr != nil {
 		return &tools.ToolResult{
 			Err:    runErr,
 			ForLLM: fmt.Sprintf("External CLI run (%s) failed: %v", cli, runErr),
-		}
-	}
-
-	if denied {
-		// The run did not complete on its own (a successful EventKindEnd was never
-		// followed by a denial in practice — the deny cancels before/at the kill),
-		// so treat any recorded denial as an aborted run regardless of `ended`.
-		reason := strings.TrimSpace(denyReason)
-		if reason == "" {
-			reason = "permission denied"
-		}
-		denyErr := fmt.Errorf("external-cli run denied: %s", reason)
-		msg := fmt.Sprintf(
-			"External CLI run (%s) was DENIED and aborted (a permission request was rejected: %s). "+
-				"The delegated task did NOT complete.", cli, reason)
-		childTS.appendIntermediateAssistantTranscript(
-			"[external-cli denied] "+reason,
-			transcriptModelFor(childTS.agent),
-		)
-		return &tools.ToolResult{
-			Err:     denyErr,
-			ForLLM:  msg,
-			ForUser: msg,
 		}
 	}
 
@@ -678,58 +656,36 @@ var newExternalDriver = func(cli string, consent runner.ConsentHandler) (runner.
 	return runner.NewDriver(cli, consent)
 }
 
-// policyApproverConsent adapts the gateway-wired PolicyApprover (al.loadToolApprover)
-// to the runner.ConsentHandler interface so external-CLI permission requests flow
-// through the same human-in-the-loop approval path as native ask-policy tools.
+// policyApproverConsent implements runner.ConsentHandler for external-CLI
+// (subagent_3p) permission requests.
 //
-// Deny-by-default: loadToolApprover never returns nil — when no approver is wired it
-// returns the fail-closed nopPolicyApprover, which denies every request. So a request
-// reaching here without a gateway approver is denied, satisfying FR-5.1.
+// AUTO-APPROVE, unconditional (operator decision, 2026-07-05, issue #488):
+// this deliberately does NOT route through the gateway-wired PolicyApprover /
+// human-in-the-loop WS approval modal that native ask-policy tools use
+// (pkg/agent/loop.go's CheckGrantOrRequestApproval) — that path is untouched
+// and still gates native agents exactly as before. External-CLI requests are
+// different in kind, not just posture: consent.go's own package doc
+// establishes that by the time a PermissionRequestEvent reaches Omnipus, the
+// CLI has already started (or finished) the tool call — an ALLOW is a no-op
+// and a DENY can only kill the whole run after the fact, never veto the call.
+// Blocking on a human "Approve" click therefore added pure friction with zero
+// preventive value, which is exactly the complaint that led to this change
+// ("the agent must just run without any popup modal"). The run can still be
+// stopped via the ordinary turn-cancellation control; there is no longer a
+// per-tool-call deny path for external-CLI runs specifically.
 type policyApproverConsent struct {
-	al        *AgentLoop
-	agentID   string
-	sessionID string
-	turnID    string
-
-	// mu guards the deny-tracking fields. RequestConsent runs on the consent
-	// dispatcher goroutine while drainExternalRun reads via lastDeny() on the
-	// dispatch goroutine, so the access must be synchronized.
-	mu         sync.Mutex
-	denied     bool
-	denyReason string
+	agentID string
+	runID   string
 }
 
-// RequestConsent routes an external-runner permission request to the policy approver
-// and returns its verdict. Implements runner.ConsentHandler.
-//
-// A DENY is recorded so the dispatch path can surface the run as aborted: a denial
-// cancels the run (the driver kills the process and suppresses its ctx-cancel
-// error), which would otherwise look like a clean, no-output success.
-func (c *policyApproverConsent) RequestConsent(ctx context.Context, req runner.ConsentRequest) (bool, string) {
-	approver := c.al.loadToolApprover()
-	approved, reason := approver.RequestApproval(ctx, PolicyApprovalReq{
-		ToolCallID: req.RequestID,
-		ToolName:   req.ToolName,
-		Args:       req.Arguments,
-		AgentID:    c.agentID,
-		SessionID:  c.sessionID,
-		TurnID:     c.turnID,
-	})
-	if !approved {
-		c.mu.Lock()
-		c.denied = true
-		c.denyReason = reason
-		c.mu.Unlock()
-	}
-	return approved, reason
-}
-
-// lastDeny reports whether any permission request in this run was denied, and the
-// reason of the most recent denial. Safe for concurrent use.
-func (c *policyApproverConsent) lastDeny() (bool, string) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.denied, c.denyReason
+// RequestConsent implements runner.ConsentHandler: auto-approves every
+// external-CLI permission request unconditionally (see the type doc above),
+// logging for observability only — no approver is consulted and no WS
+// approval frame is ever broadcast for this path.
+func (c *policyApproverConsent) RequestConsent(_ context.Context, req runner.ConsentRequest) (bool, string) {
+	slog.Info("runner/consent: auto-approved (external-cli, post-hoc observability only, issue #488)",
+		"tool", req.ToolName, "agent_id", c.agentID, "run_id", c.runID)
+	return true, ""
 }
 
 // compile-time interface assertion

--- a/pkg/agent/external_dispatch_test.go
+++ b/pkg/agent/external_dispatch_test.go
@@ -19,8 +19,9 @@ import (
 )
 
 // denyApprover is a PolicyApprover stub that always denies, recording whether it
-// was consulted. Used to prove a permission-request from an external runner is
-// routed to the consent layer and that a DENY cancels the run.
+// was consulted. Used to prove external-CLI permission requests bypass the
+// wired PolicyApprover entirely (issue #488) — even one that would deny
+// everything is never consulted.
 type denyApprover struct {
 	consulted chan runner.ConsentRequest
 }
@@ -218,10 +219,12 @@ func TestExternalDispatch_ModelAutoSet(t *testing.T) {
 	}
 }
 
-// TestExternalDispatch_RoutesPermissionToConsent_DenyCancels proves a mid-run
-// permission-request is routed to the wired PolicyApprover and that a DENY reaches
-// the driver as a non-Allow decision (best-effort post-hoc cancellation).
-func TestExternalDispatch_RoutesPermissionToConsent_DenyCancels(t *testing.T) {
+// TestExternalDispatch_PermissionRequestAutoApproved proves external-CLI
+// permission requests are auto-approved unconditionally (operator decision,
+// 2026-07-05, issue #488): even a wired PolicyApprover that denies every
+// request is NEVER consulted, the driver receives an unconditional Allow, and
+// the run completes successfully instead of being canceled.
+func TestExternalDispatch_PermissionRequestAutoApproved(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv(config.EnvHome, home)
 
@@ -232,11 +235,6 @@ func TestExternalDispatch_RoutesPermissionToConsent_DenyCancels(t *testing.T) {
 	fr, restore := withFakeDriver(t)
 	defer restore()
 
-	// Inject ONLY the permission request. The deny decision itself must cancel the
-	// run (FakeRunner.Decide calls Cancel() on !Allow, matching the real-driver
-	// contract). We deliberately do NOT inject EventKindEnd or call fr.Cancel()
-	// here: if the deny did not cancel, the drain would block until the test ctx
-	// times out — making the deny-cancel assertions load-bearing.
 	go func() {
 		fr.InjectEvent(runner.RunEvent{
 			Kind: runner.EventKindPermissionRequest,
@@ -247,71 +245,67 @@ func TestExternalDispatch_RoutesPermissionToConsent_DenyCancels(t *testing.T) {
 				RawInput:    []byte(`{"cmd":"rm -rf /"}`),
 			},
 		})
+		fr.InjectEvent(runner.RunEvent{Kind: runner.EventKindOutput, Output: &runner.OutputEvent{Text: "ok"}})
+		fr.InjectEvent(runner.RunEvent{Kind: runner.EventKindEnd})
+		fr.Cancel()
 	}()
 
-	// Bound the run with a context so a regression (deny no longer cancels) fails
-	// fast instead of hanging the suite.
 	runCtx, cancelRun := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancelRun()
 	res, err := runExternalCLISubTurn(runCtx, al, ts, "task", 30*time.Second)
-	if err == nil {
-		t.Fatalf("expected denial error from a denied permission request, got nil (res=%+v)", res)
+	if err != nil {
+		t.Fatalf("expected the run to complete despite the permission request, got error: %v (res=%+v)", err, res)
 	}
 
-	// The approver must have been consulted for the permission request.
+	// The wired approver (which would deny everything) must NEVER be consulted.
 	select {
 	case got := <-approver.consulted:
-		if got.ToolName != "shell" {
-			t.Errorf("consent tool = %q, want %q", got.ToolName, "shell")
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("approver was not consulted — permission request was not routed to consent")
+		t.Fatalf(
+			"approver was consulted (tool=%q) — external-CLI permission requests must auto-approve without consulting any PolicyApprover",
+			got.ToolName,
+		)
+	case <-time.After(200 * time.Millisecond):
+		// expected: no consultation.
 	}
 
-	// The deny decision must have reached the driver (Decide), and a deny cancels.
+	// Note: the test's own injection goroutine calls fr.Cancel() to close the
+	// event channel and let the drain loop terminate (the same pattern every
+	// other FakeRunner-based test in this file uses) — so IsCancelled() is
+	// always true here and is not a useful signal either way. The decision
+	// itself is what proves auto-approval: FakeRunner.Decide only triggers an
+	// internal Cancel on !Allow (mirroring the real deny-cancels-the-run
+	// contract), so an Allow=true decision below proves this run was never
+	// canceled BY the consent path.
 	decisions := fr.ReceivedDecisions()
 	if len(decisions) == 0 {
 		t.Fatal("no decision routed back to the driver")
 	}
-	if decisions[0].Allow {
-		t.Errorf("decision Allow = true, want false (deny)")
-	}
-	if !fr.IsCancelled() {
-		t.Error("driver was not canceled after a deny decision")
+	if !decisions[0].Allow {
+		t.Error("decision Allow = false, want true (external-CLI auto-approves unconditionally)")
 	}
 
-	// [MAJOR] The returned ToolResult MUST reflect the denial — not a success — so
-	// the delegating agent is told the sub-run was aborted, not completed.
 	if res == nil {
-		t.Fatal("expected a non-nil ToolResult on denial")
+		t.Fatal("expected a non-nil ToolResult")
 	}
-	if res.Err == nil {
-		t.Error("ToolResult.Err is nil on denial; the run must surface an error")
-	}
-	if !strings.Contains(strings.ToLower(res.ForLLM), "denied") {
-		t.Errorf("ToolResult.ForLLM = %q, want it to state the run was denied/aborted", res.ForLLM)
-	}
-	if reason := "denied for test"; res.Err != nil && !strings.Contains(res.Err.Error(), reason) {
-		t.Errorf("ToolResult.Err = %v, want it to carry the deny reason %q", res.Err, reason)
+	if res.Err != nil {
+		t.Errorf("ToolResult.Err = %v, want nil (auto-approved run must succeed)", res.Err)
 	}
 }
 
-// TestExternalDispatch_NoConsentHandler_DeniesByDefault proves that when no
-// PolicyApprover is wired, the fail-closed nop approver denies the request.
-func TestExternalDispatch_NoConsentHandler_DeniesByDefault(t *testing.T) {
+// TestExternalDispatch_NoApproverWired_StillAutoApproves proves external-CLI
+// permission requests auto-approve even when no PolicyApprover has ever been
+// wired (SetToolApprover never called) — unlike native ask-policy tools,
+// external-CLI consent never falls through to the fail-closed nopPolicyApprover
+// (issue #488: this path no longer consults loadToolApprover at all).
+func TestExternalDispatch_NoApproverWired_StillAutoApproves(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv(config.EnvHome, home)
 
 	al, ts := newExternalTestLoop(t, "opencode", "")
-	// Deliberately do NOT call SetToolApprover — loadToolApprover returns the
-	// fail-closed nopPolicyApprover (deny-by-default, FR-5.1).
+	// Deliberately do NOT call SetToolApprover.
 	fr, restore := withFakeDriver(t)
 	defer restore()
 
-	// Inject only the permission request. With no approver wired the request is
-	// denied by default, and the deny (via FakeRunner.Decide) cancels the run — so
-	// we must NOT inject EventKindEnd / Cancel ourselves (that would send on the
-	// channel the deny already closed).
 	go func() {
 		fr.InjectEvent(runner.RunEvent{
 			Kind: runner.EventKindPermissionRequest,
@@ -320,25 +314,27 @@ func TestExternalDispatch_NoConsentHandler_DeniesByDefault(t *testing.T) {
 				ToolName:  "write",
 			},
 		})
+		fr.InjectEvent(runner.RunEvent{Kind: runner.EventKindOutput, Output: &runner.OutputEvent{Text: "ok"}})
+		fr.InjectEvent(runner.RunEvent{Kind: runner.EventKindEnd})
+		fr.Cancel()
 	}()
 
 	runCtx, cancelRun := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancelRun()
 	res, err := runExternalCLISubTurn(runCtx, al, ts, "task", 30*time.Second)
-	// Deny-by-default aborts the run: it must surface as an error, not a success.
-	if err == nil {
-		t.Fatalf("expected deny-by-default to abort the run, got nil error (res=%+v)", res)
+	if err != nil {
+		t.Fatalf("expected the run to complete with no approver wired, got error: %v (res=%+v)", err, res)
 	}
 
 	decisions := fr.ReceivedDecisions()
 	if len(decisions) == 0 {
-		t.Fatal("no decision routed back to the driver (deny-by-default expected)")
+		t.Fatal("no decision routed back to the driver")
 	}
-	if decisions[0].Allow {
-		t.Error("decision Allow = true, want false (deny-by-default with no approver wired)")
+	if !decisions[0].Allow {
+		t.Error("decision Allow = false, want true (auto-approve requires no PolicyApprover at all)")
 	}
-	if res == nil || res.Err == nil {
-		t.Fatal("expected ToolResult.Err set on deny-by-default")
+	if res == nil || res.Err != nil {
+		t.Fatalf("expected a successful ToolResult with no approver wired; res=%+v", res)
 	}
 }
 

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -3129,6 +3129,10 @@ func (al *AgentLoop) ReloadProviderAndConfig(
 	// on every agent's next turn without a static-prompt cache bust.
 	wireDelegationInjectors(al, registry)
 
+	// Re-wire per-turn working-directory injectors on the new registry, same
+	// reasoning: a workspace's core_team can change via hot-reload too.
+	wireWorkingDirInjectors(al, registry)
+
 	// Atomically swap the config and registry under write lock
 	// This ensures readers see a consistent pair
 	al.mu.Lock()
@@ -5000,13 +5004,13 @@ func (al *AgentLoop) runTurn(ctx context.Context, ts *turnState) (turnResult, er
 	// — native (Main/Subagent) or subagent_3p (external-CLI), no exceptions by
 	// kind — works in that Workspace's dedicated project-work subdirectory
 	// (workspaces/<id>/work/, workspace.SafeWorkDir) instead of its private
-	// per-agent one. Unconditional (no feature flag) and driven by AGENT
-	// IDENTITY (workspace.FindForAgent's CoreTeam-membership lookup),
-	// deliberately NOT by ts.opts.WorkspaceID above: those are genuinely
-	// different signals that can diverge in both directions — a CoreTeam
-	// member responding via an unbound channel still has ts.opts.WorkspaceID
-	// == ""; a channel bound to a workspace can route to an agent stale-removed
-	// from that workspace's CoreTeam. Keying off agent identity instead of the
+	// per-agent one. Unconditional (no feature flag) and PRIMARILY driven by
+	// AGENT IDENTITY (workspace.FindForAgent's CoreTeam-membership lookup),
+	// NOT by ts.opts.WorkspaceID above: those are genuinely different signals
+	// that can diverge in both directions — a CoreTeam member responding via
+	// an unbound channel still has ts.opts.WorkspaceID == ""; a channel bound
+	// to a workspace can route to an agent stale-removed from that
+	// workspace's CoreTeam. Keying off agent identity instead of the
 	// turn-carried value is also what makes this correctly cover DELEGATED
 	// sub-agent turns: spawnSubTurn (pkg/agent/subturn.go) never threads
 	// WorkspaceID into a child's processOptions, so the old ts.opts.WorkspaceID
@@ -5014,6 +5018,17 @@ func (al *AgentLoop) runTurn(ctx context.Context, ts *turnState) (turnResult, er
 	// of any flag — this identity-keyed lookup applies uniformly to top-level
 	// turns and delegated children alike, since both resolve ts.agent.ID the
 	// same way.
+	//
+	// FindForAgentPreferring (not FindForAgent) is used here so that when the
+	// SAME agent belongs to MORE than one workspace's CoreTeam — a real,
+	// reachable state FindForAgent's own doc comment describes — the CURRENT
+	// turn's own ts.opts.WorkspaceID (when it is itself one of the agent's
+	// memberships) breaks the tie, instead of FindForAgent's arbitrary
+	// sorted-first pick. This narrows an already-ambiguous choice using a
+	// signal that is trustworthy exactly when it is present; it never widens
+	// or overrides the identity-based membership check, so the
+	// unbound-channel and delegated-child cases above are unaffected (an
+	// empty ts.opts.WorkspaceID falls straight through to FindForAgent).
 	//
 	// Security: workspaces/<id>/ lives under $OMNIPUS_HOME, which the boot
 	// Landlock policy already grants RWX — this changes only the working
@@ -5029,7 +5044,7 @@ func (al *AgentLoop) runTurn(ctx context.Context, ts *turnState) (turnResult, er
 	// pkg/tools/metadata_guard.go's app-level guard only recognizes the
 	// agents/<id>/ layout and does not match workspaces/<id>/AGENT.md, so
 	// nothing else was catching it.)
-	if wsID, found := workspace.FindForAgent(omnipusHome(), ts.agent.ID); found {
+	if wsID, found := workspace.FindForAgentPreferring(omnipusHome(), ts.agent.ID, ts.opts.WorkspaceID); found {
 		// Derive the re-root dir from the SAME canonical home ($OMNIPUS_HOME)
 		// the rest of the feature uses — buildWorkspaceInstructionsNote, the
 		// REST handlers, and ResolveDefaultID/FindForAgent — so the agent's

--- a/pkg/agent/loop_env.go
+++ b/pkg/agent/loop_env.go
@@ -1,6 +1,8 @@
 package agent
 
 import (
+	"fmt"
+	"os"
 	"strings"
 
 	"github.com/dapicom-ai/omnipus/pkg/agent/envcontext"
@@ -47,6 +49,9 @@ func (al *AgentLoop) wireEnvProviders(cfg *config.Config, registry *AgentRegistr
 
 	// Wire the per-turn delegation injector for every agent in this registry.
 	wireDelegationInjectors(al, registry)
+
+	// Wire the per-turn working-directory injector for every agent in this registry.
+	wireWorkingDirInjectors(al, registry)
 }
 
 // wireDelegationInjectors installs a delegation-context callback on every
@@ -176,6 +181,117 @@ func wireDelegationInjectors(al *AgentLoop, registry *AgentRegistry) {
 			}
 
 			return buildDelegationContext(targets, globalDepthCap)
+		})
+	}
+}
+
+// wireWorkingDirInjectors installs a per-turn working-directory context
+// callback on every agent's ContextBuilder in registry, so an agent whose
+// file tools are silently re-rooted to a Workspace's shared directory
+// (pkg/agent/loop.go's CoreTeam filesystem re-rooting block) is actually told
+// so — the same problem wireDelegationInjectors solves for delegation rules.
+//
+// Without this, a CoreTeam member has no way to know its file tools no
+// longer point at its own private agents/<id>/ directory: it can guess a
+// wrong absolute path for a write, waste turns hunting for a file it just
+// wrote, and report a false location to the user (the file is actually,
+// correctly, under the workspace's shared directory the whole time).
+//
+// The lookup (workspace.FindForAgentPreferring + workspace.SafeWorkDir +
+// os.MkdirAll) is re-run on every call — not cached — mirroring
+// wireDelegationInjectors' per-turn freshness guarantee: CoreTeam membership
+// can change at runtime and must be reflected on the very next turn. Every
+// step here — including the MkdirAll call, whose failure pkg/agent/loop.go's
+// re-rooting block also treats as "fall back to the agent's own directory" —
+// is deliberately kept in lockstep with that block so what this injector
+// advertises matches what actually gets applied. The two remain independent
+// call sites, not one shared function, so this is a maintained invariant, not
+// a structural guarantee: keep them in sync if either changes.
+func wireWorkingDirInjectors(al *AgentLoop, registry *AgentRegistry) {
+	for _, agentID := range registry.ListAgentIDs() {
+		agentInst, ok := registry.GetAgent(agentID)
+		if !ok || agentInst == nil || agentInst.ContextBuilder == nil {
+			continue
+		}
+
+		id := agentID
+		agentInst.ContextBuilder.WithWorkingDirInjector(func(workspaceID string) string {
+			home := omnipusHome()
+			// FindForAgentPreferring — NOT FindForAgent — so that an agent
+			// belonging to more than one workspace's CoreTeam is told about
+			// the CURRENT turn's own workspace (workspaceID) rather than an
+			// arbitrary sorted-first one. This mirrors the resolution
+			// pkg/agent/loop.go's re-rooting block performs, so what this
+			// block advertises matches the directory actually
+			// applied.
+			wsID, found := workspace.FindForAgentPreferring(home, id, workspaceID)
+			if !found {
+				// Not a CoreTeam member: file tools use this agent's own private
+				// directory, exactly as an operator would expect by default — no
+				// block needed.
+				return ""
+			}
+			wsDir, err := workspace.SafeWorkDir(home, wsID)
+			if err != nil {
+				logger.WarnCF(
+					"agent.env",
+					"wireWorkingDirInjectors: invalid workspace id — omitting working-directory block",
+					map[string]any{"agent_id": id, "workspace_id": wsID, "error": err.Error()},
+				)
+				return ""
+			}
+			// pkg/agent/loop.go's actual re-rooting block only applies
+			// tools.WithTurnWorkspaceDir when BOTH SafeWorkDir AND this
+			// MkdirAll succeed — on an MkdirAll failure (disk full, a
+			// non-directory file already at wsDir, permissions) it silently
+			// falls back to the agent's own private directory. Without this
+			// same check here, this injector could advertise the shared
+			// directory in a turn where the real tools stayed rooted at
+			// agents/<id>/ — reintroducing the exact false-location-report
+			// bug this feature exists to prevent. Mirrored exactly (same
+			// mode bits) so the two call sites can't silently diverge.
+			if mkErr := os.MkdirAll(wsDir, 0o700); mkErr != nil {
+				logger.WarnCF(
+					"agent.env",
+					"wireWorkingDirInjectors: MkdirAll failed — omitting working-directory block",
+					map[string]any{"agent_id": id, "workspace_id": wsID, "dir": wsDir, "error": mkErr.Error()},
+				)
+				return ""
+			}
+			// Name/Description give the agent a meaningful identity for the
+			// workspace instead of just an opaque ULID — best-effort: a
+			// missing/unreadable title falls back to the raw id alone rather
+			// than omitting the whole block over a cosmetic field. Logged at
+			// DEBUG (not WARN) since FindForAgentPreferring just confirmed
+			// this same file readable moments ago — a failure here is either
+			// a rare TOCTOU race (file edited/removed between the two reads)
+			// or a malformed name/description field, neither worth an
+			// operator-facing WARN on a per-turn hot path.
+			title := wsID
+			descLine := ""
+			name, desc, ok := workspace.LoadTitle(home, wsID)
+			if !ok {
+				logger.DebugCF(
+					"agent.env",
+					"wireWorkingDirInjectors: LoadTitle failed — falling back to the raw workspace id",
+					map[string]any{"agent_id": id, "workspace_id": wsID},
+				)
+			}
+			if ok && name != "" {
+				title = name
+				if desc != "" {
+					descLine = fmt.Sprintf("\nDescription: %s", desc)
+				}
+			}
+			return fmt.Sprintf(
+				"## Working Directory\nYou are a member of the Workspace \"%s\" (id: %s)'s shared team.%s\n\n"+
+					"Your file tools (read_file, write_file, edit_file, list_directory, bash, etc.) operate "+
+					"relative to THIS workspace's SHARED directory, NOT your own private agent directory:\n\n%s\n\n"+
+					"Always use RELATIVE paths for file operations (e.g. \"report.html\") — the tools are "+
+					"already rooted here. Do not construct or report an absolute path under agents/%s/; "+
+					"that is not where your files are.",
+				title, wsID, descLine, wsDir, id,
+			)
 		})
 	}
 }

--- a/pkg/agent/working_dir_e2e_test.go
+++ b/pkg/agent/working_dir_e2e_test.go
@@ -1,0 +1,122 @@
+// Omnipus - Ultra-lightweight personal AI agent
+// License: MIT
+// Copyright (c) 2026 Omnipus contributors
+
+package agent
+
+// working_dir_e2e_test.go closes the gap a review pass flagged: prior tests
+// verify FindForAgentPreferring's tie-break logic in isolation (pkg/workspace)
+// and the "## Working Directory" prompt block in isolation (buildDynamicContext,
+// working_dir_wiring_test.go), and a pre-existing test verifies real write_file
+// placement for the SINGLE-membership case (workspace_team_reroot_test.go) —
+// but nothing drives one real turn, with the agent belonging to TWO
+// workspaces and a genuine channel-bound workspace_id, and asserts BOTH the
+// advertised prompt block AND the actual write_file placement agree. This is
+// the one test that would catch the two call sites (loop.go's re-rooting,
+// loop_env.go's injector) drifting apart in practice, not just in theory.
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapicom-ai/omnipus/pkg/agent/testutil"
+	"github.com/dapicom-ai/omnipus/pkg/bus"
+	"github.com/dapicom-ai/omnipus/pkg/config"
+)
+
+// TestRunTurn_MultiMembership_AdvertisementMatchesEnforcement proves that for
+// a real, channel-bound turn, the agent belonging to two workspaces' CoreTeam
+// gets told about (and actually writes to) the SAME one — the turn's own
+// channel-bound workspace — not an arbitrary sorted-first pick.
+func TestRunTurn_MultiMembership_AdvertisementMatchesEnforcement(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("OMNIPUS_HOME", tmpHome)
+
+	agentWorkspaceDir := filepath.Join(tmpHome, "agents", "main")
+	require.NoError(t, os.MkdirAll(agentWorkspaceDir, 0o755))
+
+	// "ws-a-current" sorts before "ws-z-other", so a plain FindForAgent (no
+	// preference) would pick "ws-a-current" regardless of which workspace this
+	// turn is actually bound to — making this test load-bearing only if the
+	// bound instance's workspace ("ws-z-other") is the one that actually wins.
+	workspacesDir := filepath.Join(tmpHome, "workspaces")
+	require.NoError(t, os.MkdirAll(workspacesDir, 0o755))
+	writeWSRecord := func(id, name string) {
+		rec := map[string]any{"id": id, "core_team": []string{"main"}, "name": name}
+		data, err := json.Marshal(rec)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(filepath.Join(workspacesDir, id+".json"), data, 0o644))
+	}
+	writeWSRecord("ws-a-current", "Workspace A")
+	writeWSRecord("ws-z-other", "Workspace Z")
+
+	// processMessage resolves processOptions.WorkspaceID from the transcript
+	// session's OWN stored meta.WorkspaceID first, falling back to
+	// msg.Metadata["workspace_id"] for a session with no stored meta yet (see
+	// loop.go's processMessage, "M4: bind the active workspace into this
+	// turn"). Setting it via inbound metadata is the simplest way to give a
+	// FRESH turn a genuine, non-empty ts.opts.WorkspaceID — the exact signal
+	// FindForAgentPreferring uses to break the tie.
+	provider := testutil.NewScenario().
+		WithToolCall("write_file", `{"path":"proof.txt","content":"tie-broken-write","overwrite":true}`).
+		WithText("done")
+
+	cfg := &config.Config{
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{
+				Workspace:           agentWorkspaceDir,
+				ModelName:           "scripted-model",
+				MaxTokens:           4096,
+				MaxToolIterations:   10,
+				RestrictToWorkspace: true,
+			},
+		},
+	}
+
+	msgBus := bus.NewMessageBus()
+	al := mustNewAgentLoop(t, cfg, msgBus, provider)
+	defer al.Close()
+
+	msg := bus.InboundMessage{
+		Channel:    "webchat",
+		ChatID:     "chat-1",
+		Content:    "please write proof.txt for me",
+		SessionKey: "test-session-multi-membership",
+		Metadata:   map[string]string{"workspace_id": "ws-z-other"},
+	}
+
+	ctx := context.Background()
+	reply, _, err := al.processMessage(ctx, msg)
+	require.NoError(t, err, "processMessage must succeed")
+	assert.Equal(t, "done", reply)
+
+	// --- Enforcement: the file must land under the BOUND workspace's work/ dir ---
+	zFile := filepath.Join(workspacesDir, "ws-z-other", "work", "proof.txt")
+	got, readErr := os.ReadFile(zFile)
+	require.NoError(
+		t,
+		readErr,
+		"write_file must land under the channel-bound workspace (ws-z-other), got err reading %s",
+		zFile,
+	)
+	assert.Equal(t, "tie-broken-write", string(got))
+
+	aFile := filepath.Join(workspacesDir, "ws-a-current", "work", "proof.txt")
+	_, aStatErr := os.Stat(aFile)
+	assert.True(t, os.IsNotExist(aStatErr),
+		"write_file must NOT land under the OTHER (non-bound) workspace (%s) it also belongs to", aFile)
+
+	// --- Advertisement: the prompt sent to the LLM must name the SAME workspace ---
+	msgs := provider.LastMessages()
+	require.NotEmpty(t, msgs, "expected at least one message sent to the provider")
+	systemPrompt := msgs[0].Content
+	assert.Contains(t, systemPrompt, "## Working Directory")
+	assert.Contains(t, systemPrompt, "Workspace Z", "prompt must name the channel-bound workspace")
+	assert.NotContains(t, systemPrompt, "Workspace A", "prompt must NOT name the other, non-bound workspace")
+}

--- a/pkg/agent/working_dir_wiring_test.go
+++ b/pkg/agent/working_dir_wiring_test.go
@@ -1,0 +1,137 @@
+package agent
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// testWorkspaceTeamRecord is the minimal on-disk workspace shape this file's
+// tests need (id, is_default, core_team, name, description) — a sibling of
+// delegation_graph_testhelper_test.go's testWorkspaceRecord, which does not
+// carry core_team/name/description.
+type testWorkspaceTeamRecord struct {
+	ID          string   `json:"id"`
+	IsDefault   bool     `json:"is_default,omitempty"`
+	CoreTeam    []string `json:"core_team,omitempty"`
+	Name        string   `json:"name,omitempty"`
+	Description string   `json:"description,omitempty"`
+}
+
+// seedWorkspaceTeam points OMNIPUS_HOME at a fresh temp dir (auto-restored)
+// and writes workspaces/<id>.json carrying the given core_team/name/
+// description. Returns the home dir.
+func seedWorkspaceTeam(t *testing.T, wsID string, isDefault bool, coreTeam []string, name, description string) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("OMNIPUS_HOME", home)
+	writeWorkspaceTeamRecord(t, home, wsID, isDefault, coreTeam, name, description)
+	return home
+}
+
+// writeWorkspaceTeamRecord writes/overwrites workspaces/<id>.json under an
+// existing home.
+func writeWorkspaceTeamRecord(
+	t *testing.T,
+	home, wsID string,
+	isDefault bool,
+	coreTeam []string,
+	name, description string,
+) {
+	t.Helper()
+	wsDir := filepath.Join(home, "workspaces")
+	if err := os.MkdirAll(wsDir, 0o755); err != nil {
+		t.Fatalf("mkdir workspaces: %v", err)
+	}
+	rec := testWorkspaceTeamRecord{
+		ID: wsID, IsDefault: isDefault, CoreTeam: coreTeam, Name: name, Description: description,
+	}
+	data, err := json.Marshal(rec)
+	if err != nil {
+		t.Fatalf("marshal workspace record: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(wsDir, wsID+".json"), data, 0o644); err != nil {
+		t.Fatalf("write workspace file: %v", err)
+	}
+}
+
+// TestWorkingDirWiring_CoreTeamMember_BlockPresent proves a CoreTeam member's
+// dynamic context carries the "## Working Directory" block naming the
+// workspace's title/description and its shared work directory.
+func TestWorkingDirWiring_CoreTeamMember_BlockPresent(t *testing.T) {
+	const wsID = "01JWWORKDIRTEST0000000001"
+	seedWorkspaceTeam(t, wsID, true, []string{"ava"}, "Launch Prep", "Everything for the Q3 launch")
+
+	const agentID = "ava"
+	al, cb := wireTestLoopWithGraph(t, agentID)
+	_ = al
+
+	got := cb.buildDynamicContext("", "", "", "", "")
+	if !strings.Contains(got, "## Working Directory") {
+		t.Fatalf("Working Directory block missing.\ngot: %s", got)
+	}
+	if !strings.Contains(got, "Launch Prep") {
+		t.Errorf("expected workspace name %q in block.\ngot: %s", "Launch Prep", got)
+	}
+	if !strings.Contains(got, "Everything for the Q3 launch") {
+		t.Errorf("expected workspace description in block.\ngot: %s", got)
+	}
+	if !strings.Contains(got, filepath.Join("workspaces", wsID, "work")) {
+		t.Errorf("expected the resolved work dir path in block.\ngot: %s", got)
+	}
+	if !strings.Contains(got, "agents/ava/") {
+		t.Errorf("expected an explicit warning against the private agents/ava/ dir.\ngot: %s", got)
+	}
+}
+
+// TestWorkingDirWiring_NotCoreTeamMember_BlockAbsent proves an agent that is
+// NOT a member of any workspace's core_team gets no Working Directory block
+// at all — its file tools use its own private directory, exactly as before
+// this feature existed, with nothing new to tell it.
+func TestWorkingDirWiring_NotCoreTeamMember_BlockAbsent(t *testing.T) {
+	const wsID = "01JWWORKDIRTEST0000000002"
+	// "ava" is on the team; "jim" (the agent under test) is deliberately not.
+	seedWorkspaceTeam(t, wsID, true, []string{"ava"}, "Some Workspace", "")
+
+	const agentID = "jim"
+	al, cb := wireTestLoopWithGraph(t, agentID)
+	_ = al
+
+	got := cb.buildDynamicContext("", "", "", "", "")
+	if strings.Contains(got, "## Working Directory") {
+		t.Fatalf("did not expect a Working Directory block for a non-CoreTeam agent.\ngot: %s", got)
+	}
+}
+
+// TestWorkingDirWiring_PrefersCurrentSessionWorkspace proves that when an
+// agent belongs to TWO workspaces' core teams, passing the current turn's
+// workspaceID into buildDynamicContext selects THAT workspace's directory —
+// not FindForAgent's arbitrary sorted-first pick.
+func TestWorkingDirWiring_PrefersCurrentSessionWorkspace(t *testing.T) {
+	// "ws-a-current" sorts before "ws-z-other", so a plain FindForAgent would
+	// pick "ws-a-current" regardless — pick the OTHER one as the "current
+	// session" workspace so the test only passes if the preference is real.
+	const wsA = "ws-a-current"
+	const wsZ = "ws-z-other"
+	home := seedWorkspaceTeam(t, wsA, true, []string{"ray"}, "Workspace A", "")
+	writeWorkspaceTeamRecord(t, home, wsZ, false, []string{"ray"}, "Workspace Z", "")
+
+	al, cb := wireTestLoopWithGraph(t, "ray")
+	_ = al
+
+	got := cb.buildDynamicContext(wsZ, "", "", "", "")
+	if !strings.Contains(got, "Workspace Z") {
+		t.Errorf("expected the CURRENT session's workspace name %q in block.\ngot: %s", "Workspace Z", got)
+	}
+	if strings.Contains(got, "Workspace A") {
+		t.Errorf("did not expect the OTHER (non-current) workspace's name in block.\ngot: %s", got)
+	}
+	if !strings.Contains(got, filepath.Join("workspaces", wsZ, "work")) {
+		t.Errorf("expected the CURRENT session's work dir path in block.\ngot: %s", got)
+	}
+	if strings.Contains(got, filepath.Join("workspaces", wsA, "work")) {
+		t.Errorf("did not expect the OTHER workspace's work dir path in block.\ngot: %s", got)
+	}
+}

--- a/pkg/gateway/rest_executor_smoketest.go
+++ b/pkg/gateway/rest_executor_smoketest.go
@@ -43,14 +43,17 @@
 //     reaching RunOptions — defense in depth on top of each driver's own
 //     internal filtering in buildArgs().
 //   - Consent: every event is routed through the REAL runner.ConsentDispatcher
-//     / runner.RouteConsent (the identical wiring pkg/agent/external_dispatch.go
-//     uses for production dispatch), with a nil ConsentHandler. A nil handler
-//     makes RouteConsent deny AND audit-log every permission request by
-//     default (FR-5.1), and ConsentDispatcher calls driver.Decide(decision) so
-//     the driver actually cancels the run on a denial (see runner/consent.go's
-//     POST-HOC CONSENT LIMITATION doc) instead of the denial being silently
-//     dropped until the outer timeout fires — see drainSmokeTestRun's
-//     EventKindPermissionRequest case below.
+//     / runner.RouteConsent, with a nil ConsentHandler — deliberately DIFFERENT
+//     from production dispatch (pkg/agent/external_dispatch.go's
+//     policyApproverConsent, which auto-approves every request unconditionally,
+//     issue #488). A smoke test's whole purpose is validating a binary+auth+
+//     handshake without letting a real tool call run, so it intentionally keeps
+//     the nil-handler deny-by-default path: RouteConsent denies AND audit-logs
+//     every permission request by default (FR-5.1), and ConsentDispatcher calls
+//     driver.Decide(decision) so the driver actually cancels the run on a
+//     denial (see runner/consent.go's POST-HOC CONSENT LIMITATION doc) instead
+//     of the denial being silently dropped until the outer timeout fires — see
+//     drainSmokeTestRun's EventKindPermissionRequest case below.
 //   - Scrubbed child env: sandbox.ScrubGatewayEnvForRunner() — the same
 //     allowlist real dispatch uses (pkg/agent/external_dispatch.go) — so the
 //     spawned CLI never inherits gateway secrets (OMNIPUS_MASTER_KEY, bearer

--- a/pkg/workspace/find_for_agent.go
+++ b/pkg/workspace/find_for_agent.go
@@ -107,3 +107,73 @@ func FindForAgent(home, agentID string) (string, bool) {
 	}
 	return matches[0], true
 }
+
+// FindForAgentPreferring resolves the same question as FindForAgent — which
+// workspace's CoreTeam does agentID belong to — but first checks
+// preferredWsID directly when it is non-empty, disambiguating FindForAgent's
+// documented ambiguous-membership case (an agent on more than one workspace's
+// core team) in favor of the CALLER'S OWN notion of "the current one" (e.g.
+// the current turn's channel-bound workspace_id) instead of FindForAgent's
+// arbitrary sorted-first pick.
+//
+// Falls back to FindForAgent unchanged when preferredWsID is empty, invalid,
+// or the agent is not actually a member of THAT SPECIFIC workspace's
+// CoreTeam — so a caller with no turn-bound workspace (e.g. a delegated
+// sub-turn, which spawnSubTurn never threads a workspace_id into) sees no
+// behavior change from FindForAgent.
+//
+// Note: a successful preferredWsID match returns directly, WITHOUT running
+// FindForAgent's full scan — so FindForAgent's own ambiguous-membership WARN
+// (logged when an agent is found in more than one workspace) does NOT fire on
+// this fast path, even though the ambiguity the WARN exists to surface is
+// still real. This trades that operator-visible signal for avoiding a full
+// directory scan on every turn for every CoreTeam member; the scan (and its
+// WARN) still runs normally whenever preferredWsID is absent or doesn't
+// resolve.
+func FindForAgentPreferring(home, agentID, preferredWsID string) (string, bool) {
+	if agentID == "" {
+		return "", false
+	}
+	if safeID(preferredWsID) {
+		data, err := os.ReadFile(filepath.Join(dirFor(home), preferredWsID+".json"))
+		if err == nil {
+			var w teamRecord
+			if json.Unmarshal(data, &w) == nil {
+				for _, id := range w.CoreTeam {
+					if id == agentID {
+						return preferredWsID, true
+					}
+				}
+			}
+		}
+	}
+	return FindForAgent(home, agentID)
+}
+
+// titleRecord is the minimal subset of the on-disk workspace JSON LoadTitle
+// reads — mirrors teamRecord's convention of a per-reader minimal struct.
+type titleRecord struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+}
+
+// LoadTitle reads a workspace's human-readable Name and Description for an
+// already-resolved id (e.g. the id FindForAgent/FindForAgentPreferring
+// returned) — the short identity to show an agent alongside its raw
+// workspace id, since a ULID alone means nothing to it. Returns ok=false when
+// id is unsafe or the workspace file is missing/unreadable/malformed; does
+// NOT itself re-verify CoreTeam membership (that is the caller's job).
+func LoadTitle(home, id string) (name, description string, ok bool) {
+	if !safeID(id) {
+		return "", "", false
+	}
+	data, err := os.ReadFile(filepath.Join(dirFor(home), id+".json"))
+	if err != nil {
+		return "", "", false
+	}
+	var w titleRecord
+	if json.Unmarshal(data, &w) != nil {
+		return "", "", false
+	}
+	return w.Name, w.Description, true
+}

--- a/pkg/workspace/find_for_agent_test.go
+++ b/pkg/workspace/find_for_agent_test.go
@@ -156,3 +156,114 @@ func TestFindForAgent_FallsBackToFilenameWhenIDFieldEmpty(t *testing.T) {
 		t.Fatalf("FindForAgent id = %q, want filename-derived %q", id, "ws-from-filename")
 	}
 }
+
+// TestFindForAgentPreferring_DisambiguatesMultiMembership proves the core
+// contract: when an agent belongs to more than one workspace's core_team,
+// passing the CURRENT turn's own workspace id as preferredWsID wins over
+// FindForAgent's arbitrary sorted-first pick.
+func TestFindForAgentPreferring_DisambiguatesMultiMembership(t *testing.T) {
+	home := t.TempDir()
+	// "ws-a" sorts before "ws-z", so a plain FindForAgent would pick "ws-a".
+	writeWS(t, home, "ws-a", `{"id":"ws-a","core_team":["multi-agent"]}`)
+	writeWS(t, home, "ws-z", `{"id":"ws-z","core_team":["multi-agent"]}`)
+
+	id, found := FindForAgentPreferring(home, "multi-agent", "ws-z")
+	if !found {
+		t.Fatal("expected a match")
+	}
+	if id != "ws-z" {
+		t.Fatalf("FindForAgentPreferring id = %q, want the preferred %q", id, "ws-z")
+	}
+}
+
+// TestFindForAgentPreferring_FallsBackWhenPreferredNotAMember proves that a
+// preferredWsID the agent does NOT actually belong to is ignored — it must
+// not override or spoof membership, only disambiguate a real one.
+func TestFindForAgentPreferring_FallsBackWhenPreferredNotAMember(t *testing.T) {
+	home := t.TempDir()
+	writeWS(t, home, "ws-real", `{"id":"ws-real","core_team":["solo-agent"]}`)
+	writeWS(t, home, "ws-unrelated", `{"id":"ws-unrelated","core_team":["someone-else"]}`)
+
+	id, found := FindForAgentPreferring(home, "solo-agent", "ws-unrelated")
+	if !found {
+		t.Fatal("expected a match via fallback to FindForAgent")
+	}
+	if id != "ws-real" {
+		t.Fatalf("FindForAgentPreferring id = %q, want fallback to the agent's real workspace %q", id, "ws-real")
+	}
+}
+
+// TestFindForAgentPreferring_EmptyPreferredMatchesFindForAgent proves that an
+// empty preferredWsID (e.g. a delegated sub-turn, which has no turn-bound
+// workspace_id) behaves identically to plain FindForAgent — no behavior
+// change for callers with nothing to prefer.
+func TestFindForAgentPreferring_EmptyPreferredMatchesFindForAgent(t *testing.T) {
+	home := t.TempDir()
+	writeWS(t, home, "ws-solo", `{"id":"ws-solo","core_team":["jim"]}`)
+
+	want, wantFound := FindForAgent(home, "jim")
+	got, gotFound := FindForAgentPreferring(home, "jim", "")
+	if got != want || gotFound != wantFound {
+		t.Fatalf(
+			"FindForAgentPreferring(empty preferred) = (%q, %v), want FindForAgent's (%q, %v)",
+			got, gotFound, want, wantFound,
+		)
+	}
+}
+
+// TestFindForAgentPreferring_InvalidPreferredIDFallsBack proves a
+// traversal-unsafe preferredWsID (e.g. "../etc") is rejected by safeID and
+// falls back to FindForAgent rather than being used to build a file path.
+func TestFindForAgentPreferring_InvalidPreferredIDFallsBack(t *testing.T) {
+	home := t.TempDir()
+	writeWS(t, home, "ws-solo", `{"id":"ws-solo","core_team":["jim"]}`)
+
+	id, found := FindForAgentPreferring(home, "jim", "../../etc")
+	if !found || id != "ws-solo" {
+		t.Fatalf(
+			"FindForAgentPreferring with unsafe preferred id = (%q, %v), want fallback (%q, true)",
+			id,
+			found,
+			"ws-solo",
+		)
+	}
+}
+
+// TestLoadTitle_ReturnsNameAndDescription verifies the happy path.
+func TestLoadTitle_ReturnsNameAndDescription(t *testing.T) {
+	home := t.TempDir()
+	writeWS(t, home, "ws-titled", `{"id":"ws-titled","name":"My Workspace","description":"For the important stuff"}`)
+
+	name, desc, ok := LoadTitle(home, "ws-titled")
+	if !ok {
+		t.Fatal("expected LoadTitle to succeed")
+	}
+	if name != "My Workspace" {
+		t.Errorf("name = %q, want %q", name, "My Workspace")
+	}
+	if desc != "For the important stuff" {
+		t.Errorf("description = %q, want %q", desc, "For the important stuff")
+	}
+}
+
+// TestLoadTitle_MissingFileReturnsNotOK verifies a nonexistent workspace id
+// fails cleanly rather than panicking.
+func TestLoadTitle_MissingFileReturnsNotOK(t *testing.T) {
+	home := t.TempDir()
+
+	name, desc, ok := LoadTitle(home, "ws-does-not-exist")
+	if ok || name != "" || desc != "" {
+		t.Fatalf("expected (\"\", \"\", false) for a missing workspace, got (%q, %q, %v)", name, desc, ok)
+	}
+}
+
+// TestLoadTitle_UnsafeIDRejected verifies a traversal-unsafe id is rejected
+// before it can be used to build a file path.
+func TestLoadTitle_UnsafeIDRejected(t *testing.T) {
+	home := t.TempDir()
+
+	name, desc, ok := LoadTitle(home, "../../etc/passwd")
+	if ok || name != "" || desc != "" {
+		t.Fatalf("expected (\"\", \"\", false) for an unsafe id, got (%q, %q, %v)", name, desc, ok)
+	}
+}


### PR DESCRIPTION
## Summary

Two related fixes found while live-testing delegation on this hotfix branch:

**1. External-CLI tool calls no longer block on a human-approval modal.** `policyApproverConsent` (the consent handler for subagent_3p external-CLI workers — claude-code/codex/opencode) routed every detected tool_use event through the gateway's blocking WS approval modal, completely ignoring the delegate agent's own configured tool policy (ask/allow/deny) — confirmed via direct config inspection that an agent with `default_policy: allow` still saw a popup for every single tool call. It now auto-approves unconditionally, consistent with `consent.go`'s own long-standing doc that this layer is post-hoc/best-effort observability, never a pre-emptive gate (by the time it fires, the tool has already run for all 3 CLIs regardless). Native agents' own ask-policy approval gate (`pkg/agent/loop.go`'s `CheckGrantOrRequestApproval`) is untouched — this only affects external-CLI dispatch.

**2. Agents are now told their real working directory.** A CoreTeam member's file tools are silently re-rooted to the Workspace's shared directory (ADR-032), but the agent itself was never told in its own prompt/context. Root-caused via a raw tool-call transcript (not the LLM's own narration): an agent guessed a wrong absolute path for its first write (correctly blocked by the sandbox), wasted several tool calls hunting for the file it had just written, and told the user a **false** final path (`agents/<id>/report.html`) when the real file was correctly under the workspace's shared directory the whole time. Added a "## Working Directory" per-turn context block (mirrors the existing delegation-injector pattern exactly) naming the resolved workspace + directory whenever the agent is a CoreTeam member. When an agent belongs to more than one workspace, `workspace.FindForAgentPreferring` disambiguates in favor of the **current turn's own workspace** instead of an arbitrary sorted-first pick — wired into both the real re-rooting logic and the new injector (including matching the `os.MkdirAll` fallback behavior) so what's advertised can't drift from what's actually applied.

Ran the mandatory 7-reviewer gate (architect + 6 pr-review-toolkit agents) against the combined diff, fixed every finding (missing `MkdirAll` parity between the injector and the real re-rooting logic, a duplicated comment block, two stale doc comments describing pre-fix behavior, a missing doc note, a missing debug log), and added an end-to-end test proving the "advertised" and "actually applied" workspace directory agree for a real multi-workspace-membership turn.

## Test plan
- [x] `gofmt -l .` — 0
- [x] `CGO_ENABLED=0 go vet -tags goolm,stdjson ./...` — clean
- [x] `CGO_ENABLED=0 go build -tags goolm,stdjson ./...` — clean
- [x] `CGO_ENABLED=0 golangci-lint run --build-tags=goolm,stdjson ./...` — 0 issues
- [x] `CGO_ENABLED=0 go test -tags goolm,stdjson ./pkg/agent/... ./pkg/workspace/...` — pass (incl. new `TestExternalDispatch_PermissionRequestAutoApproved`, `TestWorkingDirWiring_*`, `TestRunTurn_MultiMembership_AdvertisementMatchesEnforcement`, `TestFindForAgentPreferring_*`)
- [x] `CGO_ENABLED=0 go test -tags goolm,stdjson -run '^TestPostAgentsExecutorSmokeTest' ./pkg/gateway/...` — pass (unaffected, separate deny-by-default code path)
- [ ] `ci-omnipus` full gate (`runci.sh <ref> all`) — pending, will run before requesting merge
- [ ] Manual re-test on the live preview: confirm `claude-dev` delegation no longer shows a "Tool Approval Required" popup, and confirm a CoreTeam-member agent correctly reports its workspace-shared file location